### PR TITLE
Fix channel_axis bug in transforms.py

### DIFF
--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -258,7 +258,7 @@ def convert_image(x, channels, channel_axis=None, z_axis=None,
         x = x.squeeze()
 
     # put z axis first
-    if z_axis is not None and x.ndim > 2:
+    if z_axis is not None and x.ndim > 2 and z_axis != 0:
         x = move_axis(x, m_axis=z_axis, first=True)
         if channel_axis is not None:
             channel_axis += 1


### PR DESCRIPTION
Found a bug while running the command line version of the tool. If you give it a multi-z multi-channel image with a dimension order of (z, ch, y, x) (as suggested in the documentation) and correctly set the --z_axis parameter to 0 and the  --channel_axis parameter to 1, this chunk of code in convert_image() of transforms.py:
```
# put z axis first
if z_axis is not None and x.ndim > 2:
    x = move_axis(x, m_axis=z_axis, first=True)
    if channel_axis is not None:
        channel_axis += 1
    if x.ndim==3:
        x = x[...,np.newaxis]
```
shouldn't change the image at all since the z_axis is already first but it will still add 1 to channel_axis, making it wrong because the z_axis wasn't moved. Adding an additional check before running this chunk to make sure the z_axis needs to be moved fixes this.