### PR TITLE
Checking modifier keys using bitfield operations

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -698,9 +698,7 @@ class MainW(QMainWindow):
     def keyPressEvent(self, event):
         if self.loaded:
             #self.p0.setMouseEnabled(x=True, y=True)
-            if (event.modifiers() != QtCore.Qt.ControlModifier and
-                event.modifiers() != QtCore.Qt.ShiftModifier and
-                event.modifiers() != QtCore.Qt.AltModifier) and not self.in_stroke:
+            if not (event.modifiers() & (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier | QtCore.Qt.AltModifier) or self.in_stroke):
                 updated = False
                 if len(self.current_point_set) > 0:
                     if event.key() == QtCore.Qt.Key_Return:
@@ -792,11 +790,6 @@ class MainW(QMainWindow):
                     self.brush_choose()
                 if not updated:
                     self.update_plot()
-                elif event.modifiers() == QtCore.Qt.ControlModifier:
-                    if event.key() == QtCore.Qt.Key_Z:
-                        self.undo_action()
-                    if event.key() == QtCore.Qt.Key_0:
-                        self.clear_all()
         if event.key() == QtCore.Qt.Key_Minus or event.key() == QtCore.Qt.Key_Equal:
             self.p0.keyPressEvent(event)
 
@@ -1251,8 +1244,7 @@ class MainW(QMainWindow):
         del self.strokes[stroke_ind]
 
     def plot_clicked(self, event):
-        if event.button()==QtCore.Qt.LeftButton and (event.modifiers() != QtCore.Qt.ShiftModifier and
-                    event.modifiers() != QtCore.Qt.AltModifier):
+        if event.button()==QtCore.Qt.LeftButton and not event.modifiers() & (QtCore.Qt.ShiftModifier | QtCore.Qt.AltModifier):
             if event.double():
                 try:
                     self.p0.setYRange(0,self.Ly+self.pr)

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -548,8 +548,8 @@ class ImageDraw(pg.ImageItem):
 
     def mouseClickEvent(self, ev):
         if self.parent.masksOn or self.parent.outlinesOn:
-            if  self.parent.loaded and (ev.button()==QtCore.Qt.RightButton or 
-                    ev.modifiers() == QtCore.Qt.ShiftModifier and not ev.double()):
+            if  self.parent.loaded and (ev.button() == QtCore.Qt.RightButton or 
+                    ev.modifiers() & QtCore.Qt.ShiftModifier and not ev.double()):
                 if not self.parent.in_stroke:
                     ev.accept()
                     self.create_start(ev.pos())
@@ -563,13 +563,13 @@ class ImageDraw(pg.ImageItem):
             elif not self.parent.in_stroke:
                 y,x = int(ev.pos().y()), int(ev.pos().x())
                 if y>=0 and y<self.parent.Ly and x>=0 and x<self.parent.Lx:
-                    if ev.button()==QtCore.Qt.LeftButton and not ev.double():
+                    if ev.button() == QtCore.Qt.LeftButton and not ev.double():
                         idx = self.parent.cellpix[self.parent.currentZ][y,x]
                         if idx > 0:
-                            if ev.modifiers()==QtCore.Qt.ControlModifier:
+                            if ev.modifiers() & QtCore.Qt.ControlModifier:
                                 # delete mask selected
                                 self.parent.remove_cell(idx)
-                            elif ev.modifiers()==QtCore.Qt.AltModifier:
+                            elif ev.modifiers() & QtCore.Qt.AltModifier:
                                 self.parent.merge_cells(idx)
                             elif self.parent.masksOn:
                                 self.parent.unselect_cell()


### PR DESCRIPTION
Hi, thanks for the great software.
I found a small bug in the GUI, where the `PyQt5.QtCore.Qt.KeyboardModifiers` objects of key and mouse events were checked using the equality operator, which fails when more than one modifier is held or the system reports extra modifiers as active.
There was also a small section of dead code: https://github.com/MouseLand/cellpose/blob/377cb69ec101ffb8d67197881290f07abeda213a/cellpose/gui/gui.py#L795-L799
that could never be reached as of the condition: https://github.com/MouseLand/cellpose/blob/377cb69ec101ffb8d67197881290f07abeda213a/cellpose/gui/gui.py#L701-L703
Those shortcuts are already set in `gui/menus.py` so I also excised those lines to avoid confusion.