### PR TITLE
Bugfix: Resizing masks containing over 65,535 cells not supported by OpenCV

### DIFF
--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -674,7 +674,7 @@ def normalize_img(img, normalize=True, norm3D=False, invert=False, lowhigh=None,
 
     return img_norm
 
-def resize_save(img, Ly, Lx, interpolation=cv2.INTER_LINEAR):
+def resize_safe(img, Ly, Lx, interpolation=cv2.INTER_LINEAR):
     """OpenCV resize function does not support uint32. 
     
     This function converts the image to float32 before resizing and then converts it back to uint32. Not safe!
@@ -760,9 +760,9 @@ def resize_image(img0, Ly=None, Lx=None, rsz=None, interpolation=cv2.INTER_LINEA
         else:
             imgs = np.zeros((img0.shape[0], Ly, Lx, img0.shape[-1]), np.float32)
         for i, img in enumerate(img0):
-            imgs[i] = resize_save(img, Ly, Lx, interpolation=interpolation)
+            imgs[i] = resize_safe(img, Ly, Lx, interpolation=interpolation)
     else:
-        imgs = resize_save(img0, Ly, Lx, interpolation=interpolation)
+        imgs = resize_safe(img0, Ly, Lx, interpolation=interpolation)
     return imgs
 
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -21,3 +21,22 @@ def test_normalize_img(data_dir):
 
     img_norm = normalize_img(img, norm3D=False, sharpen_radius=8)
     assert img_norm.shape == img.shape
+
+def test_resize(data_dir):
+    img = io.imread(str(data_dir.joinpath('2D').joinpath('rgb_2D_tif.tif')))
+    
+    Lx = 100
+    Ly = 200
+    
+    img8 = resize_image(img.astype("uint8"), Lx=Lx, Ly=Ly)
+    assert img8.shape == (Ly, Lx, 3)
+    assert img8.dtype == np.uint8
+    
+    img16 = resize_image(img.astype("uint16"), Lx=Lx, Ly=Ly)
+    assert img16.shape == (Ly, Lx, 3)
+    assert img16.dtype == np.uint16
+    
+    img32 = resize_image(img.astype("uint32"), Lx=Lx, Ly=Ly)
+    assert img32.shape == (Ly, Lx, 3)
+    assert img32.dtype == np.uint32
+    


### PR DESCRIPTION
Related to issue #937

When Cellpose detect over 65,535 it casts the masks vector to `uint32`. However, this format is not natively supported by OpenCV, causing its `resize` function to crash. See issue #937 for more information. 

This PR proposes to use float32 instead, which is supported by OpenCV, and includes the following changes

* If the datatype is `uint32`, first cast to `float32`, resize using `cv2`, round and cast resulting matrix to `uint32`.
* Throw a warning if casting to `float32` happens
* Adding tests to confirm that previous and new function work as expected

This PR also considers three implications:

* Time complexity: Casting datatypes is driving the increase in time complexity, causing a 5x to 30x increase. However, in this case it is almost neglectable. A 10,000 x 10,000 image on 32 cores then requires 0.47s compared to 0.02s.
* Memory requirements: Float32 will increase memory requirements. The implications are not yet tested.
* Numerical stability: Multiple tests have shown that `uint16` and the proposed approach which casts to `float32` yield identical results.

Reproducible examples

```
import cv2
import numpy as np

img16 = np.random.randint(0, 65535, size=(1000, 1000, 3)).astype("uint16")
img32 = img16.astype("uint32")

# UINT16: Succeeds
img16r = cv2.resize(img16, (300, 600))

# UINT32: Fails
img32r = cv2.resize(img32, (300, 600))

# FLOAT32: Succeeds (proposed approach)
img32r = cv2.resize(img32.astype("float32"), (300, 600)).round().astype("uint32")

# Identity
(img16r == img32r).mean()
```