### PR TITLE
Add typehints

### DIFF
--- a/cellpose/contrib/openvino_utils.py
+++ b/cellpose/contrib/openvino_utils.py
@@ -36,7 +36,7 @@ class OpenVINOModel(object):
 
         buf = io.BytesIO()
         dummy_input = torch.zeros([1] + list(inp.shape[1:]))  # To avoid extra network reloading we process batch in the loop
-   torch.onnx.export(self._base_model, dummy_input, buf, input_names=["input"], output_names=["output", "style"])
+        torch.onnx.export(self._base_model, dummy_input, buf, input_names=["input"], output_names=["output", "style"])
         net = ie.read_model(buf.getvalue(), b"")
         exec_net = ie.compile_model(net, "CPU").create_infer_request()
 

--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -308,7 +308,7 @@ class UnetModel():
         return y, style
                 
     def _run_nets(self, img: ndarray, net_avg: bool=False, augment: bool=False, tile: bool=True, tile_overlap: float=0.1, bsize: int=224, 
-                  return_conv: bool=False, progress: None=None) -> Tuple[ndarray, ndarray]:
+                  return_conv: bool=False, progress=None) -> Tuple[ndarray, ndarray]:
         """ run network (if more than one, loop over networks and average results
 
         Parameters
@@ -541,9 +541,9 @@ class UnetModel():
             styles /= (styles**2).sum()**0.5
             return yf, styles
 
-    def _run_3D(self, imgs: ndarray, rsz: float64=1.0, anisotropy: None=None, net_avg: bool=False, 
+    def _run_3D(self, imgs: ndarray, rsz: float64=1.0, anisotropy: Optional[float]=None, net_avg: bool=False, 
                 augment: bool=False, tile: bool=True, tile_overlap: float=0.1, 
-                bsize: int=224, progress: None=None) -> Tuple[ndarray, ndarray]:
+                bsize: int=224, progress=None) -> Tuple[ndarray, ndarray]:
         """ run network on stack of images
 
         (faster if augment is False)
@@ -770,10 +770,10 @@ class UnetModel():
             self.criterion2 = nn.BCEWithLogitsLoss(reduction='mean')
             
     def _train_net(self, train_data: List[ndarray], train_labels: List[ndarray], 
-              test_data: None=None, test_labels: None=None,
+              test_data: Optional[List[ndarray]]=None, test_labels: Optional[List[ndarray]]=None,
               save_path: Optional[str]=None, save_every: int=100, save_each: bool=False,
               learning_rate: float=0.2, n_epochs: int=500, momentum: float=0.9, weight_decay: float=0.00001, 
-              SGD: bool=True, batch_size: int=8, nimg_per_epoch: None=None, rescale: bool=True, model_name: None=None) -> str: 
+              SGD: bool=True, batch_size: int=8, nimg_per_epoch: Optional[int]=None, rescale: bool=True, model_name: Optional[str]=None) -> str: 
         """ train function uses loss function self.loss_fn in models.py"""
         
         d = datetime.datetime.now()

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -489,7 +489,7 @@ def steps2D(p, dP, inds, niter):
                 p[k,y,x] = min(shape[k]-1, max(0, p[k,y,x] + step[k]))
     return p
 
-def follow_flows(dP: ndarray, mask: None=None, niter: float64=200, interp: bool=True, use_gpu: bool=True, device: Optional[torch.device]=None) -> Tuple[ndarray, ndarray]:
+def follow_flows(dP: ndarray, mask: Optional[ndarray]=None, niter: float64=200, interp: bool=True, use_gpu: bool=True, device: Optional[torch.device]=None) -> Tuple[ndarray, ndarray]:
     """ define pixels and run dynamics to recover masks in 2D
     
     Pixels are meshgrid. Only pixels with non-zero cell-probability
@@ -697,7 +697,7 @@ def get_masks(p: ndarray, iscell: Optional[ndarray]=None, rpad: int=20) -> ndarr
     M0 = np.reshape(M0, shape0)
     return M0
 
-def compute_masks(dP: ndarray, cellprob: ndarray, p: None=None, niter: float64=200, 
+def compute_masks(dP: ndarray, cellprob: ndarray, p: Optional[ndarray]=None, niter: float64=200, 
                    cellprob_threshold: Union[float, int]=0.0,
                    flow_threshold: float=0.4, interp: bool=True, do_3D: bool=False, 
                    min_size: int=15, resize: Optional[List[int]]=None, 

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -17,6 +17,9 @@ from . import utils, metrics, transforms
 import torch
 from torch import optim, nn
 from . import resnet_torch
+from numpy import float64, ndarray, uint32
+from typing import List, Optional, Tuple, Union
+
 TORCH_ENABLED = True 
 torch_GPU = torch.device('cuda')
 torch_CPU = torch.device('cpu')
@@ -164,7 +167,7 @@ def masks_to_flows_gpu(masks, device=None):
 
 
 
-def masks_to_flows_cpu(masks, device=None):
+def masks_to_flows_cpu(masks: ndarray, device: Optional[torch.device]=None) -> Tuple[ndarray, ndarray]:
     """ convert masks to flows using diffusion from center pixel
     Center of masks where diffusion starts is defined to be the 
     closest pixel to the median of all pixels that is inside the 
@@ -222,7 +225,7 @@ def masks_to_flows_cpu(masks, device=None):
     return mu, mu_c
 
 
-def masks_to_flows(masks, use_gpu=False, device=None):
+def masks_to_flows(masks: ndarray, use_gpu: bool=False, device: Optional[torch.device]=None) -> ndarray:
     """ convert masks to flows using diffusion from center pixel
 
     Center of masks where diffusion starts is defined to be the 
@@ -281,7 +284,7 @@ def masks_to_flows(masks, use_gpu=False, device=None):
     else:
         raise ValueError('masks_to_flows only takes 2D or 3D arrays')
 
-def labels_to_flows(labels, files=None, use_gpu=False, device=None, redo_flows=False):
+def labels_to_flows(labels: List[ndarray], files: Optional[List[str]]=None, use_gpu: bool=False, device: Optional[torch.device]=None, redo_flows: bool=False) -> List[ndarray]:
     """ convert labels (list of masks or flows) to flows for training model 
 
     if files is not None, flows are saved to files to be reused
@@ -362,7 +365,7 @@ def map_coordinates(I, yc, xc, Y):
                       np.float32(I[c, yf1, xf1]) * y * x )
 
 
-def steps2D_interp(p, dP, niter, use_gpu=False, device=None):
+def steps2D_interp(p: ndarray, dP: ndarray, niter: uint32, use_gpu: bool=False, device: Optional[torch.device]=None) -> ndarray:
     shape = dP.shape[1:]
     if use_gpu:
         if device is None:
@@ -486,7 +489,7 @@ def steps2D(p, dP, inds, niter):
                 p[k,y,x] = min(shape[k]-1, max(0, p[k,y,x] + step[k]))
     return p
 
-def follow_flows(dP, mask=None, niter=200, interp=True, use_gpu=True, device=None):
+def follow_flows(dP: ndarray, mask: None=None, niter: float64=200, interp: bool=True, use_gpu: bool=True, device: Optional[torch.device]=None) -> Tuple[ndarray, ndarray]:
     """ define pixels and run dynamics to recover masks in 2D
     
     Pixels are meshgrid. Only pixels with non-zero cell-probability
@@ -549,7 +552,7 @@ def follow_flows(dP, mask=None, niter=200, interp=True, use_gpu=True, device=Non
             p[:,inds[:,0],inds[:,1]] = p_interp
     return p, inds
 
-def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=None):
+def remove_bad_flow_masks(masks: ndarray, flows: ndarray, threshold: float=0.4, use_gpu: bool=False, device: Optional[torch.device]=None) -> ndarray:
     """ remove masks which have inconsistent flows 
     
     Uses metrics.flow_error to compute flows from predicted masks 
@@ -583,7 +586,7 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
     masks[np.isin(masks, badi)] = 0
     return masks
 
-def get_masks(p, iscell=None, rpad=20):
+def get_masks(p: ndarray, iscell: Optional[ndarray]=None, rpad: int=20) -> ndarray:
     """ create masks using pixel convergence after running dynamics
     
     Makes a histogram of final pixel locations p, initializes masks 
@@ -694,11 +697,11 @@ def get_masks(p, iscell=None, rpad=20):
     M0 = np.reshape(M0, shape0)
     return M0
 
-def compute_masks(dP, cellprob, p=None, niter=200, 
-                   cellprob_threshold=0.0,
-                   flow_threshold=0.4, interp=True, do_3D=False, 
-                   min_size=15, resize=None, 
-                   use_gpu=False,device=None):
+def compute_masks(dP: ndarray, cellprob: ndarray, p: None=None, niter: float64=200, 
+                   cellprob_threshold: Union[float, int]=0.0,
+                   flow_threshold: float=0.4, interp: bool=True, do_3D: bool=False, 
+                   min_size: int=15, resize: Optional[List[int]]=None, 
+                   use_gpu: bool=False,device: Optional[torch.device]=None) -> Tuple[ndarray, ndarray]:
     """ compute masks using dynamics from dP, cellprob, and boundary """
     
     cp_mask = cellprob > cellprob_threshold 

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -51,6 +51,8 @@ def logger_setup():
     return logger, log_file
 
 from . import utils, plot, transforms
+from numpy import float32, ndarray
+from typing import List, Optional, Tuple, Union
 
 # helper function to check for a path; if it doesn't exist, make it 
 def check_dir(path):
@@ -65,7 +67,7 @@ def outlines_to_text(base, outlines):
             f.write(xy_str)
             f.write('\n')
 
-def imread(filename):
+def imread(filename: str) -> ndarray:
     ext = os.path.splitext(filename)[-1]
     if ext== '.tif' or ext=='.tiff':
         with tifffile.TiffFile(filename) as tif:
@@ -109,7 +111,7 @@ def imread(filename):
             return None
 
 
-def imsave(filename, arr):
+def imsave(filename: str, arr: ndarray) -> None:
     ext = os.path.splitext(filename)[-1]
     if ext== '.tif' or ext=='.tiff':
         tifffile.imsave(filename, arr)
@@ -119,7 +121,7 @@ def imsave(filename, arr):
         cv2.imwrite(filename, arr)
 #         skimage.io.imsave(filename, arr.astype()) #cv2 doesn't handle transparency
 
-def get_image_files(folder, mask_filter, imf=None, look_one_level_down=False):
+def get_image_files(folder: str, mask_filter: str, imf: None=None, look_one_level_down: bool=False) -> List[str]:
     """ find all images in a folder and if look_one_level_down all subfolders """
     mask_filters = ['_cp_masks', '_cp_output', '_flows', '_masks', mask_filter]
     image_names = []
@@ -154,7 +156,7 @@ def get_image_files(folder, mask_filter, imf=None, look_one_level_down=False):
     
     return image_names
         
-def get_label_files(image_names, mask_filter, imf=None):
+def get_label_files(image_names: List[str], mask_filter: str, imf: None=None) -> Tuple[List[str], None]:
     nimg = len(image_names)
     label_names0 = [os.path.splitext(image_names[n])[0] for n in range(nimg)]
 
@@ -194,7 +196,7 @@ def get_label_files(image_names, mask_filter, imf=None):
     return label_names, flow_names
 
 
-def load_images_labels(tdir, mask_filter='_masks', image_filter=None, look_one_level_down=False, unet=False):
+def load_images_labels(tdir: str, mask_filter: str='_masks', image_filter: None=None, look_one_level_down: bool=False, unet: bool=False) -> Tuple[List[ndarray], List[ndarray], List[str]]:
     image_names = get_image_files(tdir, mask_filter, image_filter, look_one_level_down)
     nimg = len(image_names)
 
@@ -221,7 +223,7 @@ def load_images_labels(tdir, mask_filter='_masks', image_filter=None, look_one_l
     io_logger.info(f'{k} / {nimg} images in {tdir} folder have labels')
     return images, labels, image_names
 
-def load_train_test_data(train_dir, test_dir=None, image_filter=None, mask_filter='_masks', unet=False, look_one_level_down=False):
+def load_train_test_data(train_dir: str, test_dir: None=None, image_filter: None=None, mask_filter: str='_masks', unet: bool=False, look_one_level_down: bool=False) -> Tuple[List[ndarray], List[ndarray], List[str], None, None, None]:
     images, labels, image_names = load_images_labels(train_dir, mask_filter, image_filter, look_one_level_down, unet)
                     
     # testing data
@@ -233,7 +235,7 @@ def load_train_test_data(train_dir, test_dir=None, image_filter=None, mask_filte
 
 
 
-def masks_flows_to_seg(images, masks, flows, diams, file_names, channels=None):
+def masks_flows_to_seg(images: Union[List[ndarray], ndarray], masks: Union[List[ndarray], ndarray], flows: List[Union[ndarray, List[ndarray]]], diams: Union[float32, int], file_names: Union[List[str], str], channels: Optional[List[int]]=None) -> None:
     """ save output of model eval to be loaded in GUI 
 
     can be list output (run on multiple images) or single output (run on single image)

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -121,7 +121,7 @@ def imsave(filename: str, arr: ndarray) -> None:
         cv2.imwrite(filename, arr)
 #         skimage.io.imsave(filename, arr.astype()) #cv2 doesn't handle transparency
 
-def get_image_files(folder: str, mask_filter: str, imf: None=None, look_one_level_down: bool=False) -> List[str]:
+def get_image_files(folder: str, mask_filter: str, imf: Optional=None, look_one_level_down: bool=False) -> List[str]:
     """ find all images in a folder and if look_one_level_down all subfolders """
     mask_filters = ['_cp_masks', '_cp_output', '_flows', '_masks', mask_filter]
     image_names = []
@@ -156,7 +156,7 @@ def get_image_files(folder: str, mask_filter: str, imf: None=None, look_one_leve
     
     return image_names
         
-def get_label_files(image_names: List[str], mask_filter: str, imf: None=None) -> Tuple[List[str], None]:
+def get_label_files(image_names: List[str], mask_filter: str, imf: Optional=None) -> Tuple[List[str], None]:
     nimg = len(image_names)
     label_names0 = [os.path.splitext(image_names[n])[0] for n in range(nimg)]
 
@@ -196,7 +196,7 @@ def get_label_files(image_names: List[str], mask_filter: str, imf: None=None) ->
     return label_names, flow_names
 
 
-def load_images_labels(tdir: str, mask_filter: str='_masks', image_filter: None=None, look_one_level_down: bool=False, unet: bool=False) -> Tuple[List[ndarray], List[ndarray], List[str]]:
+def load_images_labels(tdir: str, mask_filter: str='_masks', image_filter: Optional=None, look_one_level_down: bool=False, unet: bool=False) -> Tuple[List[ndarray], List[ndarray], List[str]]:
     image_names = get_image_files(tdir, mask_filter, image_filter, look_one_level_down)
     nimg = len(image_names)
 
@@ -223,7 +223,7 @@ def load_images_labels(tdir: str, mask_filter: str='_masks', image_filter: None=
     io_logger.info(f'{k} / {nimg} images in {tdir} folder have labels')
     return images, labels, image_names
 
-def load_train_test_data(train_dir: str, test_dir: None=None, image_filter: None=None, mask_filter: str='_masks', unet: bool=False, look_one_level_down: bool=False) -> Tuple[List[ndarray], List[ndarray], List[str], None, None, None]:
+def load_train_test_data(train_dir: str, test_dir: Optional=None, image_filter: Optional=None, mask_filter: str='_masks', unet: bool=False, look_one_level_down: bool=False) -> Tuple[List[ndarray], List[ndarray], List[str], None, None, None]:
     images, labels, image_names = load_images_labels(train_dir, mask_filter, image_filter, look_one_level_down, unet)
                     
     # testing data

--- a/cellpose/metrics.py
+++ b/cellpose/metrics.py
@@ -3,6 +3,9 @@ from . import utils, dynamics
 from numba import jit
 from scipy.optimize import linear_sum_assignment
 from scipy.ndimage import convolve, mean
+from numpy import int64, ndarray
+from torch import device
+from typing import List, Optional, Tuple
 
 
 def mask_ious(masks_true, masks_pred):
@@ -70,7 +73,7 @@ def aggregated_jaccard_index(masks_true, masks_pred):
     return aji 
 
 
-def average_precision(masks_true, masks_pred, threshold=[0.5, 0.75, 0.9]):
+def average_precision(masks_true: ndarray, masks_pred: ndarray, threshold: List[float]=[0.5, 0.75, 0.9]) -> Tuple[ndarray, ndarray, ndarray, ndarray]:
     """ average precision estimation: AP = TP / (TP + FP + FN)
 
     This function is based heavily on the *fast* stardist matching functions
@@ -165,7 +168,7 @@ def _label_overlap(x, y):
         overlap[x[i],y[i]] += 1
     return overlap
 
-def _intersection_over_union(masks_true, masks_pred):
+def _intersection_over_union(masks_true: ndarray, masks_pred: ndarray) -> ndarray:
     """ intersection over union of all mask pairs
     
     Parameters
@@ -206,7 +209,7 @@ def _intersection_over_union(masks_true, masks_pred):
     iou[np.isnan(iou)] = 0.0
     return iou
 
-def _true_positive(iou, th):
+def _true_positive(iou: ndarray, th: float) -> int64:
     """ true positive at threshold th
     
     Parameters
@@ -245,7 +248,7 @@ def _true_positive(iou, th):
     tp = match_ok.sum()
     return tp
 
-def flow_error(maski, dP_net, use_gpu=False, device=None):
+def flow_error(maski: ndarray, dP_net: ndarray, use_gpu: bool=False, device: Optional[device]=None) -> Tuple[ndarray, ndarray]:
     """ error in flows from predicted masks vs flows predicted by network run on image
 
     This function serves to benchmark the quality of masks, it works as follows

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -85,7 +85,7 @@ class Cellpose():
         recommended if you want to use a specific GPU (e.g. torch.device('cuda:1'))
 
     """
-    def __init__(self, gpu: bool=False, model_type: str='cyto', net_avg: bool=False, device: None=None) -> None:
+    def __init__(self, gpu: bool=False, model_type: str='cyto', net_avg: bool=False, device: Optional=None) -> None:
         super(Cellpose, self).__init__()
         self.torch = True
         
@@ -114,10 +114,10 @@ class Cellpose():
         self.sz.model_type = model_type
         
     def eval(self, x: Union[ndarray, List[ndarray]], batch_size: int=8, channels: Optional[List[int]]=None, channel_axis: Optional[int]=None, z_axis: Optional[int]=None,
-             invert: bool=False, normalize: bool=True, diameter: int=30., do_3D: bool=False, anisotropy: None=None,
+             invert: bool=False, normalize: bool=True, diameter: int=30., do_3D: bool=False, anisotropy: Optional=None,
              net_avg: bool=False, augment: bool=False, tile: bool=True, tile_overlap: float=0.1, resample: bool=True, interp: bool=True,
              flow_threshold: float=0.4, cellprob_threshold: Union[float, int]=0.0, min_size: int=15, stitch_threshold: float=0.0, 
-             rescale: None=None, progress: None=None, model_loaded: bool=False) -> Union[Tuple[ndarray, List[ndarray], ndarray, int], Tuple[ndarray, List[ndarray], ndarray, float64], Tuple[List[ndarray], List[List[ndarray]], List[ndarray], int]]:
+             rescale: Optional=None, progress: Optional=None, model_loaded: bool=False) -> Union[Tuple[ndarray, List[ndarray], ndarray, int], Tuple[ndarray, List[ndarray], ndarray, float64], Tuple[List[ndarray], List[List[ndarray]], List[ndarray], int]]:
         """ run cellpose and get masks
 
         Parameters
@@ -392,11 +392,11 @@ class CellposeModel(UnetModel):
     
     def eval(self, x: Union[ndarray, List[ndarray]], batch_size: int=8, channels: Optional[List[int]]=None, channel_axis: Optional[int]=None, 
              z_axis: Optional[int]=None, normalize: bool=True, invert: bool=False, 
-             rescale: Optional[float64]=None, diameter: Optional[int]=None, do_3D: bool=False, anisotropy: None=None, net_avg: bool=False, 
+             rescale: Optional[float64]=None, diameter: Optional[int]=None, do_3D: bool=False, anisotropy: Optional[float]=None, net_avg: bool=False, 
              augment: bool=False, tile: bool=True, tile_overlap: float=0.1,
              resample: bool=True, interp: bool=True,
              flow_threshold: float=0.4, cellprob_threshold: Union[float, int]=0.0,
-             compute_masks: bool=True, min_size: int=15, stitch_threshold: float=0.0, progress: None=None,  
+             compute_masks: bool=True, min_size: int=15, stitch_threshold: float=0.0, progress: Optional=None,  
              loop_run: bool=False, model_loaded: bool=False) -> Union[Tuple[ndarray, List[ndarray], ndarray], Tuple[List[ndarray], List[List[ndarray]], List[ndarray]]]:
         """
             segment list of images x, or 4D array - Z x nchan x Y x X
@@ -587,7 +587,7 @@ class CellposeModel(UnetModel):
                 augment: bool=False, tile: bool=True, tile_overlap: float=0.1,
                 cellprob_threshold: Union[float, int]=0.0, 
                 flow_threshold: float=0.4, min_size: int=15,
-                interp: bool=True, anisotropy: None=1.0, do_3D: bool=False, stitch_threshold: float=0.0,
+                interp: bool=True, anisotropy: Optional[float]=1.0, do_3D: bool=False, stitch_threshold: float=0.0,
                 ) -> Tuple[ndarray, ndarray, ndarray, ndarray, ndarray]:
         
         tic = time.time()
@@ -695,13 +695,13 @@ class CellposeModel(UnetModel):
 
 
     def train(self, train_data: List[ndarray], train_labels: List[ndarray], train_files: Optional[List[str]]=None, 
-              test_data: None=None, test_labels: None=None, test_files: None=None,
+              test_data: Optional=None, test_labels: Optional=None, test_files: Optional=None,
               channels: Optional[List[int]]=None, normalize: bool=True, 
               save_path: Optional[str]=None, save_every: int=100, save_each: bool=False,
               learning_rate: float=0.2, n_epochs: int=500, momentum: float=0.9, SGD: bool=True,
-              weight_decay: float=0.00001, batch_size: int=8, nimg_per_epoch: None=None,
+              weight_decay: float=0.00001, batch_size: int=8, nimg_per_epoch: Optional=None,
               rescale: bool=True, min_train_masks: int=5,
-              model_name: None=None) -> str:
+              model_name: Optional=None) -> str:
 
         """ train network with images train_data 
         
@@ -838,9 +838,9 @@ class SizeModel():
             models_logger.critical(error_message)
             raise ValueError(error_message)
         
-    def eval(self, x: ndarray, channels: Optional[List[int]]=None, channel_axis: None=None, 
+    def eval(self, x: ndarray, channels: Optional[List[int]]=None, channel_axis: Optional[int]=None, 
              normalize: bool=True, invert: bool=False, augment: bool=False, tile: bool=True,
-             batch_size: int=8, progress: None=None, interp: bool=True) -> Tuple[float64, float64]:
+             batch_size: int=8, progress: Optional=None, interp: bool=True) -> Tuple[float64, float64]:
         """ use images x to produce style or use style input to predict size of objects in image
 
             Object size estimation is done in two steps:

--- a/cellpose/plot.py
+++ b/cellpose/plot.py
@@ -3,6 +3,7 @@ import numpy as np
 import cv2
 from scipy.ndimage import gaussian_filter
 from . import utils, io, transforms
+from numpy import ndarray
 
 try:
     import matplotlib
@@ -18,7 +19,7 @@ except:
     SKIMAGE_ENABLED = False
 
 # modified to use sinebow color
-def dx_to_circ(dP,transparency=False,mask=None):
+def dx_to_circ(dP: ndarray,transparency: bool=False,mask: None=None) -> ndarray:
     """ dP is 2 x Y x X => 'optic' flow representation 
     
     Parameters

--- a/cellpose/plot.py
+++ b/cellpose/plot.py
@@ -5,6 +5,8 @@ from scipy.ndimage import gaussian_filter
 from . import utils, io, transforms
 from numpy import ndarray
 
+from typing import Optional
+
 try:
     import matplotlib
     MATPLOTLIB_ENABLED = True 
@@ -19,7 +21,7 @@ except:
     SKIMAGE_ENABLED = False
 
 # modified to use sinebow color
-def dx_to_circ(dP: ndarray,transparency: bool=False,mask: None=None) -> ndarray:
+def dx_to_circ(dP: ndarray,transparency: bool=False,mask: Optional=None) -> ndarray:
     """ dP is 2 x Y x X => 'optic' flow representation 
     
     Parameters

--- a/cellpose/resnet_torch.py
+++ b/cellpose/resnet_torch.py
@@ -218,7 +218,7 @@ class CPnet(nn.Module):
         return T0, style0
 
     def save_model(self, filename: str) -> None:
-   torch.save(self.state_dict(), filename)
+        torch.save(self.state_dict(), filename)
 
     def load_model(self, filename: str, cpu: bool=False) -> None:
         if not cpu:

--- a/cellpose/resnet_torch.py
+++ b/cellpose/resnet_torch.py
@@ -9,6 +9,9 @@ import datetime
 
 
 from . import transforms, io, dynamics, utils
+from torch.nn.modules.container import Sequential
+from torch.nn.parameter import Parameter
+from typing import List, Optional, Tuple, Union
 
 sz = 3
 
@@ -19,21 +22,21 @@ def convbatchrelu(in_channels, out_channels, sz):
         nn.ReLU(inplace=True),
     )  
 
-def batchconv(in_channels, out_channels, sz):
+def batchconv(in_channels: int, out_channels: int, sz: int) -> Sequential:
     return nn.Sequential(
         nn.BatchNorm2d(in_channels, eps=1e-5),
         nn.ReLU(inplace=True),
         nn.Conv2d(in_channels, out_channels, sz, padding=sz//2),
     )  
 
-def batchconv0(in_channels, out_channels, sz):
+def batchconv0(in_channels: int, out_channels: int, sz: int) -> Sequential:
     return nn.Sequential(
         nn.BatchNorm2d(in_channels, eps=1e-5),
         nn.Conv2d(in_channels, out_channels, sz, padding=sz//2),
     )  
 
 class resdown(nn.Module):
-    def __init__(self, in_channels, out_channels, sz):
+    def __init__(self, in_channels: int, out_channels: int, sz: int) -> None:
         super().__init__()
         self.conv = nn.Sequential()
         self.proj  = batchconv0(in_channels, out_channels, 1)
@@ -43,13 +46,13 @@ class resdown(nn.Module):
             else:
                 self.conv.add_module('conv_%d'%t, batchconv(out_channels, out_channels, sz))
                 
-    def forward(self, x):
+    def forward(self, x:torch.Tensor) ->torch.Tensor:
         x = self.proj(x) + self.conv[1](self.conv[0](x))
         x = x + self.conv[3](self.conv[2](x))
         return x
 
 class convdown(nn.Module):
-    def __init__(self, in_channels, out_channels, sz):
+    def __init__(self, in_channels: int, out_channels: int, sz: int) -> None:
         super().__init__()
         self.conv = nn.Sequential()
         for t in range(2):
@@ -64,7 +67,7 @@ class convdown(nn.Module):
         return x
 
 class downsample(nn.Module):
-    def __init__(self, nbase, sz, residual_on=True):
+    def __init__(self, nbase: List[int], sz: int, residual_on: bool=True) -> None:
         super().__init__()
         self.down = nn.Sequential()
         self.maxpool = nn.MaxPool2d(2, 2)
@@ -74,7 +77,7 @@ class downsample(nn.Module):
             else:
                 self.down.add_module('conv_down_%d'%n, convdown(nbase[n], nbase[n+1], sz))
             
-    def forward(self, x):
+    def forward(self, x:torch.Tensor) -> List[    torch.Tensor]:
         xd = []
         for n in range(len(self.down)):
             if n>0:
@@ -85,7 +88,7 @@ class downsample(nn.Module):
         return xd
     
 class batchconvstyle(nn.Module):
-    def __init__(self, in_channels, out_channels, style_channels, sz, concatenation=False):
+    def __init__(self, in_channels: int, out_channels: int, style_channels: int, sz: int, concatenation: bool=False) -> None:
         super().__init__()
         self.concatenation = concatenation
         if concatenation:
@@ -95,7 +98,7 @@ class batchconvstyle(nn.Module):
             self.conv = batchconv(in_channels, out_channels, sz)
             self.full = nn.Linear(style_channels, out_channels)
         
-    def forward(self, style, x, mkldnn=False, y=None):
+    def forward(self, style:torch.Tensor, x:torch.Tensor, mkldnn: bool=False, y: Optional[    torch.Tensor]=None) ->torch.Tensor:
         if y is not None:
             if self.concatenation:
                 x = torch.cat((y, x), dim=1)
@@ -111,7 +114,7 @@ class batchconvstyle(nn.Module):
         return y
     
 class resup(nn.Module):
-    def __init__(self, in_channels, out_channels, style_channels, sz, concatenation=False):
+    def __init__(self, in_channels: int, out_channels: int, style_channels: int, sz: int, concatenation: bool=False) -> None:
         super().__init__()
         self.conv = nn.Sequential()
         self.conv.add_module('conv_0', batchconv(in_channels, out_channels, sz))
@@ -120,13 +123,13 @@ class resup(nn.Module):
         self.conv.add_module('conv_3', batchconvstyle(out_channels, out_channels, style_channels, sz))
         self.proj  = batchconv0(in_channels, out_channels, 1)
 
-    def forward(self, x, y, style, mkldnn=False):
+    def forward(self, x:torch.Tensor, y:torch.Tensor, style:torch.Tensor, mkldnn: bool=False) ->torch.Tensor:
         x = self.proj(x) + self.conv[1](style, self.conv[0](x), y=y, mkldnn=mkldnn)
         x = x + self.conv[3](style, self.conv[2](style, x, mkldnn=mkldnn), mkldnn=mkldnn)
         return x
     
 class convup(nn.Module):
-    def __init__(self, in_channels, out_channels, style_channels, sz, concatenation=False):
+    def __init__(self, in_channels: int, out_channels: int, style_channels: int, sz: int, concatenation: bool=False) -> None:
         super().__init__()
         self.conv = nn.Sequential()
         self.conv.add_module('conv_0', batchconv(in_channels, out_channels, sz))
@@ -137,12 +140,12 @@ class convup(nn.Module):
         return x
     
 class make_style(nn.Module):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         #self.pool_all = nn.AvgPool2d(28)
         self.flatten = nn.Flatten()
 
-    def forward(self, x0):
+    def forward(self, x0:torch.Tensor) ->torch.Tensor:
         #style = self.pool_all(x0)
         style = F.avg_pool2d(x0, kernel_size=(x0.shape[-2],x0.shape[-1]))
         style = self.flatten(style)
@@ -151,7 +154,7 @@ class make_style(nn.Module):
         return style
     
 class upsample(nn.Module):
-    def __init__(self, nbase, sz, residual_on=True, concatenation=False):
+    def __init__(self, nbase: List[int], sz: int, residual_on: bool=True, concatenation: bool=False) -> None:
         super().__init__()
         self.upsampling = nn.Upsample(scale_factor=2, mode='nearest')
         self.up = nn.Sequential()
@@ -163,7 +166,7 @@ class upsample(nn.Module):
                 self.up.add_module('conv_up_%d'%(n-1), 
                     convup(nbase[n], nbase[n-1], nbase[-1], sz, concatenation))
 
-    def forward(self, style, xd, mkldnn=False):
+    def forward(self, style:torch.Tensor, xd: List[    torch.Tensor], mkldnn: bool=False) ->torch.Tensor:
         x = self.up[-1](xd[-1], xd[-1], style, mkldnn=mkldnn)
         for n in range(len(self.up)-2,-1,-1):
             if mkldnn:
@@ -174,10 +177,10 @@ class upsample(nn.Module):
         return x
     
 class CPnet(nn.Module):
-    def __init__(self, nbase, nout, sz,
-                residual_on=True, style_on=True, 
-                concatenation=False, mkldnn=False,
-                diam_mean=30.):
+    def __init__(self, nbase: List[int], nout: int, sz: int,
+                residual_on: bool=True, style_on: bool=True, 
+                concatenation: bool=False, mkldnn: bool=False,
+                diam_mean: Union[int, float, Parameter]=30.) -> None:
         super(CPnet, self).__init__()
         self.nbase = nbase
         self.nout = nout
@@ -196,7 +199,7 @@ class CPnet(nn.Module):
         self.diam_labels = nn.Parameter(data=torch.ones(1) * diam_mean, requires_grad=False)
         self.style_on = style_on
         
-    def forward(self, data):
+    def forward(self, data:torch.Tensor) -> Tuple[    torch.Tensor,torch.Tensor]:
         if self.mkldnn:
             data = data.to_mkldnn()
         T0    = self.downsample(data)
@@ -214,10 +217,10 @@ class CPnet(nn.Module):
             #T1 = T1.to_dense()    
         return T0, style0
 
-    def save_model(self, filename):
-        torch.save(self.state_dict(), filename)
+    def save_model(self, filename: str) -> None:
+   torch.save(self.state_dict(), filename)
 
-    def load_model(self, filename, cpu=False):
+    def load_model(self, filename: str, cpu: bool=False) -> None:
         if not cpu:
             state_dict = torch.load(filename)
         else:

--- a/cellpose/test_mkl.py
+++ b/cellpose/test_mkl.py
@@ -10,7 +10,7 @@ try:
 except:
     MXNET_ENABLED = False
 
-def test_mkl():
+def test_mkl() -> None:
     if MXNET_ENABLED:
         num_filter = 32
         kernel = (3, 3)

--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -405,7 +405,7 @@ def normalize_img(img: ndarray, axis: int=-1, invert: bool=False) -> ndarray:
     img = np.moveaxis(img, 0, axis)
     return img
 
-def reshape_train_test(train_data: List[ndarray], train_labels: List[ndarray], test_data: None, test_labels: None, channels: List[int], normalize: bool=True) -> Tuple[List[ndarray], List[ndarray], None, None, bool]:
+def reshape_train_test(train_data: List[ndarray], train_labels: List[ndarray], test_data: Optional, test_labels: Optional, channels: List[int], normalize: bool=True) -> Tuple[List[ndarray], List[ndarray], None, None, bool]:
     """ check sizes and reshape train and test data for training """
     nimg = len(train_data)
     # check that arrays are correct size
@@ -446,7 +446,7 @@ def reshape_train_test(train_data: List[ndarray], train_labels: List[ndarray], t
 
     return train_data, train_labels, test_data, test_labels, run_test
 
-def reshape_and_normalize_data(train_data: List[ndarray], test_data: None=None, channels: Optional[List[int]]=None, normalize: bool=True) -> Tuple[List[ndarray], None, bool]:
+def reshape_and_normalize_data(train_data: List[ndarray], test_data: Optional=None, channels: Optional[List[int]]=None, normalize: bool=True) -> Tuple[List[ndarray], None, bool]:
     """ inputs converted to correct shapes for *training* and rescaled so that 0.0=1st percentile
     and 1.0=99th percentile of image intensities in each channel
 

--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -11,6 +11,9 @@ import colorsys
 import io
 
 from . import metrics
+from logging import Logger
+from numpy import float64, ndarray
+from typing import Optional, Tuple
 
 try:
     from skimage.morphology import remove_small_holes
@@ -26,13 +29,13 @@ class TqdmToLogger(io.StringIO):
     logger = None
     level = None
     buf = ''
-    def __init__(self,logger,level=None):
+    def __init__(self,logger: Logger,level: Optional[int]=None) -> None:
         super(TqdmToLogger, self).__init__()
         self.logger = logger
         self.level = level or logging.INFO
-    def write(self,buf):
+    def write(self,buf: str) -> None:
         self.buf = buf.strip('\r\n\t ')
-    def flush(self):
+    def flush(self) -> None:
         self.logger.log(self.level, self.buf)
 
 def rgb_to_hsv(arr):
@@ -49,7 +52,7 @@ def hsv_to_rgb(arr):
     rgb = np.stack((r,g,b), axis=-1)
     return rgb
 
-def download_url_to_file(url, dst, progress=True):
+def download_url_to_file(url: str, dst: str, progress: bool=True) -> None:
     r"""Download object at the given URL to a local path.
             Thanks to torch, slightly modified
     Args:
@@ -183,7 +186,7 @@ def remove_edge_masks(masks, change_index=True):
 
     return masks
 
-def masks_to_outlines(masks):
+def masks_to_outlines(masks: ndarray) -> ndarray:
     """ get outlines of masks as a 0-1 array 
     
     Parameters
@@ -350,7 +353,7 @@ def get_masks_unet(output, cell_threshold=0, boundary_threshold=0):
     masks = np.reshape(masks, shape0)
     return masks
 
-def stitch3D(masks, stitch_threshold=0.25):
+def stitch3D(masks: ndarray, stitch_threshold: float=0.25) -> ndarray:
     """ stitch 2D masks into 3D volume with stitch_threshold on IOU """
     mmax = masks[0].max()
     empty = 0
@@ -379,7 +382,7 @@ def stitch3D(masks, stitch_threshold=0.25):
             
     return masks
 
-def diameters(masks):
+def diameters(masks: ndarray) -> Tuple[float64, ndarray]:
     _, counts = np.unique(np.int32(masks), return_counts=True)
     counts = counts[1:]
     md = np.median(counts**0.5)
@@ -412,7 +415,7 @@ def process_cells(M0, npix=20):
             M0[M0==unq[j]] = 0
     return M0
 
-def fill_holes_and_remove_small_masks(masks, min_size=15):
+def fill_holes_and_remove_small_masks(masks: ndarray, min_size: int=15) -> ndarray:
     """ fill holes in masks (2D/3D) and discard masks smaller than min_size (2D)
     
     fill holes in each mask using scipy.ndimage.morphology.binary_fill_holes

--- a/conftest.py
+++ b/conftest.py
@@ -2,16 +2,17 @@ import pytest
 import os, sys, shutil
 from cellpose import utils
 
-from pathlib import Path
+from pathlib import PosixPath, Path
+from typing import List
 
 @pytest.fixture()
-def image_names():
+def image_names() -> List[str]:
     image_names = ['gray_2D.png', 'rgb_2D.png', 'rgb_2D_tif.tif', 'gray_3D.tif', 'rgb_3D.tif',
                     'segment_80x224x448_input.tiff', 'segment_80x224x448_expected.tiff']
     return image_names
 
 @pytest.fixture()
-def data_dir(image_names):
+def data_dir(image_names: List[str]) -> PosixPath:
     cp_dir = Path.home().joinpath('.cellpose')
     cp_dir.mkdir(exist_ok=True)
     data_dir = cp_dir.joinpath('data')


### PR DESCRIPTION
Add typehints with [`monkeytype`](https://monkeytype.readthedocs.io/en/latest/). As this is a one-time operation, I'm haven't included the script in this PR.

Monkeytype traces the program and inserts typehints. I used it to trace the cellpose test suite and applied the typehints. Monkeytype isn't perfect, so I manually corrected its output a little. Since the test suite doesn't have full coverage, not all code will get typehinted. It's possible to extend typehint coverage by running other pieces of the code.

Script:
```bash
#!/bin/bash

pip install monkeytype

# trace types by running the test suite
monkeytype run -m pytest

mods=$(monkeytype list-modules)

for mod in $mods
do
    echo $mod
    monkeytype apply --ignore-existing-annotations $mod
done
```