### PR TITLE
zero out channels that aren't normazlied

### DIFF
--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -746,6 +746,14 @@ def normalize_img(img, normalize=True, norm3D=True, invert=False, lowhigh=None,
     if axis != -1 and axis != img_norm.ndim - 1:
         img_norm = np.moveaxis(img_norm, -1, axis)
 
+    # The transformer can get confused if a channel is all 1's instead of all 0's:
+    for i, chan_did_normalize in enumerate(cgood):
+        if not chan_did_normalize:
+            if img_norm.ndim == 3:
+                img_norm[:, :, i] = 0
+            if img_norm.ndim == 4:
+                img_norm[0, :, :, i] = 0
+
     return img_norm
 
 def resize_safe(img, Ly, Lx, interpolation=cv2.INTER_LINEAR):


### PR DESCRIPTION
This PR resolves an issue where the transformer model behaved inconsistently depending on how extra input channels were padded. Specifically, CP4 failed to recognize some cells that CP3 detected, due to differences in input normalization when additional channels were present.

Previously, extra channels (e.g., the 2nd and 3rd channels in grayscale images or the 3rd in RGB) were padded with ones after normalization. 

This change ensures that all extra channels are consistently padded with zeros, preventing the transformer from interpreting the padding as meaningful signal.