### PR TITLE
Add `normalize` parameter to eval

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -257,6 +257,7 @@ class Cellpose():
         masks, flows, styles = self.cp.eval(x, 
                                             batch_size=batch_size, 
                                             invert=invert, 
+                                            normalize=normalize,
                                             diameter=diameter,
                                             rescale=rescale, 
                                             anisotropy=anisotropy, 


### PR DESCRIPTION
The `normalize` parameter was missing in the `eval()` method of the `Cellpose` class