### PR TITLE
File selection cancel logic added

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -107,6 +107,8 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
     if filename is None:
         name = QFileDialog.getOpenFileName(parent, "Load image")
         filename = name[0]
+        if filename == "":
+            return
     manual_file = os.path.splitext(filename)[0] + "_seg.npy"
     load_mask = False
     if load_seg:


### PR DESCRIPTION
In current version, 9398cacda54f17103638d69a23c915a32fcc1abb, the gui.io module uses `qtpy.QtWidgets.QFileDialog` to prompt the user for an input image.

https://github.com/MouseLand/cellpose/blob/9398cacda54f17103638d69a23c915a32fcc1abb/cellpose/gui/io.py#L108

However, if the user cancels the file selection, `QFileDialog` returns an empty string, which is then passed to `imread` at line 125. 

https://github.com/MouseLand/cellpose/blob/9398cacda54f17103638d69a23c915a32fcc1abb/cellpose/gui/io.py#L125-L126

Since `imread` has its own error handling, all exceptions are suppressed, and line 126 (`parent.loaded = True`) is executed even if no file is selected.

This behavior is undesired, so a simple filename check has been added to return from the _load_image function without setting `parent.loaded` to `True` if no file is selected.




