### PR TITLE
Fix passing channel list

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -470,7 +470,7 @@ class CellposeModel(UnetModel):
                 maski, stylei, flowi = self.eval(x[i], 
                                                  batch_size=batch_size, 
                                                  channels=channels[i] if (len(channels)==len(x) and 
-                                                                          isinstance(channels[i], (list, np.ndarray)) and
+                                                                          (isinstance(channels[i], list) or isinstance(channels[i], np.ndarray)) and
                                                                           len(channels[i])==2) else channels, 
                                                  channel_axis=channel_axis, 
                                                  z_axis=z_axis, 
@@ -1014,7 +1014,7 @@ class SizeModel():
             for i in iterator:
                 diam, diam_style = self.eval(x[i], 
                                              channels=channels[i] if (len(channels)==len(x) and 
-                                                                     isinstance(channels[i], (list, np.ndarray)) and
+                                                                     (isinstance(channels[i], list) or isinstance(channels[i], np.ndarray)) and
                                                                      len(channels[i])==2) else channels,
                                              channel_axis=channel_axis, 
                                              normalize=normalize, 

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -470,7 +470,7 @@ class CellposeModel(UnetModel):
                 maski, stylei, flowi = self.eval(x[i], 
                                                  batch_size=batch_size, 
                                                  channels=channels[i] if (len(channels)==len(x) and 
-                                                                          (isinstance(channels[i], list) or isinstance(channels[i], np.ndarray)) and 
+                                                                          isinstance(channels[i], (list, np.ndarray)) and 
                                                                           len(channels[i])==2) else channels, 
                                                  channel_axis=channel_axis, 
                                                  z_axis=z_axis, 

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -470,7 +470,7 @@ class CellposeModel(UnetModel):
                 maski, stylei, flowi = self.eval(x[i], 
                                                  batch_size=batch_size, 
                                                  channels=channels[i] if (len(channels)==len(x) and 
-                                                                          (isinstance(channels[i], list) and isinstance(channels[i], np.ndarray)) and 
+                                                                          (isinstance(channels[i], list) or isinstance(channels[i], np.ndarray)) and 
                                                                           len(channels[i])==2) else channels, 
                                                  channel_axis=channel_axis, 
                                                  z_axis=z_axis, 

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -470,7 +470,7 @@ class CellposeModel(UnetModel):
                 maski, stylei, flowi = self.eval(x[i], 
                                                  batch_size=batch_size, 
                                                  channels=channels[i] if (len(channels)==len(x) and 
-                                                                          isinstance(channels[i], (list, np.ndarray)) and 
+                                                                          isinstance(channels[i], (list, np.ndarray)) and
                                                                           len(channels[i])==2) else channels, 
                                                  channel_axis=channel_axis, 
                                                  z_axis=z_axis, 
@@ -1014,7 +1014,7 @@ class SizeModel():
             for i in iterator:
                 diam, diam_style = self.eval(x[i], 
                                              channels=channels[i] if (len(channels)==len(x) and 
-                                                                     (isinstance(channels[i], list) and isinstance(channels[i], np.ndarray)) and 
+                                                                     isinstance(channels[i], (list, np.ndarray)) and
                                                                      len(channels[i])==2) else channels,
                                              channel_axis=channel_axis, 
                                              normalize=normalize, 


### PR DESCRIPTION

This PR fixes the following error when passing a list of channel definition:
```
model.eval([image1, image2], channels=[[0,1], [0,0]])
```
```
Traceback (most recent call last):
  File "run_cellpose_native.py", line 13, in <module>
    masks, flows, styles, diams = model.eval(imgs_2D, diameter=None, flow_threshold=None, channels=[[0,0], [0,0]])
  File "/home/user/miniconda3/envs/cellpose/lib/python3.8/site-packages/cellpose/models.py", line 257, in eval
    masks, flows, styles = self.cp.eval(x, 
  File "/home/user/miniconda3/envs/cellpose/lib/python3.8/site-packages/cellpose/models.py", line 471, in eval
    maski, stylei, flowi = self.eval(x[i], 
  File "/home/user/miniconda3/envs/cellpose/lib/python3.8/site-packages/cellpose/models.py", line 502, in eval
    x = transforms.convert_image(x, channels, channel_axis=channel_axis, z_axis=z_axis,
  File "/home/user/miniconda3/envs/cellpose/lib/python3.8/site-packages/cellpose/transforms.py", line 285, in convert_image
    x = reshape(x, channels=channels)
  File "/home/user/miniconda3/envs/cellpose/lib/python3.8/site-packages/cellpose/transforms.py", line 344, in reshape
    chanid = [channels[0]-1]
TypeError: unsupported operand type(s) for -: 'list' and 'int'
```