### PR TITLE
`imagecodecs` no longer compiles with `python 3.8`

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ If you are using a GPU, make sure its drivers and the cuda libraries are correct
 
 1. Install an [Anaconda](https://www.anaconda.com/products/distribution) distribution of Python. Note you might need to use an anaconda prompt if you did not add anaconda to the path.
 2. Open an anaconda prompt / command prompt which has `conda` for **python 3** in the path
-3. Create a new environment with `conda create --name cellpose python=3.8`. We recommend python 3.8, but python 3.9 and 3.10 will likely work as well.
+3. Create a new environment with `conda create --name cellpose python=3.9`. We recommend python 3.9, but python 3.10 will likely work as well.
 4. To activate this new environment, run `conda activate cellpose`
 5. To install the minimal version of cellpose, run `python -m pip install cellpose`.  
 6. To install cellpose and the GUI, run `python -m pip install cellpose[gui]`. If you're on a zsh server, you may need to use ' ' around the cellpose[gui] call: `python -m pip install 'cellpose[gui]'`.


### PR DESCRIPTION
Changed minimum python requirement to 3.9