### PR TITLE
Fix intensity normalizations

### DIFF
--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -393,7 +393,7 @@ def move_min_dim(img, force=False):
 
     Args:
         img (ndarray): The input image.
-        force (bool, optional): If True, the minimum dimension will always be moved. 
+        force (bool, optional): If True, the minimum dimension will always be moved.
             Defaults to False.
 
     Returns:
@@ -668,7 +668,7 @@ def normalize_img(img, normalize=True, norm3D=False, invert=False, lowhigh=None,
                                                            c], lower=percentile[0],
                                                   upper=percentile[1], copy=False)
         if (tile_norm_blocksize > 0 or normalize) and invert:
-            img_norm[..., c] = -1 * img_norm[..., c] + 1
+            img_norm[..., 0] = -1 * img_norm[..., 0] + 1
         elif invert:
             error_message = "cannot invert image without normalizing"
             transforms_logger.critical(error_message)
@@ -690,7 +690,7 @@ def resize_image(img0, Ly=None, Lx=None, rsz=None, interpolation=cv2.INTER_LINEA
         Lx (int, optional): Desired width of the resized image. Defaults to None.
         rsz (float, optional): Resize coefficient(s) for the image. If Ly is None, rsz is used. Defaults to None.
         interpolation (int, optional): OpenCV interpolation method. Defaults to cv2.INTER_LINEAR.
-        no_channels (bool, optional): Flag indicating whether to treat the third dimension as a channel. 
+        no_channels (bool, optional): Flag indicating whether to treat the third dimension as a channel.
             Defaults to False.
 
     Returns:
@@ -742,8 +742,8 @@ def pad_image_ND(img0, div=16, extra=1, min_size=None):
         extra (int, optional): Extra padding. Defaults to 1.
         min_size (tuple, optional): Minimum size of the image. Defaults to None.
 
-    Returns:   
-        tuple containing 
+    Returns:
+        tuple containing
             - I (ndarray): Padded image.
             - ysub (ndarray): Y range of pixels in the padded image corresponding to img0.
             - xsub (ndarray): X range of pixels in the padded image corresponding to img0.

--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -638,9 +638,13 @@ def normalize_img(img, normalize=True, norm3D=False, invert=False, lowhigh=None,
     nchan = img_norm.shape[-1]
 
     if lowhigh is not None:
+        new_min, new_max = lowhigh
         for c in range(nchan):
-            img_norm[...,
-                     c] = (img_norm[..., c] - lowhigh[0]) / (lowhigh[1] - lowhigh[0])
+            c_min = img_norm[..., c].min()
+            c_max = img_norm[..., c].max()
+            eps = 1.0e-6
+            img_norm[..., c] = (img_norm[..., c] - c_min) / (c_max - c_min + eps)
+            img_norm[..., c] = img_norm[..., c] * (new_max - new_min) + new_min
     else:
         if sharpen_radius > 0 or smooth_radius > 0:
             img_norm = smooth_sharpen_img(img_norm, sharpen_radius=sharpen_radius,

--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -642,10 +642,10 @@ def normalize_img(img, normalize=True, norm3D=False, invert=False, lowhigh=None,
     # Validate and handle lowhigh bounds
     if lowhigh is not None:
         lowhigh = np.array(lowhigh)
-        if lowhigh.ndim == 1:
-            lowhigh = np.tile(lowhigh, (nchan, 1))
+        if lowhigh.shape == (2,):
+            lowhigh = np.tile(lowhigh, (nchan, 1))  # Expand to per-channel bounds
         elif lowhigh.shape != (nchan, 2):
-            error_message = "`lowhigh` must have shape (nchan, 2)"
+            error_message = "`lowhigh` must have shape (2,) or (nchan, 2)"
             transforms_logger.critical(error_message)
             raise ValueError(error_message)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,51 +1,61 @@
 import numpy as np
+import pytest
 
 from cellpose.io import imread
 from cellpose.transforms import normalize_img, random_rotate_and_resize, resize_image
 
 
+@pytest.fixture
+def img_3d(data_dir):
+    """Fixture to load 3D image data for tests."""
+    img = imread(str(data_dir.joinpath('3D').joinpath('rgb_3D.tif')))
+    return img.transpose(0, 2, 3, 1).astype('float32')
+
+
+@pytest.fixture
+def img_2d(data_dir):
+    """Fixture to load 2D image data for tests."""
+    return imread(str(data_dir.joinpath('2D').joinpath('rgb_2D_tif.tif')))
+
+
 def test_random_rotate_and_resize__default():
     nimg = 2
     X = [np.random.rand(64, 64) for i in range(nimg)]
-
     random_rotate_and_resize(X)
 
 
-def test_normalize_img(data_dir):
-    img = imread(str(data_dir.joinpath('3D').joinpath('rgb_3D.tif')))
-    img = img.transpose(0, 2, 3, 1).astype('float32')
+def test_normalize_img(img_3d):
+    img_norm = normalize_img(img_3d, norm3D=True)
+    assert img_norm.shape == img_3d.shape
 
-    img_norm = normalize_img(img, norm3D=True)
-    assert img_norm.shape == img.shape
+    img_norm = normalize_img(img_3d, norm3D=True, tile_norm_blocksize=25)
+    assert img_norm.shape == img_3d.shape
 
-    img_norm = normalize_img(img, norm3D=True, tile_norm_blocksize=25)
-    assert img_norm.shape == img.shape
-
-    img_norm = normalize_img(img, norm3D=False, sharpen_radius=8)
-    assert img_norm.shape == img.shape
+    img_norm = normalize_img(img_3d, norm3D=False, sharpen_radius=8)
+    assert img_norm.shape == img_3d.shape
 
 
-def test_normalize_img_with_lowhigh_and_invert(data_dir):
-    img = imread(str(data_dir.joinpath('3D').joinpath('rgb_3D.tif')))
-    img = img.transpose(0, 2, 3, 1).astype('float32')
+def test_normalize_img_with_lowhigh_and_invert(img_3d):
+    img_norm = normalize_img(img_3d, lowhigh=(img_3d.min() + 1, img_3d.max() - 1))
+    assert img_norm.min() < 0 and img_norm.max() > 1
 
-    img_norm = normalize_img(img, lowhigh=(img.min(), img.max()))
-    assert img_norm.min() >= 0 and img_norm.max() <= 1
+    img_norm = normalize_img(img_3d, lowhigh=(img_3d.min(), img_3d.max()))
+    assert 0 <= img_norm.min() < img_norm.max() <= 1
 
     img_norm_channelwise = normalize_img(
-        img,
+        img_3d,
         lowhigh=(
-            (img[..., 0].min(), img[..., 0].max()),
-            (img[..., 1].min(), img[..., 1].max()),
+            (img_3d[..., 0].min(), img_3d[..., 0].max()),
+            (img_3d[..., 1].min(), img_3d[..., 1].max()),
         ),
     )
     assert img_norm_channelwise.min() >= 0 and img_norm_channelwise.max() <= 1
 
     img_norm_channelwise_inverted = normalize_img(
-        img,
+        img_3d,
         lowhigh=(
-            (img[..., 0].min(), img[..., 0].max()),
-            (img[..., 1].min(), img[..., 1].max()),
+            (img_3d[..., 0].min(), img_3d[..., 0].max()),
+            (img_3d[..., 1].min(), img_3d[..., 1].max()),
         ),
         invert=True,
     )
@@ -54,20 +64,41 @@ def test_normalize_img_with_lowhigh_and_invert(data_dir):
     )
 
 
-def test_resize(data_dir):
-    img = imread(str(data_dir.joinpath('2D').joinpath('rgb_2D_tif.tif')))
+def test_normalize_img_exceptions(img_3d):
+    img_2D = img_3d[0, ..., 0]
+    with pytest.raises(ValueError):
+        normalize_img(img_2D)
 
+    with pytest.raises(ValueError):
+        normalize_img(img_3d, lowhigh=(0, 1, 2))
+
+    with pytest.raises(ValueError):
+        normalize_img(img_3d, lowhigh=((0, 1), (0, 1, 2)))
+
+    with pytest.raises(ValueError):
+        normalize_img(img_3d, lowhigh=((0, 1),) * 4)
+
+    with pytest.raises(ValueError):
+        normalize_img(img_3d, percentile=(1, 101))
+
+    with pytest.raises(ValueError):
+        normalize_img(
+            img_3d, lowhigh=None, tile_norm_blocksize=0, normalize=False, invert=True
+        )
+
+
+def test_resize(img_2d):
     Lx = 100
     Ly = 200
 
-    img8 = resize_image(img.astype("uint8"), Lx=Lx, Ly=Ly)
+    img8 = resize_image(img_2d.astype("uint8"), Lx=Lx, Ly=Ly)
     assert img8.shape == (Ly, Lx, 3)
     assert img8.dtype == np.uint8
 
-    img16 = resize_image(img.astype("uint16"), Lx=Lx, Ly=Ly)
+    img16 = resize_image(img_2d.astype("uint16"), Lx=Lx, Ly=Ly)
     assert img16.shape == (Ly, Lx, 3)
     assert img16.dtype == np.uint16
 
-    img32 = resize_image(img.astype("uint32"), Lx=Lx, Ly=Ly)
+    img32 = resize_image(img_2d.astype("uint32"), Lx=Lx, Ly=Ly)
     assert img32.shape == (Ly, Lx, 3)
     assert img32.dtype == np.uint32

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -13,6 +13,9 @@ def test_normalize_img(data_dir):
     img = io.imread(str(data_dir.joinpath('3D').joinpath('rgb_3D.tif')))
     img = img.transpose(0, 2, 3, 1).astype('float32')
 
+    img_norm = normalize_img(img, lowhigh=(0, 1))
+    assert img_norm.min() >= 0 and img_norm.max() <= 1
+
     img_norm = normalize_img(img, norm3D=True)
     assert img_norm.shape == img.shape
 


### PR DESCRIPTION
Hi @carsen-stringer!

During the process of packaging the custom Cellpose model for bioimage.io, I identified two potential issues with the intensity normalization implementation in Cellpose. This PR proposes fixes for:

1. The current normalization with the `lowhigh` argument is not channel-wise. In this PR, `lowhigh` now either takes a 2-tuple `(low, high)` for all channels, or a `nchan`-tuple of that for each channel.
2. The current invert mechanism does not necessarily invert the channel to be segmented (`--chan`); instead, it inverts the last channel. Depending on the `--chan2` value, this might not be the intended channel. In this PR, all channels are inverted if `invert`.

<details>

<summary>Original PR message on 25 Jul 2024</summary>

## Original PR

Hi @carsen-stringer!

During the process of packaging the custom Cellpose model for bioimage.io, I identified two potential issues with the intensity normalization implementation in Cellpose. This PR proposes fixes for:

1. The current min-max normalization with the `lowhigh` argument is not channel-wise, and the argument itself might be misused.
2. The current invert mechanism does not necessarily invert the channel to be segmented (`--chan`); instead, it inverts the last channel. Depending on the `--chan2` value, this might not be the intended channel.

Please review these changes as I might have misunderstood some parts.

----

### Fix for Min-Max Normalization by 31bc5befb3573f9dd0cc46db392788fe32c96bcd

For `cellpose.transforms.normalize_img()` (channel-wise normalization), the `lowhigh` option is provided. I assume this corresponds to min-max normalization where `lowhigh` is a tuple representing (new minimum, new maximum).
https://github.com/MouseLand/cellpose/blob/84344b0ceb6eb91e759301fbdad5c9b77a1c881b/cellpose/transforms.py#L600-L601

If `lowhigh` represents (old minimum, old maximum), then normalization is not channel-wise if `lowhigh` has a length of 2:
https://github.com/MouseLand/cellpose/blob/84344b0ceb6eb91e759301fbdad5c9b77a1c881b/cellpose/transforms.py#L624-L626

In either case, the implementation needs fixing:
https://github.com/MouseLand/cellpose/blob/84344b0ceb6eb91e759301fbdad5c9b77a1c881b/cellpose/transforms.py#L640-L643
The current implementation is essentially: `img_norm = (img_norm - lowhigh[0]) / (lowhigh[1] - lowhigh[0])`

This has been fixed by commit 31bc5befb3573f9dd0cc46db392788fe32c96bcd.

----

### Fix for Invert by 91469d1273ee0b3e3e4f614d0e8a80b0587ceb40

For `cellpose.transforms.normalize_img()` (channel-wise normalization), there is an `invert` option for cases where "cells are dark instead of bright":
https://github.com/MouseLand/cellpose/blob/84344b0ceb6eb91e759301fbdad5c9b77a1c881b/cellpose/transforms.py#L598-L599

In Cellpose, the invert function is performed after `reshape()`, which moves the main channel to channel 0 and the auxiliary channel to channel 1. Therefore, the primary use case is to invert the first channel (channel 0) instead of the last one (current implementation):
https://github.com/MouseLand/cellpose/blob/84344b0ceb6eb91e759301fbdad5c9b77a1c881b/cellpose/transforms.py#L666-L667

The variable `c` retains the value from a previous loop, being 1 if `nchan` is 2 or 2 if `nchan` is 3.

This has been fixed by commit 91469d1273ee0b3e3e4f614d0e8a80b0587ceb40, but further improvements can be made to allow for a user-specified list of channels to be inverted.

</details>