### PR TITLE
Delete multiple ROIs in GUI

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,17 +19,21 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
         python-version: [3.8, 3.9, "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-#           auto-activate-base: true
+          miniconda-version: "latest"
+          auto-activate-base: true
+          activate-environment: ""
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
@@ -52,9 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1162,6 +1162,24 @@ class MainW(QMainWindow):
         self.selected = 0
 
     def remove_cell(self, idx):
+        if isinstance(idx, (int, np.integer)):
+            self.remove_single_cell(idx)
+        elif isinstance(idx, list):
+            for i in idx:
+                # TODO: this funciton updates state on each loop, need to do it at end only
+                # self.remove_single_cell(i)
+                try:
+                    raise NotImplementedError("This function is not yet implemented for multiple cells")
+                except NotImplementedError:
+                    print("This function is not yet implemented for multiple cells")
+
+        self.update_layer()
+        if self.ncells==0:
+            self.ClearButton.setEnabled(False)
+        if self.NZ==1:
+            io._save_sets(self)
+
+    def remove_single_cell(self, idx):
         # remove from manual array
         self.selected = 0
         if self.NZ > 1:
@@ -1195,11 +1213,7 @@ class MainW(QMainWindow):
         self.ncells -= 1
         print('GUI_INFO: removed cell %d'%(idx-1))
         
-        self.update_layer()
-        if self.ncells==0:
-            self.ClearButton.setEnabled(False)
-        if self.NZ==1:
-            io._save_sets(self)
+
 
 
     def remove_multiple_cells(self):

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1197,13 +1197,13 @@ class MainW(QMainWindow):
         idx.sort(reverse=True)
         for i in idx:
             self.remove_single_cell(i)
+        self.ncells -= len(idx) # _save_sets uses ncells
 
         if self.ncells==0:
             self.ClearButton.setEnabled(False)
         if self.NZ==1:
             io._save_sets(self)
 
-        self.ncells -= len(idx)
         self.update_layer()
 
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1161,17 +1161,25 @@ class MainW(QMainWindow):
                 self.update_layer()
         self.selected = 0
 
+    def unselect_cell_multi(self, idx):
+        z = self.currentZ
+        self.layerz[self.cellpix[z] == idx] = np.append(self.cellcolors[idx], self.opacity)
+        if self.outlinesOn:
+            self.layerz[self.outpix[z] == idx] = np.array(self.outcolor).astype(np.uint8)
+            # [0,0,0,self.opacity])
+        self.update_layer()
+
     def remove_cell(self, idx):
         if isinstance(idx, (int, np.integer)):
             self.remove_single_cell(idx)
         elif isinstance(idx, list):
             for i in idx:
                 # TODO: this funciton updates state on each loop, need to do it at end only
-                # self.remove_single_cell(i)
+                self.remove_single_cell(i)
                 try:
-                    raise NotImplementedError("This function is not yet implemented for multiple cells")
-                except NotImplementedError:
-                    print("This function is not yet implemented for multiple cells")
+                    raise NotImplementedError("remove_cell cannot accept more than 2 cells, currently")
+                except NotImplementedError as e:
+                    print(e)
 
         self.update_layer()
         if self.ncells==0:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1266,7 +1266,8 @@ class MainW(QMainWindow):
             self.unselect_cell()
         self.enable_buttons()
 
-        self.remove_roi(self.remove_roi_obj)
+        if self.remove_roi_obj is not None:
+            self.remove_roi(self.remove_roi_obj)
 
     def merge_cells(self, idx):
         self.prev_selected = self.selected

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1173,22 +1173,21 @@ class MainW(QMainWindow):
         if isinstance(idx, (int, np.integer)):
             idx = [idx]
 
+        # because the function remove_single_cell updates the state of the cellpix and outpix arrays
+        # by reindexing cells to avoid gaps in the indices, we need to remove the cells in reverse order
+        # so that the indices are correct
+        idx.sort(reverse=True)
         for i in idx:
-            # TODO: this funciton updates state on each loop, need to do it at end only
             self.remove_single_cell(i)
 
-            if i > 1:
-                try:
-                    raise NotImplementedError("remove_cell cannot accept more than 2 cells, currently")
-                except NotImplementedError as e:
-                    print(e)
-                    return
-
-        self.update_layer()
         if self.ncells==0:
             self.ClearButton.setEnabled(False)
         if self.NZ==1:
             io._save_sets(self)
+
+        self.ncells -= len(idx)
+        self.update_layer()
+
 
     def remove_single_cell(self, idx):
         # remove from manual array
@@ -1221,7 +1220,6 @@ class MainW(QMainWindow):
         self.ismanual = np.delete(self.ismanual, idx-1)
         self.cellcolors = np.delete(self.cellcolors, [idx], axis=0)
         del self.zdraw[idx-1]
-        self.ncells -= 1
         print('GUI_INFO: removed cell %d'%(idx-1))
         
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1171,15 +1171,18 @@ class MainW(QMainWindow):
 
     def remove_cell(self, idx):
         if isinstance(idx, (int, np.integer)):
-            self.remove_single_cell(idx)
-        elif isinstance(idx, list):
-            for i in idx:
-                # TODO: this funciton updates state on each loop, need to do it at end only
-                self.remove_single_cell(i)
+            idx = [idx]
+
+        for i in idx:
+            # TODO: this funciton updates state on each loop, need to do it at end only
+            self.remove_single_cell(i)
+
+            if i > 1:
                 try:
                     raise NotImplementedError("remove_cell cannot accept more than 2 cells, currently")
                 except NotImplementedError as e:
                     print(e)
+                    return
 
         self.update_layer()
         if self.ncells==0:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1143,6 +1143,12 @@ class MainW(QMainWindow):
             self.layerz[self.cellpix[z]==idx] = np.array([255,255,255,self.opacity])
             self.update_layer()
 
+    def select_cell_multi(self, idx):
+        if idx > 0:
+            z = self.currentZ
+            self.layerz[self.cellpix[z] == idx] = np.array([255, 255, 255, self.opacity])
+            self.update_layer()
+
     def unselect_cell(self):
         if self.selected > 0:
             idx = self.selected
@@ -1175,7 +1181,7 @@ class MainW(QMainWindow):
         # reduce other pixels by -1
         self.cellpix[self.cellpix>idx] -= 1
         self.outpix[self.outpix>idx] -= 1
-        
+
         if self.NZ==1:
             self.removed_cell = [self.ismanual[idx-1], self.cellcolors[idx], np.nonzero(cp), np.nonzero(op)]
             self.redo.setEnabled(True)
@@ -1197,24 +1203,24 @@ class MainW(QMainWindow):
 
 
     def remove_multiple_cells(self):
+        self.unselect_cell()
         self.disable_buttons_removeROIs()
         self.DoneDeleteMultipleROIButton.setStyleSheet(self.styleUnpressed)
         self.DoneDeleteMultipleROIButton.setEnabled(True)
         self.deleting_multiple = True
-        print(f"set delte_multiple to true: {self.deleting_multiple}")
-        self.removing_cells_list.append('42')
-        print(self.deleting_multiple)
 
 
     def done_remove_multiple_cells(self):
         self.deleting_multiple = False
         self.DoneDeleteMultipleROIButton.setStyleSheet(self.styleInactive)
         self.DoneDeleteMultipleROIButton.setEnabled(False)
-        print(f"removing these cells: {self.removing_cells_list}")
-        print(f"set deleting_multiple to false: {self.deleting_multiple}")
+        if self.removing_cells_list:
+            display_remove_list = [i-1 for i in self.removing_cells_list]
+            print(f"GUI_INFO: removing cells: {display_remove_list}")
+            self.remove_cell(self.removing_cells_list)
+            self.removing_cells_list.clear()
+            self.unselect_cell()
         self.enable_buttons()
-
-        self.removing_cells_list.clear()
 
     def merge_cells(self, idx):
         self.prev_selected = self.selected

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -620,6 +620,22 @@ class MainW(QMainWindow):
         self.slider.valueChanged.connect(self.level_change)
         self.l0.addWidget(self.slider, b,0,1,9)
 
+        b += 1
+        self.DeleteMultipleROIButton = QPushButton('delete multiple ROIs')
+        self.DeleteMultipleROIButton.clicked.connect(self.remove_multiple_cells)
+        self.l0.addWidget(self.DeleteMultipleROIButton, b, 5, 1, 4)
+        self.DeleteMultipleROIButton.setEnabled(False)
+        self.DeleteMultipleROIButton.setStyleSheet(self.styleInactive)
+        self.DeleteMultipleROIButton.setFont(self.boldfont)
+
+        b += 1
+        self.DoneDeleteMultipleROIButton = QPushButton('done')
+        self.DoneDeleteMultipleROIButton.clicked.connect(self.done_remove_multiple_cells)
+        self.l0.addWidget(self.DoneDeleteMultipleROIButton, b, 5, 1, 4)
+        self.DoneDeleteMultipleROIButton.setEnabled(False)
+        self.DoneDeleteMultipleROIButton.setStyleSheet(self.styleInactive)
+        self.DoneDeleteMultipleROIButton.setFont(self.boldfont)
+
         b+=1
         self.l0.addWidget(QLabel(''),b,0,1,5)
         self.l0.setRowStretch(b, 1)
@@ -1092,6 +1108,9 @@ class MainW(QMainWindow):
         self.loaded = False
         self.recompute_masks = False
 
+        self.deleting_multiple = False
+        self.removing_cells_list = []
+
 
     def brush_choose(self):
         self.brush_size = self.BrushChoose.currentIndex()*2 + 1
@@ -1175,6 +1194,27 @@ class MainW(QMainWindow):
             self.ClearButton.setEnabled(False)
         if self.NZ==1:
             io._save_sets(self)
+
+
+    def remove_multiple_cells(self):
+        self.disable_buttons_removeROIs()
+        self.DoneDeleteMultipleROIButton.setStyleSheet(self.styleUnpressed)
+        self.DoneDeleteMultipleROIButton.setEnabled(True)
+        self.deleting_multiple = True
+        print(f"set delte_multiple to true: {self.deleting_multiple}")
+        self.removing_cells_list.append('42')
+        print(self.deleting_multiple)
+
+
+    def done_remove_multiple_cells(self):
+        self.deleting_multiple = False
+        self.DoneDeleteMultipleROIButton.setStyleSheet(self.styleInactive)
+        self.DoneDeleteMultipleROIButton.setEnabled(False)
+        print(f"removing these cells: {self.removing_cells_list}")
+        print(f"set deleting_multiple to false: {self.deleting_multiple}")
+        self.enable_buttons()
+
+        self.removing_cells_list.clear()
 
     def merge_cells(self, idx):
         self.prev_selected = self.selected
@@ -1836,6 +1876,39 @@ class MainW(QMainWindow):
         self.saveServer.setEnabled(True)
         self.saveOutlines.setEnabled(True)
         self.saveROIs.setEnabled(True)
+
+        self.DeleteMultipleROIButton.setStyleSheet(self.styleUnpressed)
+        self.DeleteMultipleROIButton.setEnabled(True)
+
+        self.toggle_mask_ops()
+
+        self.update_plot()
+        self.setWindowTitle(self.filename)
+
+    def disable_buttons_removeROIs(self):
+        if len(self.model_strings) > 0:
+            self.ModelButton.setStyleSheet(self.styleInactive)
+            self.ModelButton.setEnabled(False)
+        self.StyleToModel.setStyleSheet(self.styleInactive)
+        self.StyleToModel.setEnabled(False)
+        for i in range(len(self.StyleButtons)):
+            self.StyleButtons[i].setEnabled(False)
+            self.StyleButtons[i].setStyleSheet(self.styleInactive)
+        self.SizeButton.setEnabled(False)
+        self.SCheckBox.setEnabled(False)
+        self.SizeButton.setStyleSheet(self.styleInactive)
+        self.newmodel.setEnabled(False)
+        self.loadMasks.setEnabled(False)
+        self.saveSet.setEnabled(False)
+        self.savePNG.setEnabled(False)
+        self.saveFlows.setEnabled(False)
+        self.saveServer.setEnabled(False)
+        self.saveOutlines.setEnabled(False)
+        self.saveROIs.setEnabled(False)
+
+        self.DeleteMultipleROIButton.setStyleSheet(self.styleInactive)
+        self.DeleteMultipleROIButton.setEnabled(True)
+
         self.toggle_mask_ops()
 
         self.update_plot()

--- a/cellpose/gui/guihelpwindowtext.html
+++ b/cellpose/gui/guihelpwindowtext.html
@@ -1,0 +1,151 @@
+<qt>
+    <p class="has-line-data" data-line-start="5" data-line-end="6">
+        <b>Main GUI mouse controls:</b>
+    </p>
+    <ul>
+        <li class="has-line-data" data-line-start="7" data-line-end="8">Pan = left-click + drag</li>
+        <li class="has-line-data" data-line-start="8" data-line-end="9">Zoom = scroll wheel (or +/= and - buttons)</li>
+        <li class="has-line-data" data-line-start="9" data-line-end="10">Full view = double left-click</li>
+        <li class="has-line-data" data-line-start="10" data-line-end="11">Select mask = left-click on mask</li>
+        <li class="has-line-data" data-line-start="11" data-line-end="12">Delete mask = Ctrl (or COMMAND on Mac) +
+            left-click
+        </li>
+        <li class="has-line-data" data-line-start="11" data-line-end="12">Merge masks = Alt + left-click (will merge
+            last two)
+        </li>
+        <li class="has-line-data" data-line-start="12" data-line-end="13">Start draw mask = right-click</li>
+        <li class="has-line-data" data-line-start="13" data-line-end="15">End draw mask = right-click, or return to
+            circle at beginning
+        </li>
+    </ul>
+    <p class="has-line-data" data-line-start="15" data-line-end="16">Overlaps in masks are NOT allowed. If you
+        draw a mask on top of another mask, it is cropped so that it doesn’t overlap with the old mask. Masks in 2D
+        should be single strokes (single stroke is checked). If you want to draw masks in 3D (experimental), then
+        you can turn this option off and draw a stroke on each plane with the cell and then press ENTER. 3D
+        labelling will fill in planes that you have not labelled so that you do not have to as densely label.
+    </p>
+    <p class="has-line-data" data-line-start="17" data-line-end="18"> <b>!NOTE!:</b> The GUI automatically saves after
+        you draw a mask in 2D but NOT after 3D mask drawing and NOT after segmentation. Save in the file menu or
+        with Ctrl+S. The output file is in the same folder as the loaded image with <code>_seg.npy</code> appended.
+    </p>
+
+    <p class="has-line-data" data-line-start="19" data-line-end="20"> <b>Bulk Mask Deletion</b>
+        Clicking the 'delete multiple' button will allow you to select and delete multiple masks at once.
+        Masks can be deselected by clicking on them again. Once you have selected all the masks you want to delete,
+        click the 'done' button to delete them.
+        <br>
+        <br>
+        Alternatively, you can create a rectangular region to delete a regions of masks by clicking the
+        'delete multiple' button, and then moving and/or resizing the region to select the masks you want to delete.
+        Once you have selected the masks you want to delete, click the 'done' button to delete them.
+        <br>
+        <br>
+        At any point in the process, you can click the 'cancel' button to cancel the bulk deletion.
+    </p>
+    <hr>
+    <table class="table table-striped table-bordered">
+        <br>
+        <br>
+        FYI there are tooltips throughout the GUI (hover over text to see)
+        <br>
+        <thead>
+        <tr>
+            <th>Keyboard shortcuts</th>
+            <th>Description</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td>=/+ button // - button</td>
+            <td>zoom in // zoom out</td>
+        </tr>
+        <tr>
+            <td>CTRL+Z</td>
+            <td>undo previously drawn mask/stroke</td>
+        </tr>
+        <tr>
+            <td>CTRL+Y</td>
+            <td>undo remove mask</td>
+        </tr>
+        <tr>
+            <td>CTRL+0</td>
+            <td>clear all masks</td>
+        </tr>
+        <tr>
+            <td>CTRL+L</td>
+            <td>load image (can alternatively drag and drop image)</td>
+        </tr>
+        <tr>
+            <td>CTRL+S</td>
+            <td>SAVE MASKS IN IMAGE to <code>_seg.npy</code> file</td>
+        </tr>
+        <tr>
+            <td>CTRL+T</td>
+            <td>train model using _seg.npy files in folder
+        </tr>
+        <tr>
+            <td>CTRL+P</td>
+            <td>load <code>_seg.npy</code> file (note: it will load automatically with image if it exists)</td>
+        </tr>
+        <tr>
+            <td>CTRL+M</td>
+            <td>load masks file (must be same size as image with 0 for NO mask, and 1,2,3… for masks)</td>
+        </tr>
+        <tr>
+            <td>CTRL+N</td>
+            <td>save masks as PNG</td>
+        </tr>
+        <tr>
+            <td>CTRL+R</td>
+            <td>save ROIs to native ImageJ ROI format</td>
+        </tr>
+        <tr>
+            <td>CTRL+F</td>
+            <td>save flows to image file</td>
+        </tr>
+        <tr>
+            <td>A/D or LEFT/RIGHT</td>
+            <td>cycle through images in current directory</td>
+        </tr>
+        <tr>
+            <td>W/S or UP/DOWN</td>
+            <td>change color (RGB/gray/red/green/blue)</td>
+        </tr>
+        <tr>
+            <td>R / G / B</td>
+            <td>toggle between RGB and Red or Green or Blue</td>
+        </tr>
+        <tr>
+            <td>PAGE-UP / PAGE-DOWN</td>
+            <td>change to flows and cell prob views (if segmentation computed)</td>
+        </tr>
+        <tr>
+            <td>X</td>
+            <td>turn masks ON or OFF</td>
+        </tr>
+        <tr>
+            <td>Z</td>
+            <td>toggle outlines ON or OFF</td>
+        </tr>
+        <tr>
+            <td>, / .</td>
+            <td>increase / decrease brush size for drawing masks</td>
+        </tr>
+        </tbody>
+    </table>
+    <p class="has-line-data" data-line-start="36" data-line-end="37"><strong>Segmentation options \
+        (2D only) </strong></p>
+    <p class="has-line-data" data-line-start="38" data-line-end="39">SIZE: you can manually enter the \
+        approximate diameter for your cells, or press “calibrate” to let the model estimate it. The size is \
+        represented by a disk at the bottom of the view window (can turn this disk of by unchecking \
+        “scale disk on”).</p>
+    <p class="has-line-data" data-line-start="40" data-line-end="41">use GPU: if you have specially \
+        installed the cuda version of mxnet, then you can activate this, but it won’t give huge speedups when \
+        running single 2D images in the GUI.</p>
+    <p class="has-line-data" data-line-start="42" data-line-end="43">MODEL: there is a <em>cytoplasm</em> \
+        model and a <em>nuclei</em> model, choose what you want to segment</p>
+    <p class="has-line-data" data-line-start="44" data-line-end="45">CHAN TO SEG: this is the channel in \
+        which the cytoplasm or nuclei exist</p>
+    <p class="has-line-data" data-line-start="46" data-line-end="47">CHAN2 (OPT): if <em>cytoplasm</em> model \
+        is chosen, then choose the nuclear channel for this option</p>
+</qt>

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -528,7 +528,7 @@ class ImageDraw(pg.ImageItem):
             is_right_click = ev.button() == QtCore.Qt.RightButton
             if self.parent.loaded \
                     and (is_right_click or ev.modifiers() & QtCore.Qt.ShiftModifier and not ev.double())\
-                    and not self.deleting_multiple:
+                    and not self.parent.deleting_multiple:
                 if not self.parent.in_stroke:
                     ev.accept()
                     self.create_start(ev.pos())

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -552,9 +552,14 @@ class ImageDraw(pg.ImageItem):
                                 self.parent.unselect_cell()
                                 self.parent.select_cell(idx)
                             elif self.parent.deleting_multiple:
-                                # todo: is this broken?
-                                self.parent.select_cell(idx)
-                        elif self.parent.masksOn:
+                                if idx in self.parent.removing_cells_list:
+                                    self.parent.unselect_cell_multi(idx)
+                                    self.parent.removing_cells_list.remove(idx)
+                                else:
+                                    self.parent.select_cell_multi(idx)
+                                    self.parent.removing_cells_list.append(idx)
+
+                        elif self.parent.masksOn and not self.parent.deleting_multiple:
                             self.parent.unselect_cell()
 
     def mouseDragEvent(self, ev):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -5,7 +5,8 @@ Copright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer an
 import PyQt5
 from PyQt5 import QtGui, QtCore, QtWidgets
 from PyQt5.QtGui import QPainter, QPixmap
-from PyQt5.QtWidgets import QApplication, QRadioButton, QWidget, QDialog, QButtonGroup, QSlider, QStyle, QStyleOptionSlider, QGridLayout, QPushButton, QLabel, QLineEdit, QDialogButtonBox, QComboBox, QCheckBox
+from PyQt5.QtWidgets import QApplication, QRadioButton, QWidget, QDialog, QButtonGroup, QSlider, QStyle, \
+    QStyleOptionSlider, QGridLayout, QPushButton, QLabel, QLineEdit, QDialogButtonBox, QComboBox, QCheckBox
 import pyqtgraph as pg
 from pyqtgraph import functions as fn
 from pyqtgraph import Point
@@ -22,11 +23,15 @@ def create_channel_choose():
     for i in range(2):
         ChannelLabels.append(QLabel(cstr[i]))
         if i==0:
-            ChannelLabels[i].setToolTip('this is the channel in which the cytoplasm or nuclei exist that you want to segment')
-            ChannelChoose[i].setToolTip('this is the channel in which the cytoplasm or nuclei exist that you want to segment')
+            ChannelLabels[i].setToolTip('this is the channel in which the cytoplasm or nuclei exist \
+            that you want to segment')
+            ChannelChoose[i].setToolTip('this is the channel in which the cytoplasm or nuclei exist \
+            that you want to segment')
         else:
-            ChannelLabels[i].setToolTip('if <em>cytoplasm</em> model is chosen, and you also have a nuclear channel, then choose the nuclear channel for this option')
-            ChannelChoose[i].setToolTip('if <em>cytoplasm</em> model is chosen, and you also have a nuclear channel, then choose the nuclear channel for this option')
+            ChannelLabels[i].setToolTip('if <em>cytoplasm</em> model is chosen, and you also have a \
+            nuclear channel, then choose the nuclear channel for this option')
+            ChannelChoose[i].setToolTip('if <em>cytoplasm</em> model is chosen, and you also have a \
+            nuclear channel, then choose the nuclear channel for this option')
         
     return ChannelChoose, ChannelLabels
 
@@ -188,63 +193,63 @@ class QuadButton(QPushButton):
         parent.p0.setYRange(self.yrange[0], self.yrange[1])
         parent.show()
 
-def horizontal_slider_style():
-    return """QSlider::groove:horizontal {
-            border: 1px solid #bbb;
-            background: black;
-            height: 10px;
-            border-radius: 4px;
-            }
-
-            QSlider::sub-page:horizontal {
-            background: qlineargradient(x1: 0, y1: 0,    x2: 0, y2: 1,
-                stop: 0 black, stop: 1 rgb(150,255,150));
-            background: qlineargradient(x1: 0, y1: 0.2, x2: 1, y2: 1,
-                stop: 0 black, stop: 1 rgb(150,255,150));
-            border: 1px solid #777;
-            height: 10px;
-            border-radius: 4px;
-            }
-
-            QSlider::add-page:horizontal {
-            background: black;
-            border: 1px solid #777;
-            height: 10px;
-            border-radius: 4px;
-            }
-
-            QSlider::handle:horizontal {
-            background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
-                stop:0 #eee, stop:1 #ccc);
-            border: 1px solid #777;
-            width: 13px;
-            margin-top: -2px;
-            margin-bottom: -2px;
-            border-radius: 4px;
-            }
-
-            QSlider::handle:horizontal:hover {
-            background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
-                stop:0 #fff, stop:1 #ddd);
-            border: 1px solid #444;
-            border-radius: 4px;
-            }
-
-            QSlider::sub-page:horizontal:disabled {
-            background: #bbb;
-            border-color: #999;
-            }
-
-            QSlider::add-page:horizontal:disabled {
-            background: #eee;
-            border-color: #999;
-            }
-
-            QSlider::handle:horizontal:disabled {
-            background: #eee;
-            border: 1px solid #aaa;
-            border-radius: 4px;
-            }"""
+# def horizontal_slider_style():
+#     return """QSlider::groove:horizontal {
+#             border: 1px solid #bbb;
+#             background: black;
+#             height: 10px;
+#             border-radius: 4px;
+#             }
+#
+#             QSlider::sub-page:horizontal {
+#             background: qlineargradient(x1: 0, y1: 0,    x2: 0, y2: 1,
+#                 stop: 0 black, stop: 1 rgb(150,255,150));
+#             background: qlineargradient(x1: 0, y1: 0.2, x2: 1, y2: 1,
+#                 stop: 0 black, stop: 1 rgb(150,255,150));
+#             border: 1px solid #777;
+#             height: 10px;
+#             border-radius: 4px;
+#             }
+#
+#             QSlider::add-page:horizontal {
+#             background: black;
+#             border: 1px solid #777;
+#             height: 10px;
+#             border-radius: 4px;
+#             }
+#
+#             QSlider::handle:horizontal {
+#             background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
+#                 stop:0 #eee, stop:1 #ccc);
+#             border: 1px solid #777;
+#             width: 13px;
+#             margin-top: -2px;
+#             margin-bottom: -2px;
+#             border-radius: 4px;
+#             }
+#
+#             QSlider::handle:horizontal:hover {
+#             background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
+#                 stop:0 #fff, stop:1 #ddd);
+#             border: 1px solid #444;
+#             border-radius: 4px;
+#             }
+#
+#             QSlider::sub-page:horizontal:disabled {
+#             background: #bbb;
+#             border-color: #999;
+#             }
+#
+#             QSlider::add-page:horizontal:disabled {
+#             background: #eee;
+#             border-color: #999;
+#             }
+#
+#             QSlider::handle:horizontal:disabled {
+#             background: #eee;
+#             border: 1px solid #aaa;
+#             border-radius: 4px;
+#             }"""
 
 class ExampleGUI(QDialog):
     def __init__(self, parent=None):
@@ -265,128 +270,16 @@ class ExampleGUI(QDialog):
 class HelpWindow(QDialog):
     def __init__(self, parent=None):
         super(HelpWindow, self).__init__(parent)
-        self.setGeometry(100,50,700,850)
+        self.setGeometry(100, 50, 700, 1000)
         self.setWindowTitle('cellpose help')
         self.win = QWidget(self)
         layout = QGridLayout()
         self.win.setLayout(layout)
-        
-        text = ('''
-            <p class="has-line-data" data-line-start="5" data-line-end="6">Main GUI mouse controls:</p>
-            <ul>
-            <li class="has-line-data" data-line-start="7" data-line-end="8">Pan  = left-click  + drag</li>
-            <li class="has-line-data" data-line-start="8" data-line-end="9">Zoom = scroll wheel (or +/= and - buttons) </li>
-            <li class="has-line-data" data-line-start="9" data-line-end="10">Full view = double left-click</li>
-            <li class="has-line-data" data-line-start="10" data-line-end="11">Select mask = left-click on mask</li>
-            <li class="has-line-data" data-line-start="11" data-line-end="12">Delete mask = Ctrl (or COMMAND on Mac) + left-click</li>
-            <li class="has-line-data" data-line-start="11" data-line-end="12">Merge masks = Alt + left-click (will merge last two)</li>
-            <li class="has-line-data" data-line-start="12" data-line-end="13">Start draw mask = right-click</li>
-            <li class="has-line-data" data-line-start="13" data-line-end="15">End draw mask = right-click, or return to circle at beginning</li>
-            </ul>
-            <p class="has-line-data" data-line-start="15" data-line-end="16">Overlaps in masks are NOT allowed. If you \
-            draw a mask on top of another mask, it is cropped so that it doesn’t overlap with the old mask. Masks in 2D \
-            should be single strokes (single stroke is checked). If you want to draw masks in 3D (experimental), then \
-            you can turn this option off and draw a stroke on each plane with the cell and then press ENTER. 3D \
-            labelling will fill in planes that you have not labelled so that you do not have to as densely label.</p>
-            <p class="has-line-data" data-line-start="17" data-line-end="18">!NOTE!: The GUI automatically saves after \
-            you draw a mask in 2D but NOT after 3D mask drawing and NOT after segmentation. Save in the file menu or \
-            with Ctrl+S. The output file is in the same folder as the loaded image with <code>_seg.npy</code> appended.</p>
-            <table class="table table-striped table-bordered">
-            <br><br>
-            FYI there are tooltips throughout the GUI (hover over text to see)
-            <br>
-            <thead>
-            <tr>
-            <th>Keyboard shortcuts</th>
-            <th>Description</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr>
-            <td>=/+  button // - button</td>
-            <td>zoom in // zoom out</td>
-            </tr>
-            <tr>
-            <td>CTRL+Z</td>
-            <td>undo previously drawn mask/stroke</td>
-            </tr>
-            <tr>
-            <td>CTRL+Y</td>
-            <td>undo remove mask</td>
-            </tr>
-            <tr>
-            <td>CTRL+0</td>
-            <td>clear all masks</td>
-            </tr>
-            <tr>
-            <td>CTRL+L</td>
-            <td>load image (can alternatively drag and drop image)</td>
-            </tr>
-            <tr>
-            <td>CTRL+S</td>
-            <td>SAVE MASKS IN IMAGE to <code>_seg.npy</code> file</td>
-            </tr>
-            <tr>
-            <td>CTRL+T</td>
-            <td>train model using _seg.npy files in folder
-            </tr>
-            <tr>
-            <td>CTRL+P</td>
-            <td>load <code>_seg.npy</code> file (note: it will load automatically with image if it exists)</td>
-            </tr>
-            <tr>
-            <td>CTRL+M</td>
-            <td>load masks file (must be same size as image with 0 for NO mask, and 1,2,3… for masks)</td>
-            </tr>
-            <tr>
-            <td>CTRL+N</td>
-            <td>save masks as PNG</td>
-            </tr>
-            <tr>
-            <td>CTRL+R</td>
-            <td>save ROIs to native ImageJ ROI format</td>
-            </tr>
-            <tr>
-            <td>CTRL+F</td>
-            <td>save flows to image file</td>
-            </tr>
-            <tr>
-            <td>A/D or LEFT/RIGHT</td>
-            <td>cycle through images in current directory</td>
-            </tr>
-            <tr>
-            <td>W/S or UP/DOWN</td>
-            <td>change color (RGB/gray/red/green/blue)</td>
-            </tr>
-            <tr>
-            <td>R / G / B </td>
-            <td>toggle between RGB and Red or Green or Blue</td>
-            </tr>
-            <tr>
-            <td>PAGE-UP / PAGE-DOWN</td>
-            <td>change to flows and cell prob views (if segmentation computed)</td>
-            </tr>
-            <tr>
-            <td>X</td>
-            <td>turn masks ON or OFF</td>
-            </tr>
-            <tr>
-            <td>Z</td>
-            <td>toggle outlines ON or OFF</td>
-            </tr>
-            <tr>
-            <td>, / .</td>
-            <td>increase / decrease brush size for drawing masks</td>
-            </tr>
-            </tbody>
-            </table>
-            <p class="has-line-data" data-line-start="36" data-line-end="37"><strong>Segmentation options (2D only) </strong></p>
-            <p class="has-line-data" data-line-start="38" data-line-end="39">SIZE: you can manually enter the approximate diameter for your cells, or press “calibrate” to let the model estimate it. The size is represented by a disk at the bottom of the view window (can turn this disk of by unchecking “scale disk on”).</p>
-            <p class="has-line-data" data-line-start="40" data-line-end="41">use GPU: if you have specially installed the cuda version of mxnet, then you can activate this, but it won’t give huge speedups when running single 2D images in the GUI.</p>
-            <p class="has-line-data" data-line-start="42" data-line-end="43">MODEL: there is a <em>cytoplasm</em> model and a <em>nuclei</em> model, choose what you want to segment</p>
-            <p class="has-line-data" data-line-start="44" data-line-end="45">CHAN TO SEG: this is the channel in which the cytoplasm or nuclei exist</p>
-            <p class="has-line-data" data-line-start="46" data-line-end="47">CHAN2 (OPT): if <em>cytoplasm</em> model is chosen, then choose the nuclear channel for this option</p>
-            ''')
+
+        text_file = pathlib.Path(__file__).parent.joinpath('guihelpwindowtext.html')
+        with open(str(text_file.resolve()), 'r') as f:
+            text = f.read()
+
         label = QLabel(text)
         label.setFont(QtGui.QFont("Arial", 8))
         label.setWordWrap(True)
@@ -402,19 +295,11 @@ class TrainHelpWindow(QDialog):
         self.win = QWidget(self)
         layout = QGridLayout()
         self.win.setLayout(layout)
-        
-        text = ('''
-            Check out this <a href="https://youtu.be/3Y1VKcxjNy4">video</a> to learn the process.
-            <ol>
-                <li>Drag and drop an image from a folder of images with a similar style (like similar cell types).</li>
-                <li>Run the built-in models on one of the images using the "model zoo" and find the one that works best for your data. Make sure that if you have a nuclear channel you have selected it for CHAN2.</li>
-                <li>Fix the labelling by drawing new ROIs (right-click) and deleting incorrect ones (CTRL+click). The GUI autosaves any manual changes (but does not autosave after running the model, for that click CTRL+S). The segmentation is saved in a "_seg.npy" file.</li>
-                <li> Go to the "Models" menu in the File bar at the top and click "Train new model..." or use shortcut CTRL+T. </li>
-                <li> Choose the pretrained model to start the training from (the model you used in #2), and type in the model name that you want to use. The other parameters should work well in general for most data types. Then click OK. </li>
-                <li> The model will train (much faster if you have a GPU) and then auto-run on the next image in the folder. Next you can repeat #3-#5 as many times as is necessary. </li>
-                <li> The trained model is available to use in the future in the GUI in the "custom model" section and is saved in your image folder. </li>
-            </ol>
-            ''')
+
+        text_file = pathlib.Path(__file__).parent.joinpath('guitrainhelpwindowtext.html')
+        with open(str(text_file.resolve()), 'r') as f:
+            text = f.read()
+
         label = QLabel(text)
         label.setFont(QtGui.QFont("Arial", 8))
         label.setWordWrap(True)

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -548,8 +548,11 @@ class ImageDraw(pg.ImageItem):
                                 self.parent.remove_cell(idx)
                             elif ev.modifiers() & QtCore.Qt.AltModifier:
                                 self.parent.merge_cells(idx)
-                            elif self.parent.masksOn:
+                            elif self.parent.masksOn and not self.parent.deleting_multiple:
                                 self.parent.unselect_cell()
+                                self.parent.select_cell(idx)
+                            elif self.parent.deleting_multiple:
+                                # todo: is this broken?
                                 self.parent.select_cell(idx)
                         elif self.parent.masksOn:
                             self.parent.unselect_cell()

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -524,9 +524,11 @@ class ImageDraw(pg.ImageItem):
         self.parent.in_stroke = False
 
     def mouseClickEvent(self, ev):
-        if self.parent.masksOn or self.parent.outlinesOn:
-            if  self.parent.loaded and (ev.button() == QtCore.Qt.RightButton or 
-                    ev.modifiers() & QtCore.Qt.ShiftModifier and not ev.double()):
+        if (self.parent.masksOn or self.parent.outlinesOn) and not self.parent.removing_region:
+            is_right_click = ev.button() == QtCore.Qt.RightButton
+            if self.parent.loaded \
+                    and (is_right_click or ev.modifiers() & QtCore.Qt.ShiftModifier and not ev.double())\
+                    and not self.deleting_multiple:
                 if not self.parent.in_stroke:
                     ev.accept()
                     self.create_start(ev.pos())

--- a/cellpose/gui/guitrainhelpwindowtext.html
+++ b/cellpose/gui/guitrainhelpwindowtext.html
@@ -1,0 +1,25 @@
+<qt>
+    Check out this <a href="https://youtu.be/3Y1VKcxjNy4">video</a> to learn the process.
+    <ol>
+        <li>Drag and drop an image from a folder of images with a similar style (like similar cell types).</li>
+        <li>Run the built-in models on one of the images using the "model zoo" and find the one that works best for your
+            data. Make sure that if you have a nuclear channel you have selected it for CHAN2.
+        </li>
+        <li>Fix the labelling by drawing new ROIs (right-click) and deleting incorrect ones (CTRL+click). The GUI
+            autosaves any manual changes (but does not autosave after running the model, for that click CTRL+S). The
+            segmentation is saved in a "_seg.npy" file.
+        </li>
+        <li> Go to the "Models" menu in the File bar at the top and click "Train new model..." or use shortcut CTRL+T.
+        </li>
+        <li> Choose the pretrained model to start the training from (the model you used in #2), and type in the model
+            name that you want to use. The other parameters should work well in general for most data types. Then click
+            OK.
+        </li>
+        <li> The model will train (much faster if you have a GPU) and then auto-run on the next image in the folder.
+            Next you can repeat #3-#5 as many times as is necessary.
+        </li>
+        <li> The trained model is available to use in the future in the GUI in the "custom model" section and is saved
+            in your image folder.
+        </li>
+    </ol>
+</qt>

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -60,6 +60,25 @@ ENTER.
     3D labelling will fill in unlabelled z-planes so that you do not
     have to densely label, for example you can skip some planes.
 
+Bulk Mask Deletion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+..
+    image:: images/cellpose_delete-multiple-demo.gif
+    :width: 600
+
+Clicking the 'delete multiple' button will allow you to select and
+delete multiple masks at once. Masks can be deselected by clicking
+on them again. Once you have selected all the masks you want to delete,
+click the 'done' button to delete them.
+
+Alternatively, you can create a rectangular region to delete a regions of masks
+by clicking the 'delete multiple' button, and then moving and/or resizing
+the region to select the masks you want to delete. Once you have selected
+the masks you want to delete, click the 'done' button to delete them.
+
+At any point in the process, you can click the 'cancel' button to cancel
+the bulk deletion.
+
 
 Segmentation options
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -54,7 +54,10 @@ in 2D should be single strokes (if *single_stroke* is checked).
 
 If you want to draw masks in 3D, then you can turn *single_stroke*
 option off and draw a stroke on each plane with the cell and then press
-ENTER. 
+ENTER.
+
+.. image:: https://www.cellpose.org/static/images/cellpose_gui.png
+    :width: 600
 
 .. note::
     3D labelling will fill in unlabelled z-planes so that you do not
@@ -62,10 +65,6 @@ ENTER.
 
 Bulk Mask Deletion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-..
-    image:: images/cellpose_delete-multiple-demo.gif
-    :width: 600
-
 Clicking the 'delete multiple' button will allow you to select and
 delete multiple masks at once. Masks can be deselected by clicking
 on them again. Once you have selected all the masks you want to delete,
@@ -78,6 +77,9 @@ the masks you want to delete, click the 'done' button to delete them.
 
 At any point in the process, you can click the 'cancel' button to cancel
 the bulk deletion.
+
+.. image:: https://www.cellpose.org/static/images/cellpose_delete_demo.gif
+    :width: 600
 
 
 Segmentation options

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,8 +23,8 @@ Cellpose 2.0
 Cellpose 1.0 
 
 - `paper <https://www.biorxiv.org/content/10.1101/2020.02.02.931238v1>`_ on biorxiv (see figure 1 below) and in `nature methods <https://t.co/kBMXmPp3Yn?amp=1>`_
-- twitter `thread`_
-- Marius's `talk`_
+- twitter `thread <https://twitter.com/computingnature/status/1224477812763119617>`_
+- Marius's `talk <https://www.youtube.com/watch?v=7y9d4VIKiS8>`_
 
 .. image:: _static/fig1.PNG
     :width: 1200px
@@ -32,9 +32,7 @@ Cellpose 1.0
     :alt: fig1
 
 .. _cellpose.org: http://www.cellpose.org
-.. _thread: https://twitter.com/computingnature/status/1224477812763119617
 .. _issue: https://github.com/MouseLand/cellpose/issues
-.. _talk: https://www.youtube.com/watch?v=7y9d4VIKiS8
 .. _pypi: https://pypi.org/project/cellpose/
 
 

--- a/docs/outputs.rst
+++ b/docs/outputs.rst
@@ -89,7 +89,7 @@ This function is also available in the GUI.
 
 
 (Legacy ImageJ Interface) ROI manager compatible output for ImageJ
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can save the outlines of ROIs in a text file that's compatible with ImageJ 
 ROI Manager in the GUI File menu.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -8,7 +8,7 @@ See the :ref:`cpclass` for all run options.
 
 Here is an example of calling the Cellpose class and
 running a list of images for reference:
-::
+::code-block::
     from cellpose import models
     from cellpose.io import imread
 
@@ -17,7 +17,7 @@ running a list of images for reference:
 
     files = ['img0.tif', 'img1.tif']
     imgs = [imread(f) for f in files]
-    masks, flows, styles, diams = model.eval(imgs, diameter=None, channels=[0,0], 
+    masks, flows, styles, diams = model.eval(imgs, diameter=None, channels=[0,0],
                                              flow_threshold=0.4, do_3D=False)
 
 You can make lists of channels/diameter for each image, or set the same channels/diameter for all images
@@ -39,7 +39,9 @@ Set channels to a list with each of these elements, e.g.
 
 On the command line the above would be ``--chan 0 --chan2 0`` or ``--chan 2 --chan2 3``.
 
+
 .. _diameter:
+
 Diameter 
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
### Add functionality to GUI to allow 'batch' deletion of masks:

Current implementation is a button that starts batch deletion mode and masks can be selected/deselected until pressing the 'done' button. Once the 'done' button is pressed, the masks are removed from the relevant state variables and the mask is saved once. 

### Task list: 
- [x] Add button(s) to start/stop batch deletion mode
- [x] Add function(s) to connect buttons
- [x] Allow region selection of multiple ROIs
- [x] ~~Write tests?~~
- [x] Write documentation with images (maybe video?)
- [ ] User testing on 
    - [x] Linux
    - [x] Windows
    - [ ] Mac
 - [x] Test with 3d image stack 
 - [x] Verify that `manual` tags are properly updated

### Addresses:
- #703 
- #501 
