### PR TITLE
Fix bug with single object masks

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,38 +25,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: conda-incubator/setup-miniconda@v2
         with:
+          auto-activate-base: true
           python-version: ${{ matrix.python-version }}
-
-      # these libraries, along with pytest-xvfb (added in the `deps` in tox.ini),
-      # enable testing on Qt on linux
-      - name: Install Linux libraries
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0 libxcb-icccm4 \
-            libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
-            libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 pkg-config libhdf5-103 libhdf5-dev
-      # strategy borrowed from vispy for installing opengl libs on windows
-      - name: Install Windows OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          git clone --depth 1 https://www.github.com/pyvista/gl-ci-helpers.git
-          powershell gl-ci-helpers/appveyor/install_opengl.ps1
-      # note: if you need dependencies from conda, considering using
-      # setup-miniconda: https://github.com/conda-incubator/setup-miniconda
-      # and
-      # tox-conda: https://github.com/tox-dev/tox-conda
       - name: Install dependencies
+        shell: bash -l {0}
         run: |
-          python -m pip install --upgrade pip
-          pip install dask dask_image scikit-learn
-          pip install wheel setuptools tox tox-gh-actions
+          python -m pip install tox tox-gh-actions
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        run: tox
+        shell: bash -l {0}
+        run: |
+          tox
         env:
           PLATFORM: ${{ matrix.platform }}
 

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -85,7 +85,7 @@ def _extend_centers_gpu(neighbors, centers, isneighbor, Ly, Lx, n_iter=200, devi
     dy = grads[:,0] - grads[:,1]
     dx = grads[:,2] - grads[:,3]
     del grads
-    mu_torch = np.stack((dy.cpu().squeeze(), dx.cpu().squeeze()), axis=-2)
+    mu_torch = np.stack((dy.cpu().squeeze(0), dx.cpu().squeeze(0)), axis=-2)
     return mu_torch
 
 

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+import torch
+
+from cellpose.dynamics import masks_to_flows_gpu
+
+CUDA_AVAILABLE = torch.cuda.is_available()
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason='No CUDA device available')
+def test__masks_to_flows_gpu__single_object():
+    masks = np.zeros((32, 32), dtype=int)
+    masks[16, 16] = 1
+    masks_to_flows_gpu(masks, device=torch.device('cuda'))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
+requires = tox-conda
 envlist = py{38,39}-{linux,macos,windows}
 
 [gh-actions]
@@ -25,10 +26,22 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 extras = gui,distributed
+conda_deps =
+    pytest
+    pytorch
+    linux,windows: cpuonly
+conda_channels = 
+    pytorch
 deps = 
     .[gui,distributed]
-    pytest  # https://docs.pytest.org/en/latest/contents.html
-    pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
-    pytest-xvfb ; sys_platform == 'linux'
+    pytest-cov
+    pytest-xvfb
 # ignoring contrib tests for now
-commands = pytest -v --color=yes --cov=cellpose --cov-report=xml --ignore=tests/contrib 
+commands = 
+    pytest -v --color=yes --cov=cellpose --cov-report=xml --ignore=tests/contrib
+    
+[testenv:gpu]
+conda_deps = 
+    pytest
+    pytorch
+    linux,windows: cudatoolkit=11.3


### PR DESCRIPTION
During one of my GPU model trainings I ran into a problem in `cellpose/dynamics.py`. The line: 
https://github.com/MouseLand/cellpose/blob/e6d7d2e73fe27754288de1fb30ea71bf295930e9/cellpose/dynamics.py#L88
fails if a label image contains only a single object since `squeeze` operates on all singular array dimensions. Here it should operate only on the first dimension:
```
    mu_torch = np.stack((dy.cpu().squeeze(0), dx.cpu().squeeze(0)), axis=-2)
```
To verify the bug (and test the fix), I adapted the `tox` test test runs such that it now can run locally on a GPU via:
```
tox -e gpu
```
This only requires an installed NVIDIA GPU and the its drivers. CUDA and pytorch are installed via `tox-conda`. This btw closes #395 as well.

I also noticed that large fractions of the library installations are not used during the `pytest` runs and therefore deleted them from the github actions. The GPU test is skipped during the github action runs and the cpu-only version of pytorch is used.