### PR TITLE
Fix import bug in `cellpose/plot.py` file

### DIFF
--- a/cellpose/plot.py
+++ b/cellpose/plot.py
@@ -4,6 +4,7 @@ import cv2
 from scipy.ndimage import gaussian_filter
 import scipy
 import colorsys
+import skimage.io as io
 
 from . import utils
 


### PR DESCRIPTION
Scikit Image `io` operation is used inline 91 - 94 but `io` is not imported which throws an error when running the `show_segmentation`  function with `file_name` argument