### PR TITLE
feat: custom output name

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -31,7 +31,7 @@ def main():
     """
 
     args = get_arg_parser().parse_args(
-    )  # this has to be in a seperate file for autodoc to work
+    )  # this has to be in a separate file for autodoc to work
 
     if args.version:
         print(version_str)
@@ -240,8 +240,19 @@ def main():
                                           diams=diams, restore_type=restore_type,
                                           ratio=1.)
                 if saving_something:
-                    suffix = args.output_name if len(args.output_name) > 0 else "_cp_masks"
-                    io.save_masks(image, masks, flows, image_name, 
+
+                    # `savedir` not define..
+                    if args.savedir == None:
+                        # ..imposes `suffix` to exists, otherwise default value
+                        suffix = args.output_name if len(args.output_name) > 0 else "_cp_masks"
+                    # `savedir` defined..
+                    else:
+                        # ..and different than `dir`..
+                        if args.savedir != args.dir:
+                            #..allows `suffix` to be null
+                            suffix = args.output_name
+
+                    io.save_masks(image, masks, flows, image_name,
                                   suffix=suffix, png=args.save_png,
                                   tif=args.save_tif, save_flows=args.save_flows,
                                   save_outlines=args.save_outlines,

--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -240,17 +240,13 @@ def main():
                                           diams=diams, restore_type=restore_type,
                                           ratio=1.)
                 if saving_something:
-
-                    # `savedir` not define..
-                    if args.savedir == None:
-                        # ..imposes `suffix` to exists, otherwise default value
-                        suffix = args.output_name if len(args.output_name) > 0 else "_cp_masks"
-                    # `savedir` defined..
-                    else:
-                        # ..and different than `dir`..
-                        if args.savedir != args.dir:
-                            #..allows `suffix` to be null
-                            suffix = args.output_name
+                    if args.savedir == None:            # (1) If `savedir` is not defined,
+                        if len(args.output_name) > 0:   # then must have a non-zero `suffix`
+                            suffix = args.output_name   # which takes the value passes as a param.,
+                        else: suffix = "_cp_masks"      # otherwise is the default value.
+                    else:                               # (2) If `savedir` is defined,
+                        if args.savedir != args.dir:    # and different from `dir` then
+                            suffix = args.output_name   # takes the value passed as a param. (which can be empty string)!
 
                     io.save_masks(image, masks, flows, image_name,
                                   suffix=suffix, png=args.save_png,

--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -246,7 +246,8 @@ def main():
                         else: suffix = "_cp_masks"      # otherwise is the default value.
                     else:                               # (2) If `savedir` is defined,
                         if args.savedir != args.dir:    # and different from `dir` then
-                            suffix = args.output_name   # takes the value passed as a param. (which can be empty string)!
+                            suffix = args.output_name   # takes the value passed as a param. (which can be empty string),
+                        else: suffix = "_cp_masks"      # otherwise is the default value.
 
                     io.save_masks(image, masks, flows, image_name,
                                   suffix=suffix, png=args.save_png,

--- a/cellpose/cli.py
+++ b/cellpose/cli.py
@@ -148,7 +148,7 @@ def get_arg_parser():
         help="save masks as tif and outlines as text file for ImageJ")
     output_args.add_argument(
         "--output_name", default=[], type=str,
-        help="suffix for saved masks, default is _cp_masks")
+        help="suffix for saved masks, default is _cp_masks, can be empty if `savedir` used and different of `dir`")
     output_args.add_argument("--no_npy", action="store_true",
                              help="suppress saving of npy")
     output_args.add_argument(


### PR DESCRIPTION
### Description
We have got some images in an input A folder and want to use the *MouseLand/cellpose* models on them. These images have a name that makes them unique and identifiable. After processing the *MouseLand/cellpose* models, we would like to have the results for each image in a folder B with the same file names as the input files. So image named X in folder B corresponds to image X in folder A after calculation by the AI.

*MouseLand/cellpose* team already made that possible thanks to the parameters `output_name`. Unfortunately, it's impossible to set this parameter to an empty string, and that's perfectly normal because we do not want to ever over-write someone's original tif.

### Changes made
I have added the check that a different input (`dir`) and output (`savedir`) folders are properly passed as parameters and if so, then you don't need to add anything to the output file (`output_name`) name.

### Benefits
In cases where the input folder (`dir`) and output folder (`savedir`) are defined and different, you can now keep the exact same name for the results files. This simplifies the steps in a complex workflow, where image analysis steps follow one another and file names are used as identifiers.

### Examples

Before:
``` bash
folder_A / X.tif
folder_B /
```

New commands:
```bash
$ cellpose --pretrained_model nuclei --dir ./folder_A/ --savedir ./folder_B/   # (1)
$ cellpose --pretrained_model nuclei --dir ./folder_A/ --savedir ./folder_B/ --output_name '_res'   # (2)
$ cellpose --pretrained_model nuclei --dir ./folder_A/ --savedir ./folder_B/ --output_name ''   # (3)

# (4)
$ cellpose --pretrained_model nuclei --dir ./folder_A/ --output_name ''
```

After new different commands:
``` bash
folder_B / X_cp_masks.tif # (1)
folder_B / X_res.tif # (2)
folder_B / X.tif # (3)

# (4) the user could rewrite the X file, but we prevent this by adding `_cp_masks`
folder_A / X.tif
folder_A / X_cp_masks.tif
```
