### PR TITLE
 Adds 'invert' arg to CLI to enable 'invert grayscale' parameter

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -46,6 +46,7 @@ def main():
                         default=0, type=int, help='channel to segment; 0: GRAY, 1: RED, 2: GREEN, 3: BLUE')
     parser.add_argument('--chan2', required=False, 
                         default=0, type=int, help='nuclear channel (if cyto, optional); 0: NONE, 1: RED, 2: GREEN, 3: BLUE')
+    parser.add_argument('--invert', required=False, action='store_true', help='invert grayscale channel')
     parser.add_argument('--all_channels', action='store_true', help='use all channels in image if using own model and images with special channels')
     parser.add_argument('--diameter', required=False, 
                         default=30., type=float, help='cell diameter, if 0 cellpose will estimate for each image')
@@ -155,6 +156,7 @@ def main():
                                                     resample=args.resample,
                                                     flow_threshold=args.flow_threshold,
                                                     cellprob_threshold=args.cellprob_threshold,
+                                                    invert=args.invert,
                                                     batch_size=args.batch_size,
                                                     interp=(not args.no_interp))
                     
@@ -224,7 +226,7 @@ def main():
             
             # train segmentation model
             if args.train:
-                cpmodel_path = model.train(images, labels, train_files=image_names, 
+                cpmodel_path = model.train(images, labels, train_files=image_names,
                                             test_data=test_images, test_labels=test_labels, test_files=image_names_test,
                                             learning_rate=args.learning_rate, channels=channels, 
                                             save_path=os.path.realpath(args.dir), rescale=rescale, n_epochs=args.n_epochs,


### PR DESCRIPTION
Hi,

this is an attempted fix to #174. If merged, this PR will:

- Add the 'invert' argument to the CLI
- Call the `model.eval` function with the argument set in the invert parameter.

Thank you for any assistance you can provide,

V