### PR TITLE
bugfix: rescale must support copy() function

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -170,7 +170,7 @@ class Cellpose():
             else:
                 if rescale is None:
                     if do_3D:
-                        rescale = 1.0
+                        rescale = np.ones(1)
                     else:
                         rescale = np.ones(len(x), np.float32)
                 diams = self.diam_mean / rescale.copy() / (np.pi**0.5/2)


### PR DESCRIPTION
First: Thank you for the awesome segmentation tool. It looks like we can use it directly in our existing image analysis pipelines!

Today I tested the 3D version of the `model.eval()` function. Somehow a error message appeared that `rescale `does not have a `copy()` function in line 176.

I looked into the code and made a quick-and-dirty bugfix I want to share with you.