### PR TITLE
Update metrics.py

### DIFF
--- a/cellpose/metrics.py
+++ b/cellpose/metrics.py
@@ -118,8 +118,8 @@ def average_precision(masks_true, masks_pred, threshold=[0.5, 0.75, 0.9]):
     tp = np.zeros((len(masks_true), len(threshold)), np.float32)
     fp = np.zeros((len(masks_true), len(threshold)), np.float32)
     fn = np.zeros((len(masks_true), len(threshold)), np.float32)
-    n_true = np.array(list(map(np.max, masks_true)))
-    n_pred = np.array(list(map(np.max, masks_pred)))
+    n_true = np.array([len(np.unique(mt)) - 1 for mt in masks_true])
+    n_pred = np.array([len(np.unique(mp)) - 1 for mp in masks_pred])
 
     for n in range(len(masks_true)):
         #_,mt = np.reshape(np.unique(masks_true[n], return_index=True), masks_pred[n].shape)


### PR DESCRIPTION
### Description:
The original implementation for calculating **n_true** and **n_pred** was based on using **np.max**, which assumes that the mask labels always start from 1 and are consecutive. This implementation can fail in cases where the labels start from an arbitrary number (e.g., 5, 6, 7...) or are cropped, leading to incorrect counts.

To address this, the code has been updated to use **np.unique**. The new approach ensures that the calculation of the number of unique labels in each mask is robust and independent of the starting value of the labels. Subtracting 1 accounts for the background label (assumed to be 0).

### Changes Made:
Replaced the **np.max** approach with **len(np.unique(mask)) - 1** to count the number of unique labels in each mask, excluding the background label.
Used a list comprehension to ensure this works for all elements in **masks_true** and **masks_pred**.

### Benefits:
_Robustness:_ The new implementation works regardless of the starting value of the labels or whether they are consecutive.
_Generality:_ It ensures consistent behavior for cropped images or cases with arbitrary label ranges.
_Correctness:_ Avoids errors caused by relying on **np.max** when the labels are not consecutive.

### Example:
Original Code:
```
masks_true = [np.array([0, 1, 2, 3]), np.array([0, 4, 5, 6])]
n_true = np.array(list(map(np.max, masks_true)))  # Incorrectly assumes max gives count
print(n_true)  # Output: [3, 6]
```

### Updated Code:
```
masks_true = [np.array([0, 1, 2, 3]), np.array([0, 4, 5, 6])]
n_true = np.array([len(np.unique(mask)) - 1 for mask in masks_true])
print(n_true)  # Output: [3, 3]
```

This refactor ensures that the calculation of n_true and n_pred is accurate and adaptable to a variety of label formats.