### PR TITLE
add multiprocessing to outlines_list

### DIFF
--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -9,6 +9,7 @@ from scipy.stats import gmean
 import numpy as np
 import colorsys
 import io
+from multiprocessing import Pool, cpu_count
 
 from . import metrics
 
@@ -219,7 +220,15 @@ def masks_to_outlines(masks):
                 outlines[vr, vc] = 1
         return outlines
 
-def outlines_list(masks):
+def outlines_list(masks, multiprocessing=True):
+    """ get outlines of masks as a list to loop over for plotting
+    This function is a wrapper for outlines_list_single and outlines_list_multi """
+    if multiprocessing:
+        return outlines_list_multi(masks)
+    else:
+        return outlines_list_single(masks)
+
+def outlines_list_single(masks):
     """ get outlines of masks as a list to loop over for plotting """
     outpix=[]
     for n in np.unique(masks)[1:]:
@@ -234,6 +243,27 @@ def outlines_list(masks):
             else:
                 outpix.append(np.zeros((0,2)))
     return outpix
+
+def outlines_list_multi(masks, num_processes=None):
+    """ get outlines of masks as a list to loop over for plotting """
+    if num_processes is None:
+        num_processes = cpu_count()
+
+    unique_masks = np.unique(masks)[1:]
+    with Pool(processes=num_processes) as pool:
+        outpix = pool.map(get_outline_multi, [(masks, n) for n in unique_masks])
+    return outpix
+
+def get_outline_multi(args):
+    masks, n = args
+    mn = masks == n
+    if mn.sum() > 0:
+        contours = cv2.findContours(mn.astype(np.uint8), mode=cv2.RETR_EXTERNAL, method=cv2.CHAIN_APPROX_NONE)
+        contours = contours[-2]
+        cmax = np.argmax([c.shape[0] for c in contours])
+        pix = contours[cmax].astype(int).squeeze()
+        return pix if len(pix) > 4 else np.zeros((0, 2))
+    return np.zeros((0, 2))
 
 def get_perimeter(points):
     """ perimeter of points - npoints x ndim """

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -119,10 +119,17 @@ def test_outlines_list(data_dir, image_names):
 
     assert len(outlines_single) == len(outlines_multi)
 
-    # due to multiprocessing, the order of the outlines may be different, so we check
-    # that the outlines are the same, but not necessarily in the same order
-    for outline in outlines_single:
-        assert outline in outlines_multi
+    # Check that the outlines are the same, but not necessarily in the same order
+    outlines_matched = [False] * len(outlines_single)
+    for i, outline_single in enumerate(outlines_single):
+        for j, outline_multi in enumerate(outlines_multi):
+            if not outlines_matched[j] and np.array_equal(outline_single, outline_multi):
+                outlines_matched[j] = True
+                break
+        else:
+            assert False, "Outline not found in outlines_multi: {}".format(outline_single)
+
+    assert all(outlines_matched), "Not all outlines in outlines_multi were matched"
 
 
 def compare_masks(data_dir, image_names, runtype, model_type):


### PR DESCRIPTION
Per #704, saving outlines takes a long time to find contours for each mask. To speed up the process I added multiprocessing to process the masks in parallel. 

Tested on Ubuntu 22, needs to be tested on Windows and Mac.