### PR TITLE
fixed "RuntimeError: structure and input must have equal rank"

### DIFF
--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -866,13 +866,13 @@ def block_face_adjacency_graph(faces, nlabels):
     # print("Final nlabels:", nlabels, "Type:", type(nlabels))
 
     all_mappings = []
-    structure = scipy.ndimage.generate_binary_structure(3, 1)
     for face in faces:
         sl0 = tuple(slice(0, 1) if d==2 else slice(None) for d in face.shape)
         sl1 = tuple(slice(1, 2) if d==2 else slice(None) for d in face.shape)
         a = shrink_labels(face[sl0], 1.0)
         b = shrink_labels(face[sl1], 1.0)
         face = np.concatenate((a, b), axis=np.argmin(a.shape))
+        structure = scipy.ndimage.generate_binary_structure(face.ndim, 1)
         mapped = dask_image.ndmeasure._utils._label._across_block_label_grouping(face, structure)
         all_mappings.append(mapped)
     i, j = np.concatenate(all_mappings, axis=1)


### PR DESCRIPTION
In `block_face_adjacency_graph` function of `distributed_segmentation` the assumption for the face dimensions is 3D while it will raise an error if you pass 2D input (blocks).
```python
File /miniforge3/envs/cellpose/lib/python3.10/site-packages/scipy/ndimage/_measurements.py:182, in label(input, structure, output)
    180 structure = np.asarray(structure, dtype=bool)
    181 if structure.ndim != input.ndim:
--> 182     raise RuntimeError('structure and input must have equal rank')
```

I update the code so the *structure* will have the same rank as the *face* ([here](https://github.com/mese79/cellpose/blob/5366069fe0d2a37babdbfd064627fcfd8ee1a359/cellpose/contrib/distributed_segmentation.py#L875)):
```python
structure = scipy.ndimage.generate_binary_structure(face.ndim, 1)
```
