### PR TITLE
"file_path" referenced before assignment

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -650,12 +650,15 @@ class CellposeModel():
         if save_path is not None:
             _, file_label = os.path.split(save_path)
             file_path = os.path.join(save_path, 'models/')
+
+            if not os.path.exists(file_path):
+                os.makedirs(file_path)
         else:
             print('WARNING: no save_path given, model not saving')
+
         ksave = 0
-        if not os.path.exists(file_path):
-            os.makedirs(file_path)
         rsc = 1.0
+
         for iepoch in range(self.n_epochs):
             np.random.seed(iepoch)
             rperm = np.random.permutation(nimg)


### PR DESCRIPTION
Corrected error `local variable 'file_path' referenced before assignment` which arises when a model is trained without defining a `save_path`.

Expected behavior would be to check for `file_path` existence only if a `save_path` is given during training.