### PR TITLE
Disable gui autosave

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1178,7 +1178,7 @@ class MainW(QMainWindow):
         if self.ncells==0:
             self.ClearButton.setEnabled(False)
         if self.NZ==1:
-            io._save_sets(self)
+            io._save_sets_with_check(self)
 
     def merge_cells(self, idx):
         self.prev_selected = self.selected
@@ -1210,7 +1210,7 @@ class MainW(QMainWindow):
             self.remove_cell(self.selected)
             print('GUI_INFO: merged two cells')
             self.update_layer()
-            io._save_sets(self)
+            io._save_sets_with_check(self)
             self.undo.setEnabled(False)      
             self.redo.setEnabled(False)    
 
@@ -1228,7 +1228,7 @@ class MainW(QMainWindow):
             self.zdraw.append([])
             print('>>> added back removed cell')
             self.update_layer()
-            io._save_sets(self)
+            io._save_sets_with_check(self)
             self.removed_cell = []
             self.redo.setEnabled(False)
 
@@ -1431,7 +1431,7 @@ class MainW(QMainWindow):
                     self.ismanual = np.append(self.ismanual, True)
                     if self.NZ==1:
                         # only save after each cell if single image
-                        io._save_sets(self)
+                        io._save_sets_with_check(self)
             self.current_stroke = []
             self.strokes = []
             self.current_point_set = []

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -504,16 +504,12 @@ def _save_sets(parent):
                  'cellprob_threshold': cellprob_threshold
                  })
     else:
-        image = parent.chanchoose(parent.stack[parent.currentZ].copy())
-        if image.ndim < 4:
-            image = image[np.newaxis,...]
         np.save(base + '_seg.npy',
                 {'outlines': parent.outpix.squeeze(),
                  'colors': parent.cellcolors[1:],
                  'masks': parent.cellpix.squeeze(),
                  'chan_choose': [parent.ChannelChoose[0].currentIndex(),
                                  parent.ChannelChoose[1].currentIndex()],
-                 'img': image.squeeze(),
                  'filename': parent.filename,
                  'flows': parent.flows,
                  'ismanual': parent.ismanual,

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -476,9 +476,17 @@ def _save_outlines(parent):
     else:
         print('ERROR: cannot save 3D outlines')
     
+def _save_sets_with_check(parent):
+    """ Save masks and update *_seg.npy file. Use this function when saving should be optional
+     based on the disableAutosave checkbox. Otherwise, use _save_sets """
+    if not parent.disableAutosave.isChecked():
+        _save_sets(parent)
+
 
 def _save_sets(parent):
-    """ save masks to *_seg.npy """
+    """ save masks to *_seg.npy. This function should be used when saving
+    is forced, e.g. when clicking the save button. Otherwise, use _save_sets_with_check
+    """
     filename = parent.filename
     base = os.path.splitext(filename)[0]
     flow_threshold, cellprob_threshold = parent.get_thresholds()

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -20,7 +20,11 @@ def mainmenu(parent):
     parent.autoloadMasks = QAction("Autoload masks from _masks.tif file", parent, checkable=True)
     parent.autoloadMasks.setChecked(False)
     file_menu.addAction(parent.autoloadMasks)
-    
+
+    parent.disableAutosave = QAction("Disable autosave _seg.npy file", parent, checkable=True)
+    parent.disableAutosave.setChecked(False)
+    file_menu.addAction(parent.disableAutosave)
+
     parent.loadMasks = QAction("Load &masks (*.tif, *.png, *.jpg)", parent)
     parent.loadMasks.setShortcut("Ctrl+M")
     parent.loadMasks.triggered.connect(lambda: io._load_masks(parent))


### PR DESCRIPTION
For larger files, it would be useful to not save the *_seg.npy file each time a mask is edited. This PR adds a File menu dropdown checkbox that allows the user to turn off autosaving. Additionally, I removed the 'img' data saved to the .npy file to reduce time/space of writing that repeatedly. 

Addresses: 
#703