### PR TITLE
Optimize fill_holes_and_remove_small_masks

### DIFF
--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -640,20 +640,22 @@ def fill_holes_and_remove_small_masks(masks, min_size=15):
         raise ValueError("masks_to_outlines takes 2D or 3D array, not %dD array" %
                          masks.ndim)
 
+    # Filter small masks
+    if min_size > 0:
+        counts = np.bincount(masks.ravel())
+        filter = np.isin(masks, np.where(counts < min_size)[0])
+        masks[filter] = 0
+
     slices = find_objects(masks)
     j = 0
     for i, slc in enumerate(slices):
         if slc is not None:
             msk = masks[slc] == (i + 1)
-            npix = msk.sum()
-            if min_size > 0 and npix < min_size:
-                masks[slc][msk] = 0
-            elif npix > 0:
-                if msk.ndim == 3:
-                    for k in range(msk.shape[0]):
-                        msk[k] = binary_fill_holes(msk[k])
-                else:
-                    msk = binary_fill_holes(msk)
-                masks[slc][msk] = (j + 1)
-                j += 1
+            if msk.ndim == 3:
+                for k in range(msk.shape[0]):
+                    msk[k] = binary_fill_holes(msk[k])
+            else:
+                msk = binary_fill_holes(msk)
+            masks[slc][msk] = (j + 1)
+            j += 1
     return masks

--- a/cellpose/utils.py
+++ b/cellpose/utils.py
@@ -11,6 +11,7 @@ from scipy.spatial import ConvexHull
 import numpy as np
 import colorsys
 import fastremap
+import fill_voids
 from multiprocessing import Pool, cpu_count
 
 from . import metrics
@@ -619,7 +620,7 @@ def size_distribution(masks):
 def fill_holes_and_remove_small_masks(masks, min_size=15):
     """ Fills holes in masks (2D/3D) and discards masks smaller than min_size.
 
-    This function fills holes in each mask using scipy.ndimage.morphology.binary_fill_holes.
+    This function fills holes in each mask using fill_voids.fill.
     It also removes masks that are smaller than the specified min_size.
 
     Parameters:
@@ -652,10 +653,9 @@ def fill_holes_and_remove_small_masks(masks, min_size=15):
         if slc is not None:
             msk = masks[slc] == (i + 1)
             if msk.ndim == 3:
-                for k in range(msk.shape[0]):
-                    msk[k] = binary_fill_holes(msk[k])
+                msk = np.array([fill_voids.fill(msk[k]) for k in range(msk.shape[0])])
             else:
-                msk = binary_fill_holes(msk)
+                msk = fill_voids.fill(msk)
             masks[slc][msk] = (j + 1)
             j += 1
     return masks

--- a/environment.yml
+++ b/environment.yml
@@ -26,4 +26,5 @@ dependencies:
     - zarr
     - dask_jobqueue
     - bokeh
+    - fill-voids
   

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_deps = [
     'fastremap',
     'imagecodecs',
     'roifile',
+    'fill-voids',
 ]
 
 image_deps = ['nd2', 'pynrrd']


### PR DESCRIPTION
### Identifying and replacing bottlenecks in the `fill_holes_and_remove_small_masks` function

For my own projects, I was depending on `fill_holes_and_remove_small_masks`, which would often slow down the processing throughput of large datasets. I managed to narrow down the bottleneck to `scipy.ndimage.morphology.binary_fill_holes`. When this is replaced by a more optimized algorithm like `fill_voids.fill` ([documentation](https://github.com/seung-lab/fill_voids)), we can get massive speedups, especially since it can easily be rewritten into a multithreaded calculation in this way.

Another change proposed in this PR is the separation of small mask filtering and the fill_holes operation. This approach results in rapid filtering of small masks by counting the labels in the flattened label image (so it supports 2D & 3D) using `np.bincount`. If any of the counts are below `min_size`, they are set to 0 through the `np.isin` filter. The advantage of splitting the for-loop into two components is that we can now omit calculating the sum of every individual mask, which saves more time in the end.