### PR TITLE
Report errors when saving masks to *_seg.npy

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -664,7 +664,6 @@ def _save_sets(parent):
         }
         if parent.restore is not None:
             dat["img_restore"] = parent.stack_filtered
-        np.save(base + "_seg.npy", dat)
     else:
         dat = {
             "outlines":
@@ -705,7 +704,10 @@ def _save_sets(parent):
         }
         if parent.restore is not None:
             dat["img_restore"] = parent.stack_filtered
+    try:
         np.save(base + "_seg.npy", dat)
+        print("GUI_INFO: %d ROIs saved to %s" % (parent.ncells, base + "_seg.npy"))
+    except Exception as e:
+        print(f"ERROR: {e}")
     del dat
     #print(parent.point_sets)
-    print("GUI_INFO: %d ROIs saved to %s" % (parent.ncells, base + "_seg.npy"))


### PR DESCRIPTION
Currently, in the GUI, when saving the masks in a `*_seg.npy` file fails, no error message is printed and the process silently stops in the call to `np.save` in `gui/io.py`, function `_save_sets`.

With this PR, an error message would be displayed, giving hints about the cause of the failure (e.g. ``permission denied''), and the process would go further (e.g. updating the graphical display if needed, which should happen even if the call to `np.save` failed).