### PR TITLE
Add option not to fill masks. Compression to TIFF files.

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -756,7 +756,7 @@ def get_masks(p, iscell=None, rpad=20):
     return M0
 
 def resize_and_compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold=0.0,
-                             flow_threshold=0.4, interp=True, do_3D=False, min_size=15,
+                             flow_threshold=0.4, interp=True, do_3D=False, min_size=15, fill_holes=True,
                              resize=None, device=None):
     """Compute masks using dynamics from dP and cellprob, and resizes masks if resize is not None.
 
@@ -770,6 +770,7 @@ def resize_and_compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold
         interp (bool, optional): Whether to interpolate during dynamics computation. Defaults to True.
         do_3D (bool, optional): Whether to perform mask computation in 3D. Defaults to False.
         min_size (int, optional): The minimum size of the masks. Defaults to 15.
+        fill_holes (bool, optional): Whether to fill holes in the masks. Defaults to True.
         resize (tuple, optional): The desired size for resizing the masks. Defaults to None.
         device (str, optional): The torch device to use for computation. Defaults to None.
 
@@ -779,7 +780,7 @@ def resize_and_compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold
     mask, p = compute_masks(dP, cellprob, p=p, niter=niter,
                             cellprob_threshold=cellprob_threshold,
                             flow_threshold=flow_threshold, interp=interp, do_3D=do_3D,
-                            min_size=min_size, device=device)
+                            min_size=min_size, fill_holes=fill_holes, device=device)
 
     if resize is not None:
         mask = transforms.resize_image(mask, resize[0], resize[1],
@@ -794,7 +795,7 @@ def resize_and_compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold
 
 def compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold=0.0,
                   flow_threshold=0.4, interp=True, do_3D=False, min_size=15,
-                  device=None):
+                  fill_holes=True, device=None):
     """Compute masks using dynamics from dP and cellprob.
 
     Args:
@@ -807,6 +808,7 @@ def compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold=0.0,
         interp (bool, optional): Whether to interpolate during dynamics computation. Defaults to True.
         do_3D (bool, optional): Whether to perform mask computation in 3D. Defaults to False.
         min_size (int, optional): The minimum size of the masks. Defaults to 15.
+        fill_holes (bool, optional): Whether to fill holes in the masks. Defaults to True.
         device (str, optional): The torch device to use for computation. Defaults to None.
 
     Returns:
@@ -856,7 +858,7 @@ def compute_masks(dP, cellprob, p=None, niter=200, cellprob_threshold=0.0,
         p = np.zeros((len(shape), *shape), np.uint16)
         return mask, p
 
-    mask = utils.fill_holes_and_remove_small_masks(mask, min_size=min_size)
+    mask = utils.fill_holes_and_remove_small_masks(mask, min_size=min_size, fill_holes=fill_holes)
 
     if mask.dtype == np.uint32:
         dynamics_logger.warning(

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -261,7 +261,7 @@ def imsave(filename, arr):
     """
     ext = os.path.splitext(filename)[-1].lower()
     if ext == ".tif" or ext == ".tiff":
-        tifffile.imwrite(filename, arr)
+        tifffile.imwrite(filename, arr, compression="zlib")
     else:
         if len(arr.shape) > 2:
             arr = cv2.cvtColor(arr, cv2.COLOR_BGR2RGB)

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -305,7 +305,7 @@ class CellposeModel():
              z_axis=None, normalize=True, invert=False, rescale=None, diameter=None,
              flow_threshold=0.4, cellprob_threshold=0.0, do_3D=False, anisotropy=None,
              stitch_threshold=0.0, min_size=15, niter=None, augment=False, tile=True,
-             tile_overlap=0.1, bsize=224, interp=True, compute_masks=True,
+             tile_overlap=0.1, bsize=224, interp=True, compute_masks=True, fill_holes=True,
              progress=None):
         """ segment list of images x, or 4D array - Z x nchan x Y x X
 
@@ -352,6 +352,7 @@ class CellposeModel():
             bsize (int, optional): block size for tiles, recommended to keep at 224, like in training. Defaults to 224.
             interp (bool, optional): interpolate during 2D dynamics (not available in 3D) . Defaults to True.
             compute_masks (bool, optional): Whether or not to compute dynamics and return masks. This is set to False when retrieving the styles for the size model. Defaults to True.
+            fill_holes (bool, optional): Whether or not to fill holes in masks. Defaults to True.
             progress (QProgressBar, optional): pyqt progress bar. Defaults to None.
 
         Returns:
@@ -384,7 +385,7 @@ class CellposeModel():
                     tile_overlap=tile_overlap, bsize=bsize, resample=resample,
                     interp=interp, flow_threshold=flow_threshold,
                     cellprob_threshold=cellprob_threshold, compute_masks=compute_masks,
-                    min_size=min_size, stitch_threshold=stitch_threshold,
+                    min_size=min_size, fill_holes=fill_holes, stitch_threshold=stitch_threshold,
                     progress=progress, niter=niter)
                 masks.append(maski)
                 flows.append(flowi)
@@ -412,7 +413,7 @@ class CellposeModel():
                 rescale=rescale, resample=resample, augment=augment, tile=tile,
                 tile_overlap=tile_overlap, bsize=bsize, flow_threshold=flow_threshold,
                 cellprob_threshold=cellprob_threshold, interp=interp, min_size=min_size,
-                do_3D=do_3D, anisotropy=anisotropy, niter=niter,
+                do_3D=do_3D, anisotropy=anisotropy, niter=niter, fill_holes=fill_holes,
                 stitch_threshold=stitch_threshold)
 
             flows = [plot.dx_to_circ(dP), dP, cellprob, p]
@@ -421,7 +422,7 @@ class CellposeModel():
     def _run_cp(self, x, compute_masks=True, normalize=True, invert=False, niter=None,
                 rescale=1.0, resample=True, augment=False, tile=True, tile_overlap=0.1,
                 cellprob_threshold=0.0, bsize=224, flow_threshold=0.4, min_size=15,
-                interp=True, anisotropy=1.0, do_3D=False, stitch_threshold=0.0):
+                interp=True, anisotropy=1.0, do_3D=False, stitch_threshold=0.0, fill_holes=True):
 
         if isinstance(normalize, dict):
             normalize_params = {**normalize_default, **normalize}
@@ -505,7 +506,7 @@ class CellposeModel():
                 masks, p = dynamics.resize_and_compute_masks(
                     dP, cellprob, niter=niter, cellprob_threshold=cellprob_threshold,
                     flow_threshold=flow_threshold, interp=interp, do_3D=do_3D,
-                    min_size=min_size, resize=None,
+                    min_size=min_size, resize=None, fill_holes=fill_holes,
                     device=self.device if self.gpu else None)
             else:
                 masks, p = [], []
@@ -524,6 +525,7 @@ class CellposeModel():
                         resize=resize,
                         min_size=min_size if stitch_threshold == 0 or nimg == 1 else
                         -1,  # turn off for 3D stitching
+                        fill_holes=fill_holes,
                         device=self.device if self.gpu else None)
                     masks.append(outputs[0])
                     p.append(outputs[1])
@@ -536,7 +538,7 @@ class CellposeModel():
                     )
                     masks = utils.stitch3D(masks, stitch_threshold=stitch_threshold)
                     masks = utils.fill_holes_and_remove_small_masks(
-                        masks, min_size=min_size)
+                        masks, min_size=min_size, fill_holes=fill_holes)
                 elif nimg > 1:
                     models_logger.warning("3D stack used, but stitch_threshold=0 and do_3D=False, so masks are made per plane only")
 

--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -611,7 +611,7 @@ def size_distribution(masks):
     counts = np.unique(masks, return_counts=True)[1][1:]
     return np.percentile(counts, 25) / np.percentile(counts, 75)
 
-def fill_holes_and_remove_small_masks(masks, min_size=15):
+def fill_holes_and_remove_small_masks(masks, min_size=15, fill_holes=True):
     """ Fills holes in masks (2D/3D) and discards masks smaller than min_size.
 
     This function fills holes in each mask using scipy.ndimage.morphology.binary_fill_holes.
@@ -624,6 +624,7 @@ def fill_holes_and_remove_small_masks(masks, min_size=15):
     min_size (int, optional): Minimum number of pixels per mask.
         Masks smaller than min_size will be removed.
         Set to -1 to turn off this functionality. Default is 15.
+    fill_holes (bool, optional): Whether to fill holes in masks. Default is True.
 
     Returns:
     ndarray: Int, 2D or 3D array of masks with holes filled and small masks removed.
@@ -644,11 +645,12 @@ def fill_holes_and_remove_small_masks(masks, min_size=15):
             if min_size > 0 and npix < min_size:
                 masks[slc][msk] = 0
             elif npix > 0:
-                if msk.ndim == 3:
-                    for k in range(msk.shape[0]):
-                        msk[k] = binary_fill_holes(msk[k])
-                else:
-                    msk = binary_fill_holes(msk)
+                if fill_holes:
+                    if msk.ndim == 3:
+                        for k in range(msk.shape[0]):
+                            msk[k] = binary_fill_holes(msk[k])
+                    else:
+                        msk = binary_fill_holes(msk)
                 masks[slc][msk] = (j + 1)
                 j += 1
     return masks


### PR DESCRIPTION
Often with the glial cells Cellpose fills in masks where the hole between processes is present. This affects the downstream morphological analysis and intensities computations. Added an option to disable this behaviour when calling `eval`.

Also, noticed that saved masks in `.tif` or `.tiff` format are quite large in size, so added compression which significantly reduced the size of the file.