### PR TITLE
pyarrow missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ distributed_deps = [
     'zarr',
     'dask_jobqueue',
     'bokeh',
+    'pyarrow',
 ]
 
 bioimageio_deps = [


### PR DESCRIPTION
Annoying, but a library which dask_image depends on, which used to install automatically along the dependency graph, seems to be missing from new installs. Added it to the distributed dependency list.