### PR TITLE
Increase clarity of image output of masks

### DIFF
--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -34,7 +34,7 @@ def mainmenu(parent):
     file_menu.addAction(parent.saveSet)
     parent.saveSet.setEnabled(False)
 
-    parent.savePNG = QAction("Save masks as P&NG", parent)
+    parent.savePNG = QAction("Save masks as P&NG/tif", parent)
     parent.savePNG.setShortcut("Ctrl+N")
     parent.savePNG.triggered.connect(lambda: io._save_png(parent))
     file_menu.addAction(parent.savePNG)


### PR DESCRIPTION
When saving 3D or large images, the output is tiff and not PNG, changed the text to represnt it. When having 3D image the option as it is now (Save masks as PNG) is confusing as PNG does not have Z channel.

https://github.com/MouseLand/cellpose/blob/377cb69ec101ffb8d67197881290f07abeda213a/cellpose/gui/io.py#L433