### PR TITLE
Prevent list of trained model names from having repeats

### DIFF
--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -140,13 +140,12 @@ def add_model(filename):
     """ add model to .cellpose models folder to use with GUI or CLI """
     from . import models
     fname = os.path.split(filename)[-1]
-    overwrite = False
     try:
         shutil.copyfile(filename, os.fspath(models.MODEL_DIR.joinpath(fname)))
     except shutil.SameFileError:
-        overwrite = True
+        pass
     print(f'{filename} copied to models folder {os.fspath(models.MODEL_DIR)}')
-    if not overwrite:
+    if fname not in models.get_user_models():
         with open(models.MODEL_LIST_PATH, 'a') as textfile:
             textfile.write(fname + '\n')
 

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -140,13 +140,15 @@ def add_model(filename):
     """ add model to .cellpose models folder to use with GUI or CLI """
     from . import models
     fname = os.path.split(filename)[-1]
+    overwrite = False
     try:
         shutil.copyfile(filename, os.fspath(models.MODEL_DIR.joinpath(fname)))
     except shutil.SameFileError:
-        pass
+        overwrite = True
     print(f'{filename} copied to models folder {os.fspath(models.MODEL_DIR)}')
-    with open(models.MODEL_LIST_PATH, 'a') as textfile:
-        textfile.write(fname + '\n')
+    if not overwrite:
+        with open(models.MODEL_LIST_PATH, 'a') as textfile:
+            textfile.write(fname + '\n')
 
 def imsave(filename, arr):
     ext = os.path.splitext(filename)[-1].lower()


### PR DESCRIPTION
In `add_model()` of the `io` module, the list of user model_names is appended to with the new name, even if it already existed. This is confusing, because in the select custom model section of the GUI, it will repeat the name, even though only one model under that name already exists. This corrects that by checking if the `fname` of the new model exists in `models.get_user_models()` before adding it. 