### PR TITLE
Downgraded `numpy` to be less then version 2.0.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - pip:
     - qtpy
 #    - PyQt5.sip
-    - numpy>=1.20.0
+    - numpy>=1.20.0,<2.0.0
     - numba>=0.43.1
     - scipy
     - torch>=1.6
@@ -19,4 +19,3 @@ dependencies:
     - cellpose
     - roifile
     - pyqt5
-  


### PR DESCRIPTION
Installing `cellpose` sometimes gives errors due to `numpy` version