### PR TITLE
pyqtgraph added into environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,4 +19,5 @@ dependencies:
     - cellpose
     - roifile
     - pyqt5
+    - pyqtgraph
   


### PR DESCRIPTION
CellPose requires pyqtgraph when cloned from the GitHub repository and installed via `pip install -e .` command, otherwise it gives the following error:

```
(DVP) ➜  DeepVisualProteomics git:(development) ✗ python -m cellpose
GUI ERROR: No module named 'pyqtgraph'
GUI FAILED: GUI dependencies may not be installed, to install, run
     pip install 'cellpose[gui]'
```

`pip install pyqtgraph` solves the problem.