### PR TITLE
GUI selection for SGD/RAdam Training

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -295,6 +295,7 @@ class MainW(QMainWindow):
             "learning_rate": 0.1,
             "weight_decay": 0.0001,
             "n_epochs": 100,
+            "SGD": True,
             "model_name": "CP" + d.strftime("_%Y%m%d_%H%M%S"),
         }
 
@@ -2170,13 +2171,15 @@ class MainW(QMainWindow):
         save_path = os.path.dirname(self.filename)
 
         print("GUI_INFO: name of new model: " + self.training_params["model_name"])
+        print(f"GUI_INFO: SGD activated: {self.training_params['SGD']}")
         self.new_model_path, train_losses = train.train_seg(
             self.model.net, train_data=self.train_data, train_labels=self.train_labels,
             channels=self.channels, normalize=normalize_params, min_train_masks=0,
-            save_path=save_path, nimg_per_epoch=max(8, len(self.train_data)), SGD=True,
+            save_path=save_path, nimg_per_epoch=max(8, len(self.train_data)),
             learning_rate=self.training_params["learning_rate"],
             weight_decay=self.training_params["weight_decay"],
             n_epochs=self.training_params["n_epochs"],
+            SGD=self.training_params["SGD"],
             model_name=self.training_params["model_name"])[:2]
         # save train losses
         np.save(str(self.new_model_path) + "_train_losses.npy", train_losses)

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -237,9 +237,6 @@ class TrainWindow(QDialog):
         use_SGD = "SGD"
         self.useSGD = QCheckBox(f"{use_SGD}")
         self.useSGD.setChecked(True)
-        # self.edits[-1].setText(str(use_SGD))
-        # self.edits[-1].setFixedWidth(200)
-        # self.l0.addWidget(self.edits[-1], i + yoff, 1, 1, 1)
         self.l0.addWidget(self.useSGD, i+yoff, 1, 1, 1)
 
         yoff += len(labels)

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -233,6 +233,15 @@ class TrainWindow(QDialog):
             self.edits[-1].setFixedWidth(200)
             self.l0.addWidget(self.edits[-1], i + yoff, 1, 1, 1)
 
+        yoff += 1
+        use_SGD = "SGD"
+        self.useSGD = QCheckBox(f"{use_SGD}")
+        self.useSGD.setChecked(True)
+        # self.edits[-1].setText(str(use_SGD))
+        # self.edits[-1].setFixedWidth(200)
+        # self.l0.addWidget(self.edits[-1], i + yoff, 1, 1, 1)
+        self.l0.addWidget(self.useSGD, i+yoff, 1, 1, 1)
+
         yoff += len(labels)
 
         yoff += 1
@@ -289,6 +298,7 @@ class TrainWindow(QDialog):
             "weight_decay": float(self.edits[1].text()),
             "n_epochs": int(self.edits[2].text()),
             "model_name": self.edits[3].text(),
+            "SGD": True if self.useSGD.isChecked() else False,
             #"use_norm": True if self.use_norm.isChecked() else False,
         }
         self.done(1)


### PR DESCRIPTION
On the [image.sc forum](https://forum.image.sc/), user Brian Northan and I have found questions regarding zero masks being found during Cellpose GUI model training. Issues reported: [1](https://forum.image.sc/t/cellpose-v2-2-3-constantly-zero-0-roi-after-training/), [2](https://forum.image.sc/t/cellpose-no-pixels-found-after-successful-training/100481/3), and [3](https://forum.image.sc/t/cellpose-model-training/98582/7).

We reason that the SGD solver might be overly restrictive. Based on Brian's and my testing [here](https://forum.image.sc/t/cellpose-v2-2-3-constantly-zero-0-roi-after-training/101801/14?u=ianfc), it seems that at least at low epoch numbers, certain sets of training images will result in 0 masks while using SGD.

This PR also addresses/closes issues #947 and #1017 

As such, this PR adds a QCheckBox which defaults to SGD, but allows users to choose the option of the RAdam solver. It follows the same pattern as other parameters and I was able to use it successfully.