### PR TITLE
make GPU check fix

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -577,7 +577,7 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
         size [Ly x Lx] or [Lz x Ly x Lx]
     
     """
-    if masks.size > 10000*10000:
+    if masks.size > 10000*10000 and use_gpu:
         
         major_version, minor_version, _ = torch.__version__.split(".")
         


### PR DESCRIPTION
Per #705, an image with lots of bad masks will attempt to call `torch.cuda.get_device_properties(0)` in `dynamics.remove_bad_flow_masks()` without regard for the GPU status set by the `use_gpu` flag. @alix-simon 's fix is to check the flag in line 580. 