### PR TITLE
Qtpy refactor

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -7,11 +7,10 @@ import gc
 from natsort import natsorted
 from tqdm import tqdm, trange
 
-import PyQt5
-from PyQt5 import QtGui, QtCore, Qt, QtWidgets
+from qtpy import QtGui, QtCore, QtWidgets
 from superqt import QRangeSlider
 from qtpy.QtCore import Qt as Qtp
-from PyQt5.QtWidgets import QMainWindow, QApplication, QWidget, QScrollBar, QSlider, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox
+from qtpy.QtWidgets import QMainWindow, QApplication, QWidget, QScrollBar, QSlider, QComboBox, QGridLayout, QPushButton, QFrame, QCheckBox, QLabel, QProgressBar, QLineEdit, QMessageBox, QGroupBox
 import pyqtgraph as pg
 from pyqtgraph import GraphicsScene
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -2,10 +2,9 @@
 Copright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer and Marius Pachitariu.
 """
 
-import PyQt5
-from PyQt5 import QtGui, QtCore, QtWidgets
-from PyQt5.QtGui import QPainter, QPixmap
-from PyQt5.QtWidgets import QApplication, QRadioButton, QWidget, QDialog, QButtonGroup, QSlider, QStyle, QStyleOptionSlider, QGridLayout, QPushButton, QLabel, QLineEdit, QDialogButtonBox, QComboBox, QCheckBox
+from qtpy import QtGui, QtCore, QtWidgets
+from qtpy.QtGui import QPainter, QPixmap
+from qtpy.QtWidgets import QApplication, QRadioButton, QWidget, QDialog, QButtonGroup, QSlider, QStyle, QStyleOptionSlider, QGridLayout, QPushButton, QLabel, QLineEdit, QDialogButtonBox, QComboBox, QCheckBox
 import pyqtgraph as pg
 from pyqtgraph import functions as fn
 from pyqtgraph import Point
@@ -509,7 +508,7 @@ class ImageDraw(pg.ImageItem):
     for controlling the levels and lookup table used to display the image.
     """
 
-    sigImageChanged = QtCore.pyqtSignal()
+    sigImageChanged = QtCore.Signal()
 
     def __init__(self, image=None, viewbox=None, parent=None, **kargs):
         super(ImageDraw, self).__init__()

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -15,8 +15,8 @@ from ..io import imread, imsave, outlines_to_text, add_model, remove_model, save
 from ..transforms import normalize99
 
 try:
-    import PyQt5
-    from PyQt5.QtWidgets import QFileDialog
+    import qtpy
+    from qtpy.QtWidgets import QFileDialog
     GUI = True
 except:
     GUI = False

--- a/cellpose/gui/menus.py
+++ b/cellpose/gui/menus.py
@@ -2,8 +2,8 @@
 Copright © 2023 Howard Hughes Medical Institute, Authored by Carsen Stringer and Marius Pachitariu.
 """
 
-import PyQt5
-from PyQt5.QtWidgets import QAction
+import qtpy
+from qtpy.QtWidgets import QAction
 from . import io
 from .. import models
 from ..io import save_server

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -15,8 +15,8 @@ from roifile import ImagejRoi, roiwrite
 
 
 try:
-    from PyQt5 import QtGui, QtCore, Qt, QtWidgets
-    from PyQt5.QtWidgets import QMessageBox
+    from qtpy import QtGui, QtCore, Qt, QtWidgets
+    from qtpy.QtWidgets import QMessageBox
     GUI = True
 except:
     GUI = False

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ dependencies:
   - python==3.8.5
   - pip
   - pip:
-    - PyQt5
-    - PyQt5.sip
+    - qtpy
+#    - PyQt5.sip
     - numpy>=1.20.0
     - numba>=0.43.1
     - scipy

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,9 @@ install_deps = ['numpy>=1.20.0', 'scipy', 'natsort',
 
 gui_deps = [
         'pyqtgraph>=0.11.0rc0', 
-        'pyqt5', 
-        'pyqt5.sip',
+        "pyqt6",
+        "pyqt6.sip",
+        'qtpy',
         'superqt',
         'google-cloud-storage'
 ]
@@ -39,6 +40,29 @@ try:
     major_version, minor_version, _ = torch.__version__.split(".")
     if major_version == "2" or int(minor_version) >= 6:
         install_deps.remove("torch>=1.6")
+except:
+    pass
+
+try:
+    import PyQt5
+    gui_deps.remove("pyqt6")
+    gui_deps.remove("pyqt6.sip")
+    gui_deps.append("pyqt5")
+    gui_deps.append("pyqt5.sip")
+except:
+    pass
+
+try:
+    import PySide2
+    gui_deps.remove("pyqt6")
+    gui_deps.remove("pyqt6.sip")
+except:
+    pass
+
+try:
+    import PySide6
+    gui_deps.remove("pyqt6")
+    gui_deps.remove("pyqt6.sip")
 except:
     pass
 


### PR DESCRIPTION
Replace PyQt5 dependency with more flexible qtpy library. 

Test on:
- OS testing
  - [x] Windows
  - [x] Mac
  - [x] Linux
- [x] implement pip install logic to look if a pyqt install exists (check with rastermap/setup.py)
- [x] Test uninstall pyqt5 followed upgrade pyqt6