### PR TITLE
do not attempt to merge masks when nothing is selected

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1445,6 +1445,8 @@ class MainW(QMainWindow):
             self.remove_roi(self.remove_roi_obj)
 
     def merge_cells(self, idx):
+        if self.selected == 0:
+            return
         self.prev_selected = self.selected
         self.selected = idx
         if self.selected != self.prev_selected:


### PR DESCRIPTION
The converse of this change was already present in the code ("ignore attempted merges on non-masked position"), but this makes that behavior symmetric.