### PR TITLE
Correct GUI initialization order of load_3D for modular usage. 

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -283,6 +283,8 @@ class MainW(QMainWindow):
         self.ratio = 1.
         self.reset()
 
+        self.load_3D = False
+
         # if called with image, load it
         if image is not None:
             self.filename = image
@@ -299,7 +301,6 @@ class MainW(QMainWindow):
             "model_name": "CP" + d.strftime("_%Y%m%d_%H%M%S"),
         }
 
-        self.load_3D = False
         self.stitch_threshold = 0.
         self.flow3D_smooth = 0.
         self.anisotropy = 1.


### PR DESCRIPTION
When gui.MainW is imported and used in another GUI application, it fails to initialize correctly. This PR addresses this by moving the self.load_3D = False initialization before io._load_image is called. This change resolves the issue without affecting standard Cellpose usage from the command line.