### PR TITLE
Pass gpu flag to the CellposeModel constructor

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -220,7 +220,8 @@ def main():
                                         concatenation=args.concatenation,
                                         nclasses=args.nclasses)
             else:
-                model = models.CellposeModel(device=device,
+                model = models.CellposeModel(gpu=gpu,
+                                            device=device,
                                             torch=(not args.mxnet),
                                             pretrained_model=cpmodel_path, 
                                             diam_mean=szmean,


### PR DESCRIPTION
Otherwise, we risk an inconsistent state, e.g. model having
device set to cuda and mkl (CPU-based) enabled at the
same time.

Fixes #195

Side-note: there seems to be a redundancy between mkl, device and gpu flags that's the root cause of the issue here.