### PR TITLE
Scale flows to correct shape

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -718,11 +718,29 @@ def get_masks(p, iscell=None, rpad=20):
     M0 = np.reshape(M0, shape0)
     return M0
 
+def resize_and_compute_masks(dP, cellprob, p=None, niter=200,
+                                cellprob_threshold=0.0,
+                                flow_threshold=0.4, interp=True, do_3D=False,
+                                min_size=15, resize=None,
+                                use_gpu=False, device=None):
+    """ compute masks using dynamics from dP, cellprob, and boundary """
+    mask, p = compute_masks(dP, cellprob, p=p, niter=niter,
+                            cellprob_threshold=cellprob_threshold,
+                            flow_threshold=flow_threshold, interp=interp,
+                            do_3D=do_3D, min_size=min_size,
+                            use_gpu=use_gpu, device=device)
+
+    if resize is not None:
+        mask = transforms.resize_image(mask, resize[0], resize[1], interpolation=cv2.INTER_NEAREST)
+        p = transforms.resize_image(p, resize[0], resize[1], interpolation=cv2.INTER_NEAREST)
+
+    return mask, p
+
+
 def compute_masks(dP, cellprob, p=None, niter=200, 
                    cellprob_threshold=0.0,
                    flow_threshold=0.4, interp=True, do_3D=False, 
-                   min_size=15, resize=None, 
-                   use_gpu=False,device=None):
+                   min_size=15, use_gpu=False,device=None):
     """ compute masks using dynamics from dP, cellprob, and boundary """
     
     cp_mask = cellprob > cellprob_threshold 
@@ -734,7 +752,7 @@ def compute_masks(dP, cellprob, p=None, niter=200,
                                             use_gpu=use_gpu, device=device)
             if inds is None:
                 dynamics_logger.info('No cell pixels found.')
-                shape = resize if resize is not None else cellprob.shape
+                shape = cellprob.shape
                 mask = np.zeros(shape, np.uint16)
                 p = np.zeros((len(shape), *shape), np.uint16)
                 return mask, p
@@ -744,31 +762,27 @@ def compute_masks(dP, cellprob, p=None, niter=200,
             
         # flow thresholding factored out of get_masks
         if not do_3D:
-            shape0 = p.shape[1:]
             if mask.max()>0 and flow_threshold is not None and flow_threshold > 0:
                 # make sure labels are unique at output of get_masks
                 mask = remove_bad_flow_masks(mask, dP, threshold=flow_threshold, use_gpu=use_gpu, device=device)
         
-        if resize is not None:
-            #if verbose:
-            #    dynamics_logger.info(f'resizing output with resize = {resize}')
-            if mask.max() > 2**16-1:
-                recast = True
-                mask = mask.astype(np.float32)
-            else:
-                recast = False
-                mask = mask.astype(np.uint16)
-            mask = transforms.resize_image(mask, resize[0], resize[1], interpolation=cv2.INTER_NEAREST)
-            if recast:
-                mask = mask.astype(np.uint32)
-            Ly,Lx = mask.shape
-        elif mask.max() < 2**16:
+        if mask.max() > 2**16-1:
+            recast = True
+            mask = mask.astype(np.float32)
+        else:
+            recast = False
+            mask = mask.astype(np.uint16)
+
+        if recast:
+            mask = mask.astype(np.uint32)
+
+        if mask.max() < 2**16:
             mask = mask.astype(np.uint16)
 
     else: # nothing to compute, just make it compatible
         dynamics_logger.info('No cell pixels found.')
-        shape = resize if resize is not None else cellprob.shape
-        mask = np.zeros(shape, np.uint16)
+        shape = cellprob.shape
+        mask = np.zeros(cellprob.shape, np.uint16)
         p = np.zeros((len(shape), *shape), np.uint16)
         return mask, p
 

--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -732,7 +732,7 @@ def resize_and_compute_masks(dP, cellprob, p=None, niter=200,
 
     if resize is not None:
         mask = transforms.resize_image(mask, resize[0], resize[1], interpolation=cv2.INTER_NEAREST)
-        p = transforms.resize_image(p, resize[0], resize[1], interpolation=cv2.INTER_NEAREST)
+        p = np.array([transforms.resize_image(pi, resize[0], resize[1], interpolation=cv2.INTER_NEAREST) for pi in p])
 
     return mask, p
 

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -642,7 +642,7 @@ class CellposeModel(UnetModel):
             tic=time.time()
             niter = 200 if (do_3D and not resample) else (1 / rescale * 200)
             if do_3D:
-                masks, p = dynamics.compute_masks(dP, cellprob, niter=niter, 
+                masks, p = dynamics.resize_and_compute_masks(dP, cellprob, niter=niter,
                                                       cellprob_threshold=cellprob_threshold,
                                                       flow_threshold=flow_threshold,
                                                       interp=interp, do_3D=do_3D, min_size=min_size,
@@ -653,7 +653,7 @@ class CellposeModel(UnetModel):
                 masks, p = [], []
                 resize = [shape[1], shape[2]] if not resample else None
                 for i in iterator:
-                    outputs = dynamics.compute_masks(dP[:,i], cellprob[i], niter=niter, cellprob_threshold=cellprob_threshold,
+                    outputs = dynamics.resize_and_compute_masks(dP[:,i], cellprob[i], niter=niter, cellprob_threshold=cellprob_threshold,
                                                          flow_threshold=flow_threshold, interp=interp, resize=resize, 
                                                          min_size=min_size if stitch_threshold==0 or nimg==1 else -1, # turn off for 3D stitching
                                                          use_gpu=self.gpu, device=self.device)


### PR DESCRIPTION
Per #774, when `resize` is not `None`, masks get resized but the flows don't in `dynamics.compute_masks()`. This isn't immediately an issue, except that if no putative cellpix are found ([here](https://github.com/MouseLand/cellpose/blob/95f8d9822e14f7fb5b204c8f302f3f5d71a86d3d/cellpose/dynamics.py#L735C1-L740C31)), zero-filled arrays of the original size are returned. 

The result is that, depending on if putative cellpix are found, iterating through the images ([here](https://github.com/MouseLand/cellpose/blob/95f8d9822e14f7fb5b204c8f302f3f5d71a86d3d/cellpose/models.py#L655C5-L655C5)) produces a list of inconsistent np array shapes. Finally, trying to convert the list-of-arrays into a stack of arrays fails at [line 663](https://github.com/MouseLand/cellpose/blob/95f8d9822e14f7fb5b204c8f302f3f5d71a86d3d/cellpose/models.py#L663C1-L663C32). 

This fix reshapes the flows to the correct shape.

Should we think about tests that address this? 