### PR TITLE
iou patch

### DIFF
--- a/cellpose/metrics.py
+++ b/cellpose/metrics.py
@@ -181,6 +181,17 @@ def _intersection_over_union(masks_true, masks_pred):
 
     iou: ND-array, float
         matrix of IOU pairs of size [x.max()+1, y.max()+1]
+
+    to_fwd: coo_matrix
+        matrix of the pairs of labels from masks_true that are fully covered
+        by a mask from masks_pred. For example (to_fwd.row[i], to_fwd_col[i]to_fwd_col[i])
+        means that the mask labeled as to_fwd.row[i] (on the next page of the z-stack) is
+        totally covered by another mask which is labeled as to_fwd.col[i] (on the current page
+        of the z-stack)
+
+    to_bwd: coo_matrix
+        Same as to_fwd but now it looks for masks in masks_pred that are totally covered by
+        a mask in masks_true
     
     ------------
     How it works:

--- a/cellpose/metrics.py
+++ b/cellpose/metrics.py
@@ -207,8 +207,8 @@ def _intersection_over_union(masks_true, masks_pred):
 
     ## The following code checks if a cell at page t completely overshadows (total overlap, not partial)
     ## another cell at page t+1 (and the other way round)
-    to_fwd = None
-    to_bwd = None
+    to_fwd = coo_matrix([])
+    to_bwd = coo_matrix([])
     if np.any(masks_true) and np.any(masks_pred):
         to_fwd = np.zeros(overlap.shape)
         np.divide(overlap, n_pixels_true, out=to_fwd, where=n_pixels_true != 0)

--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -361,7 +361,8 @@ def stitch3D(masks, stitch_threshold=0.25):
     empty = 0
     
     for i in range(len(masks)-1):
-        iou = metrics._intersection_over_union(masks[i+1], masks[i])[1:,1:]
+        iou, to_fwd, to_bwd = metrics._intersection_over_union(masks[i + 1], masks[i])
+        iou = iou[1:, 1:]
         if not iou.size and empty == 0:
             masks[i+1] = masks[i+1]
             mmax = masks[i+1].max()
@@ -379,6 +380,11 @@ def stitch3D(masks, stitch_threshold=0.25):
             istitch[ino] = np.arange(mmax+1, mmax+len(ino)+1, 1, int)
             mmax += len(ino)
             istitch = np.append(np.array(0), istitch)
+
+            if (to_fwd is not None) and (to_bwd is not None):
+                istitch[to_fwd.row] = to_fwd.col
+                istitch[to_bwd.row] = to_bwd.col
+
             masks[i+1] = istitch[masks[i+1]]
             empty = 1
             

--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -381,7 +381,9 @@ def stitch3D(masks, stitch_threshold=0.25):
             mmax += len(ino)
             istitch = np.append(np.array(0), istitch)
 
-            if (to_fwd is not None) and (to_bwd is not None):
+            # apply the patch so that if cells fully overlap between successive slices
+            # they get the same label regardless to the iou metric
+            if (to_fwd.nnz != 0) or (to_bwd.nnz != 0):  # this line can be removed.
                 istitch[to_fwd.row] = to_fwd.col
                 istitch[to_bwd.row] = to_bwd.col
 

--- a/paper/performance_figs.py
+++ b/paper/performance_figs.py
@@ -490,7 +490,8 @@ def mask_stats(test_root, save_root, save_figure=False):
     for j in range(len(masks)):
         iouall=np.zeros(0)
         for i in range(len(test_labels)):
-            iou = metrics._intersection_over_union(test_labels[i], masks[j][i])[1:,1:]
+            iou, to_fwd, to_bwd = metrics._intersection_over_union(test_labels[i], masks[j][i])
+            iou = iou[1:, 1:]
             n_min = min(iou.shape[0], iou.shape[1])
             costs = -(iou >= 0.5).astype(float) - iou / (2*n_min)
             true_ind, pred_ind = linear_sum_assignment(costs)


### PR DESCRIPTION
I think it makes more sense to me in cases where you have a 3d image and let's say there is a mask on some page of the z-stack that completely overshadows another mask on the next page (ie it is not just a partial overlap) the stitching algorithm should consider these two masks as belonging to the same cell regardless what the IoU statistic says

For example, if you have a case like  the one shown below, the mask at the (almost) top left of page 0 occupies the same area that the top-left mask of page 1 does **and** a lot more. The mask when you move from page 0 to page 1 shrinks and keeps its center almost at the same point. In this case, I think these two masks should be labelled the same whatever the formal IoU value is.

![two_masks](https://user-images.githubusercontent.com/12761550/152704973-ff7c7bc6-b174-4fed-bc53-f3dfe98e9f4f.jpg)

This PR is a small patch to handle these cases

Some code with the expected results is included below
```
import pandas as pd
import numpy as np
from cellpose.utils import stitch3D

mask_0 = pd.read_csv('https://raw.githubusercontent.com/acycliq/Anne-s_viewer/master/temp_data/mask_0.csv').values
mask_1 = pd.read_csv('https://raw.githubusercontent.com/acycliq/Anne-s_viewer/master/temp_data/mask_1.csv').values

masks = np.stack([mask_0, mask_1]).astype(np.uint16)

out = stitch3D(masks, stitch_threshold=0.5)

print('Before stitching, mask_0 at (x, y) = (18, 17) has label %d' % mask_0[17, 18])
print('Before stitching, mask_1 at (x, y) = (18, 17) has label %d \n' % mask_1[17, 18])

print('After stitching, mask_0 at (x, y) = (18, 17) has label %d' % out[0, 17, 18])
print('After stitching, mask_1 at (x, y) = (18, 17) has label %d \n' % out[1, 17, 18])
```

Output:
```
Before stitching, mask_0 at (x, y) = (18, 17) has label 4968
Before stitching, mask_1 at (x, y) = (18, 17) has label 5221 

After stitching, mask_0 at (x, y) = (18, 17) has label 4968
After stitching, mask_1 at (x, y) = (18, 17) has label 4968 
```

Thanks!