### PR TITLE
fix #297 stitch threshold numbering issue

### DIFF
--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -353,9 +353,20 @@ def get_masks_unet(output, cell_threshold=0, boundary_threshold=0):
 def stitch3D(masks, stitch_threshold=0.25):
     """ stitch 2D masks into 3D volume with stitch_threshold on IOU """
     mmax = masks[0].max()
+    empty = 0
+    
     for i in range(len(masks)-1):
         iou = metrics._intersection_over_union(masks[i+1], masks[i])[1:,1:]
-        if iou.size > 0:
+        if not iou.size and empty == 0:
+            masks[i+1] = masks[i+1]
+            mmax = masks[i+1].max()
+        elif not iou.size and not empty == 0:
+            icount = masks[i+1].max()
+            istitch = np.arange(mmax+1, mmax + icount+1, 1, int)
+            mmax += icount
+            istitch = np.append(np.array(0), istitch)
+            masks[i+1] = istitch[masks[i+1]]
+        else:
             iou[iou < stitch_threshold] = 0.0
             iou[iou < iou.max(axis=0)] = 0.0
             istitch = iou.argmax(axis=1) + 1
@@ -364,6 +375,8 @@ def stitch3D(masks, stitch_threshold=0.25):
             mmax += len(ino)
             istitch = np.append(np.array(0), istitch)
             masks[i+1] = istitch[masks[i+1]]
+            empty = 1
+            
     return masks
 
 # merged deiameter functions


### PR DESCRIPTION
It fixes #297, when empty first z slice and empty (no masks) z slices are found in the middle of the volume, to make sure numbering doesn't restart from 1 during stitching.
