### PR TITLE
modified doc-string

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -261,7 +261,7 @@ class CellposeModel():
     def eval(self, x, channels=None, invert=False, rescale=None, do_3D=False, net_avg=True, 
              tile=True, flow_threshold=0.4, cellprob_threshold=0.0, compute_masks=True, progress=None):
         """
-            segment list of images x, or 4D array - Z x nchan x Y x X
+            segment list of images x, or 4D array - Z x x Y x X x nchan
 
             Parameters
             ----------


### PR DESCRIPTION
If the `channels` parameter in `CellposeModel.eval` is set, https://github.com/MouseLand/cellpose/blob/2b5dca97de9ac09cbbb9a3b46392bae2e890883f/cellpose/models.py#L326 requires that each list item in `x` has the format `Z x Y x X x nchan`.

