### PR TITLE
Add compatability for torch <1.10

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -7,7 +7,6 @@ from tqdm import trange
 from numba import njit, float32, int32, vectorize
 import cv2
 import fastremap
-from packaging import version
 
 import logging
 dynamics_logger = logging.getLogger(__name__)
@@ -580,16 +579,18 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
     """
     if masks.size > 10000*10000:
         
-        if version.parse(torch.__version__) >= version.parse('1.10'):
-            # for PyTorch version 1.10 and above
-            def mem_info():
-                total_mem, used_mem = torch.cuda.mem_get_info()
-                return total_mem, used_mem
-        else:
+        major_version, minor_version, _ = torch.__version__.split(".")
+        
+        if major_version == "1" and int(minor_version) < 10):
             # for PyTorch version lower than 1.10
             def mem_info():
                 total_mem = torch.cuda.get_device_properties(0).total_memory
                 used_mem = torch.cuda.memory_allocated()
+                return total_mem, used_mem
+        else:
+            # for PyTorch version 1.10 and above
+            def mem_info():
+                total_mem, used_mem = torch.cuda.mem_get_info()
                 return total_mem, used_mem
         
         if masks.size * 20 > mem_info()[0]:

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -581,7 +581,7 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
         
         major_version, minor_version, _ = torch.__version__.split(".")
         
-        if major_version == "1" and int(minor_version) < 10):
+        if major_version == "1" and int(minor_version) < 10:
             # for PyTorch version lower than 1.10
             def mem_info():
                 total_mem = torch.cuda.get_device_properties(0).total_memory

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -7,6 +7,7 @@ from tqdm import trange
 from numba import njit, float32, int32, vectorize
 import cv2
 import fastremap
+from packaging import version
 
 import logging
 dynamics_logger = logging.getLogger(__name__)
@@ -579,7 +580,7 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
     """
     if masks.size > 10000*10000:
         
-        if torch.__version__ >= '1.10':
+        if version.parse(torch.__version__) >= version.parse('1.10'):
             # for PyTorch version 1.10 and above
             def mem_info():
                 total_mem, used_mem = torch.cuda.mem_get_info()

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -578,7 +578,20 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
     
     """
     if masks.size > 10000*10000:
-        if masks.size * 20 > torch.cuda.mem_get_info()[0]:
+        
+        if torch.__version__ >= '1.10':
+            # for PyTorch version 1.10 and above
+            def mem_info():
+                total_mem, used_mem = torch.cuda.mem_get_info()
+                return total_mem, used_mem
+        else:
+            # for PyTorch version lower than 1.10
+            def mem_info():
+                total_mem = torch.cuda.get_device_properties(0).total_memory
+                used_mem = torch.cuda.memory_allocated()
+                return total_mem, used_mem
+        
+        if masks.size * 20 > mem_info()[0]:
             dynamics_logger.warning('WARNING: image is very large, not using gpu to compute flows from masks for QC step flow_threshold')
             dynamics_logger.info('turn off QC step with flow_threshold=0 if too slow')
         use_gpu = False

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_deps = ['numpy>=1.20.0', 'scipy', 'natsort',
                 'torch>=1.6',
                 'opencv-python-headless',
                 'fastremap',
-                'imagecodecs'
+                'imagecodecs', 'packaging'
                 ]
 
 gui_deps = [

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_deps = ['numpy>=1.20.0', 'scipy', 'natsort',
                 'torch>=1.6',
                 'opencv-python-headless',
                 'fastremap',
-                'imagecodecs', 'packaging'
+                'imagecodecs'
                 ]
 
 gui_deps = [


### PR DESCRIPTION
See issue #646 

TL;DR: torch 1.10 introduced the function `torch.cuda.mem_get_info()` so it crashes for lower torch versions. 

I Added a wrapper function which checks for which version is being run and returns the same information as `torch.cuda.mem_get_info()` but works for both lower and higher than torch 1.10.

Snipped from `dynamics.py`
```
...
if version.parse(torch.__version__) >= version.parse('1.10'):
    # for PyTorch version 1.10 and above
    def mem_info():
        total_mem, used_mem = torch.cuda.mem_get_info()
        return total_mem, used_mem
else:
    # for PyTorch version lower than 1.10
    def mem_info():
        total_mem = torch.cuda.get_device_properties(0).total_memory
        used_mem = torch.cuda.memory_allocated()
        return total_mem, used_mem

if masks.size * 20 > mem_info()[0]:
...
```

I am open to pulling this function definition out of `remove_bad_flow_masks()` (see below), but for now I wrote it inside for minimal invasiveness as I am not read up on cellposes code. 

```
def cuda_mem_info():
    if version.parse(torch.__version__) >= version.parse('1.10'):
        # for PyTorch version 1.10 and above
        total_mem, used_mem = torch.cuda.mem_get_info()
        return total_mem, used_mem
    else:
        # for PyTorch version lower than 1.10
        total_mem = torch.cuda.get_device_properties(0).total_memory
        used_mem = torch.cuda.memory_allocated()
        return total_mem, used_mem
```