### PR TITLE
Fix NameError: name 'subprocess' is not defined

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -1,4 +1,4 @@
-import os, sys, time, shutil, tempfile, datetime, pathlib
+import os, sys, time, shutil, tempfile, datetime, pathlib, subprocess
 import numpy as np
 from tqdm import trange, tqdm
 from urllib.parse import urlparse


### PR DESCRIPTION
On Python 3.8, 64-bit, Windows 10:
```
Running test snippet to check if MKL running (https://mxnet.apache.org/versions/1.6/api/python/docs/tutorials/performance/backend/mkldnn/mkldnn_readme.html#4)
Traceback (most recent call last):
  File "X:\Python38\lib\site-packages\cellpose\models.py", line 28, in check_mkl
    process = subprocess.Popen(['python', 'test_mkl.py'],
NameError: name 'subprocess' is not defined
```
With patch:
```
Running test snippet to check if MKL running (https://mxnet.apache.org/versions/1.6/api/python/docs/tutorials/performance/backend/mkldnn/mkldnn_readme.html#4)
** MKL version working - CPU version is fast. **
```