### PR TITLE
Bugfix: Removing unused 'ARBITRARY_SIZE'

### DIFF
--- a/cellpose/export.py
+++ b/cellpose/export.py
@@ -79,6 +79,12 @@ from bioimageio.spec.model.v0_5 import (
     Version,
     WeightsDescr,
 )
+# Define ARBITRARY_SIZE if it is not available in the module
+try:
+    from bioimageio.spec.model.v0_5 import ARBITRARY_SIZE
+except ImportError:
+    ARBITRARY_SIZE = 1  # or set to a default value if appropriate
+
 from bioimageio.spec.common import HttpUrl
 from bioimageio.spec import save_bioimageio_package
 from bioimageio.core import test_model

--- a/cellpose/export.py
+++ b/cellpose/export.py
@@ -83,7 +83,7 @@ from bioimageio.spec.model.v0_5 import (
 try:
     from bioimageio.spec.model.v0_5 import ARBITRARY_SIZE
 except ImportError:
-    ARBITRARY_SIZE = 1  # or set to a default value if appropriate
+    ARBITRARY_SIZE = ParameterizedSize(min=1, step=1)
 
 from bioimageio.spec.common import HttpUrl
 from bioimageio.spec import save_bioimageio_package

--- a/cellpose/export.py
+++ b/cellpose/export.py
@@ -54,7 +54,6 @@ from cellpose.transforms import pad_image_ND, normalize_img, convert_image
 from cellpose.resnet_torch import CPnetBioImageIO
 
 from bioimageio.spec.model.v0_5 import (
-    ARBITRARY_SIZE,
     ArchitectureFromFileDescr,
     Author,
     AxisId,


### PR DESCRIPTION
Found error:
Traceback (most recent call last):
  File "/home/pablo/mambaforge/envs/colab_cellpose/lib/python3.10/site-packages/cellpose/export.py", line 56, in <module>
    from bioimageio.spec.model.v0_5 import (
ImportError: cannot import name 'ARBITRARY_SIZE' from 'bioimageio.spec.model.v0_5' (/home/pablo/mambaforge/envs/colab_cellpose/lib/python3.10/site-packages/bioimageio/spec/model/v0_5.py)

It turns out, they removed 'ARBITRARY_SIZE':
https://github.com/bioimage-io/spec-bioimage-io/commit/39d343681d427ec93cf69eef7597d9eb9678deb1

By removing the parameter, this code will work again.