### PR TITLE
Fixing syntax error in imagej_roi_converter.py for older Python versions.

### DIFF
--- a/imagej_roi_converter.py
+++ b/imagej_roi_converter.py
@@ -14,16 +14,16 @@ rm = RM.getRoiManager()
 
 imp = IJ.getImage()
 
-with open(file_name, 'r') as textfile:
-	for line in textfile:
-		xy = map(int, line.rstrip().split(','))
-		X = xy[::2]
-		Y = xy[1::2]
-		imp.setRoi(PolygonRoi(X, Y, Roi.POLYGON));
-		#IJ.run(imp, "Convex Hull", "")
-		roi = imp.getRoi()
-		print roi
-		rm.addRoi(roi)
-  
+textfile = open(file_name, 'r')
+for line in textfile:
+	xy = map(int, line.rstrip().split(','))
+	X = xy[::2]
+	Y = xy[1::2]
+	imp.setRoi(PolygonRoi(X, Y, Roi.POLYGON));
+	#IJ.run(imp, "Convex Hull", "")
+	roi = imp.getRoi()
+	print(roi)
+	rm.addRoi(roi)
+textfile.close()  
 rm.runCommand("Associate", "true")	 
 rm.runCommand("Show All with labels")

--- a/imagej_roi_converter.py
+++ b/imagej_roi_converter.py
@@ -1,7 +1,7 @@
-from ij import IJ;
-from ij.plugin.frame import RoiManager;
-from ij.gui import PolygonRoi;
-from ij.gui import Roi;
+from ij import IJ
+from ij.plugin.frame import RoiManager
+from ij.gui import PolygonRoi
+from ij.gui import Roi
 from java.awt import FileDialog
 
 fd = FileDialog(IJ.getInstance(), "Open", FileDialog.LOAD)
@@ -14,16 +14,16 @@ rm = RM.getRoiManager()
 
 imp = IJ.getImage()
 
-textfile = open(file_name, 'r')
+textfile = open(file_name, "r")
 for line in textfile:
-	xy = map(int, line.rstrip().split(','))
-	X = xy[::2]
-	Y = xy[1::2]
-	imp.setRoi(PolygonRoi(X, Y, Roi.POLYGON));
-	#IJ.run(imp, "Convex Hull", "")
-	roi = imp.getRoi()
-	print(roi)
-	rm.addRoi(roi)
-textfile.close()  
-rm.runCommand("Associate", "true")	 
+    xy = map(int, line.rstrip().split(","))
+    X = xy[::2]
+    Y = xy[1::2]
+    imp.setRoi(PolygonRoi(X, Y, Roi.POLYGON))
+    # IJ.run(imp, "Convex Hull", "")
+    roi = imp.getRoi()
+    print(roi)
+    rm.addRoi(roi)
+textfile.close()
+rm.runCommand("Associate", "true")
 rm.runCommand("Show All with labels")


### PR DESCRIPTION
Hi,

This is a fix for #172. if merged, this PR will:

* remove the `with` statement from the `imagej_roi_converter.py` macro;
* Add parentheses to the print statement at line 25.
* Format script with [Black](https://black.readthedocs.io/en/stable/)

I know using the `with` statement for opening files is a best practice for current Python code, however it was causing problems with older Python versions. This change fixes that.

Thank you for any assistance you can provide,

V