### PR TITLE
Remove GIL lock and manual garbage collection

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -9,7 +9,7 @@ import mxnet.ndarray as nd
 from numba import njit, float32, int32, vectorize
 from . import utils, metrics
 
-@njit('(float64[:], int32[:], int32[:], int32, int32, int32, int32)')
+@njit('(float64[:], int32[:], int32[:], int32, int32, int32, int32)', nogil=True)
 def _extend_centers(T,y,x,ymed,xmed,Lx, niter):
     """ run diffusion from center of mask (ymed, xmed) on mask pixels (y, x)
 
@@ -167,7 +167,7 @@ def masks_to_flows(masks):
 
     return mu, mu_c
 
-@njit('(float32[:,:,:,:],float32[:,:,:,:], int32[:,:], int32)')
+@njit('(float32[:,:,:,:],float32[:,:,:,:], int32[:,:], int32)', nogil=True)
 def steps3D(p, dP, inds, niter):
     """ run dynamics of pixels to recover masks in 3D
     
@@ -208,7 +208,7 @@ def steps3D(p, dP, inds, niter):
             p[2,z,y,x] = min(shape[2]-1, max(0, p[2,z,y,x] - dP[2,p0,p1,p2]))
     return p
 
-@njit('(float32[:,:,:], float32[:,:,:], int32[:,:], int32)')
+@njit('(float32[:,:,:], float32[:,:,:], int32[:,:], int32)', nogil=True)
 def steps2D(p, dP, inds, niter):
     """ run dynamics of pixels to recover masks in 2D
     

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -1,4 +1,4 @@
-import os, sys, time, shutil, tempfile, datetime, pathlib, gc
+import os, sys, time, shutil, tempfile, datetime, pathlib
 import numpy as np
 from tqdm import trange, tqdm
 from urllib.parse import urlparse
@@ -518,8 +518,6 @@ class CellposeModel():
         yf = transforms.average_tiles(y, ysub, xsub, Ly, Lx)
         yf = yf[:,:imgi.shape[1],:imgi.shape[2]]
         styles /= (styles**2).sum()**0.5
-        del IMG
-        gc.collect()
         return yf, styles
 
     def _run_net(self, img, rsz=1.0, tile=True, bsize=224):


### PR DESCRIPTION
When running this code in a worker-type application ([dask](https://dask.org/)), there were a couple performance bottlenecks. This PR tries to address these, provided these tweaks do not interfere with workloads that are typically used with this library.
