### PR TITLE
Fixing NameError on cpmodel_path

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -169,6 +169,7 @@ if __name__ == '__main__':
                 else:
                     szmean = 15.
             else:
+                cpmodel_path = os.fspath(args.pretrained_model)
                 szmean = 27.
             
             if args.all_channels:


### PR DESCRIPTION
Hi, I'm enjoying this wonderful package. Thanks a lot!
When I was training a model with `--pretrained_model None` as described in the README, I got the error "NameError: name 'cpmodel_path' is not defined". This commit intends to fix that problem by defining the variable.