### PR TITLE
Gh actions failing due to repeated py version runs

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - gh_actions_2
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - gh_actions_2
     tags:
       - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
 requires = tox-conda
-envlist = py{38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =


### PR DESCRIPTION
Actions are failing because all 3 py versions are running for each platform causing GH actions runner to exceed storage limit. Removing tox envlist environments fixes this to only run one version per job. 