### PR TITLE
Fixed model loading behavior when using GPU device other than cuda:0

### DIFF
--- a/cellpose/contrib/openvino_utils.py
+++ b/cellpose/contrib/openvino_utils.py
@@ -28,7 +28,7 @@ class OpenVINOModel(object):
 
         # Load a new instance of the model with updated weights
         if self._model_id != "default":
-            self._base_model.load_model(self._model_id, cpu=True)
+            self._base_model.load_model(self._model_id, device=None)
 
         buf = io.BytesIO()
         dummy_input = torch.zeros([1] + list(inp.shape[1:]))  # To avoid extra network reloading we process batch in the loop
@@ -63,7 +63,7 @@ class OpenVINOModel(object):
             return torch.tensor(outs["output"]), torch.tensor(outs["style"])
 
 
-    def load_model(self, path, cpu):
+    def load_model(self, path, device):
         self._model_id = path
         return self
 

--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -142,7 +142,7 @@ class UnetModel():
                                         diam_mean=diam_mean).to(self.device)
         
         if pretrained_model is not None and isinstance(pretrained_model, str):
-            self.net.load_model(pretrained_model, cpu=(not self.gpu))
+            self.net.load_model(pretrained_model, device=self.device)
 
     def eval(self, x, batch_size=8, channels=None, channels_last=False, invert=False, normalize=True,
              rescale=None, do_3D=False, anisotropy=None, net_avg=False, augment=False,
@@ -363,7 +363,7 @@ class UnetModel():
                                      bsize=bsize, return_conv=return_conv)
         else:  
             for j in range(len(self.pretrained_model)):
-                self.net.load_model(self.pretrained_model[j], cpu=(not self.gpu))
+                self.net.load_model(self.pretrained_model[j], device=self.device)
                 y0, style = self._run_net(img, augment=augment, tile=tile, 
                                           tile_overlap=tile_overlap, bsize=bsize,
                                           return_conv=return_conv)

--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -242,7 +242,7 @@ class UnetModel():
         if isinstance(self.pretrained_model, list):
             model_path = self.pretrained_model[0]
             if not net_avg:
-                self.net.load_model(self.pretrained_model[0])
+                self.net.load_model(self.pretrained_model[0], device=self.device)
         else:
             model_path = self.pretrained_model
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1839,4 +1839,3 @@ class MainW(QMainWindow):
 
     def toggle_mask_ops(self):
         self.toggle_removals()
-        

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -366,7 +366,7 @@ class CellposeModel(UnetModel):
         self.unet = False
         self.pretrained_model = pretrained_model
         if self.pretrained_model:
-            self.net.load_model(self.pretrained_model[0], device=device)
+            self.net.load_model(self.pretrained_model[0], device=self.device)
             self.diam_mean = self.net.diam_mean.data.cpu().numpy()[0]
             self.diam_labels = self.net.diam_labels.data.cpu().numpy()[0]
             models_logger.info(f'>>>> model diam_mean = {self.diam_mean: .3f} (ROIs rescaled to this size during training)')

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -366,7 +366,7 @@ class CellposeModel(UnetModel):
         self.unet = False
         self.pretrained_model = pretrained_model
         if self.pretrained_model:
-            self.net.load_model(self.pretrained_model[0], cpu=(not self.gpu))
+            self.net.load_model(self.pretrained_model[0], device=device)
             self.diam_mean = self.net.diam_mean.data.cpu().numpy()[0]
             self.diam_labels = self.net.diam_labels.data.cpu().numpy()[0]
             models_logger.info(f'>>>> model diam_mean = {self.diam_mean: .3f} (ROIs rescaled to this size during training)')
@@ -533,7 +533,7 @@ class CellposeModel(UnetModel):
         
         else:
             if not model_loaded and (isinstance(self.pretrained_model, list) and not net_avg and not loop_run):
-                self.net.load_model(self.pretrained_model[0], cpu=(not self.gpu))
+                self.net.load_model(self.pretrained_model[0], device=self.device)
                 
             # reshape image (normalization happens in _run_cp)
             x = transforms.convert_image(x, channels, channel_axis=channel_axis, z_axis=z_axis,
@@ -996,7 +996,7 @@ class SizeModel():
                                                                                                    channels, normalize)
         if isinstance(self.cp.pretrained_model, list):
             cp_model_path = self.cp.pretrained_model[0]
-            self.cp.net.load_model(cp_model_path, cpu=(not self.cp.gpu))
+            self.cp.net.load_model(cp_model_path, device=self.cp.device)
         else:
             cp_model_path = self.cp.pretrained_model
         

--- a/cellpose/resnet_torch.py
+++ b/cellpose/resnet_torch.py
@@ -217,9 +217,9 @@ class CPnet(nn.Module):
     def save_model(self, filename):
         torch.save(self.state_dict(), filename)
 
-    def load_model(self, filename, cpu=False):
-        if not cpu:
-            state_dict = torch.load(filename)
+    def load_model(self, filename, device=None):
+        if (device is not None) and (device.type != 'cpu'):
+            state_dict = torch.load(filename, map_location=device)
         else:
             self.__init__(self.nbase,
                           self.nout,

--- a/paper/2.0/train_specialists.py
+++ b/paper/2.0/train_specialists.py
@@ -281,7 +281,7 @@ def train_general_net(root, style_path,
     nout = 3
     net = resnet_torch.CPnet(nbase=nbase, nout=nout, sz=3).to(device)
     if pretrained_model is not None:
-        net.load_model(pretrained_model)
+        net.load_model(pretrained_model, device=device)
     optimizer = torch.optim.SGD(net.parameters(), 
                                 lr = learning_rate, 
                                 weight_decay = weight_decay, 


### PR DESCRIPTION
Currently, `load_state_dict` assumes that the device used is `cuda:0`, leaving the CellposeModel randomly initialized if the target device is different than `cuda:0`. This fix replaces the `cpu` argument of `load_model` with `device`, to allow proper checkpoint reloading.