### PR TITLE
fix mask_flows_to_seg to work for multiple inputs

### DIFF
--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -496,7 +496,9 @@ def masks_flows_to_seg(images, masks, flows, file_names, diams=30., channels=Non
         if not isinstance(diams, (list, np.ndarray)):
             diams = diams * np.ones(len(masks), np.float32)
         if imgs_restore is None:
-            imgs_restore = [] * len(masks)
+            imgs_restore = [None] * len(masks)
+        if isinstance(file_names, str):
+            file_names = [file_names] * len(masks)
         for k, [image, mask, flow, diam,
                 file_name, img_restore] in enumerate(zip(images, masks, flows, diams, file_names, imgs_restore)):
             channels_img = channels


### PR DESCRIPTION
When using `io.masks_flows_to_seg()` the iteration over the arguments when the input is a list of images did not succeed and fails quietly. I adjusted the iteration to correctly iterate through the arguments. 

Resolves: 
#904
#894

Remaining issue: in CP2 the arguments for `diams` and `file_names` are switched in order compared to CP3. It shouldn't matter if the keywords are used but order-based calls to `io.masks_flows_to_seg()` will be wrong between the versions. The order cannot be switched without removing the default argument for `diams`, since there isn't a default for `file_names`.

Possible solution: set the default `diams = None` since it is used in the .npy `est_diam` key. Currently it is set to a default of 30, which may not be correct either.