### PR TITLE
Fix #679 - Train sizemodel on dataset with partially empty masks 

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -1006,15 +1006,15 @@ class SizeModel():
             diam_test = np.array([utils.diameters(lbl)[0] for lbl in test_labels])
         
         # remove images with no masks
+        indices_to_be_removed = []
         for i in range(len(diam_train)):
-            if diam_train[i]==0.0:
-                del train_data[i]
-                del train_labels[i]
-        if run_test:
-            for i in range(len(diam_test)):
-                if diam_test[i]==0.0:
-                    del test_data[i]
-                    del test_labels[i]
+            if diam_train[i] == 0.0:
+                indices_to_be_removed.append(i)
+        indices_to_be_removed.sort(reverse=True)
+        for i in indices_to_be_removed:
+            del train_data[i]
+            del train_labels[i]
+            diam_train = np.delete(diam_train, i)
 
         nimg = len(train_data)
         styles = np.zeros((n_epochs*nimg, 256), np.float32)
@@ -1031,7 +1031,7 @@ class SizeModel():
                 feat = self.cp.network(imgi)[1]
                 styles[inds+nimg*iepoch] = feat
                 diams[inds+nimg*iepoch] = np.log(diam_train[inds]) - np.log(self.diam_mean) + np.log(scale)
-            del feat
+                del feat
             if (iepoch+1)%2==0:
                 models_logger.info('ran %d epochs in %0.3f sec'%(iepoch+1, time.time()-tic))
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -3,10 +3,17 @@ from pathlib import Path
 from subprocess import check_output, STDOUT
 import os, shutil
 from glob import glob
+import numpy as np
 
 os.environ["KMP_DUPLICATE_LIB_OK"]="TRUE"
 
 
+def test_train_size_model():
+    model = models.Cellpose(model_type='cyto')
+    image_shape = (3, 256, 256)
+    images = [np.ones(image_shape), np.ones(image_shape)]
+    labels = [np.zeros(image_shape), np.ones(image_shape)]
+    model.sz.train(images, labels, n_epochs=2, batch_size=1)
 
 def test_class_train(data_dir):
     train_dir = str(data_dir.joinpath('2D').joinpath('train'))


### PR DESCRIPTION
I encountered #679 while trying to train a SizeModel on my own dataset.
Please allow me to propose a fix via this PR. A testcase is included in `test_train.py`.

From what I see, there are two small issues
* `del train_data[i]` while iterating over the list can cause the index to go out of bounds.
* `del feat` is run outside the for-loop of iterating over batches. Arguably, this should not be a problem for real world datasets. The sample testcase just happened to catch that as well.

Thanks for maintaining this repository!