### PR TITLE
Update dynamics.py with torch version fix

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -583,7 +583,7 @@ def remove_bad_flow_masks(masks, flows, threshold=0.4, use_gpu=False, device=Non
     """
     if masks.size > 10000*10000 and use_gpu:
         
-        major_version, minor_version, _ = torch.__version__.split(".")
+        major_version, minor_version = torch.__version__.split(".")[:2]
         
         if major_version == "1" and int(minor_version) < 10:
             # for PyTorch version lower than 1.10


### PR DESCRIPTION
`torch.__version__.split(".")` could return more than 3 arguments, which the previous code did not account for.

For example, on my local machine with a fresh `torch `install from Conda, `torch.__version__` returns `'2.0.0.post301'.
With the proposed changes, it will only grab the first 2 items after the "." split, thus eliminating the need for the throwaway variable and also the ValueError that would be raised if the version split returns more than 4 variables.