### PR TITLE
undo the switch back to save_sets()

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1210,7 +1210,7 @@ class MainW(QMainWindow):
         if self.ncells==0:
             self.ClearButton.setEnabled(False)
         if self.NZ==1:
-            io._save_sets(self)
+            io._save_sets_with_check(self)
 
         self.update_layer()
 


### PR DESCRIPTION
Hotfix the disable autosave feature after merging. 

The `io._save_sets()` function was replaced with `io._save_sets_with_check()` to check if it should save the npy file or just update the memory. A stray line was reset to the original version which caused the disable autosave feature to break. 

