### PR TITLE
Correct file-filter condition in train_Cellpose-SAM.ipynb

### DIFF
--- a/notebooks/train_Cellpose-SAM.ipynb
+++ b/notebooks/train_Cellpose-SAM.ipynb
@@ -179,7 +179,7 @@
         "# ^ assumes images from Cellpose GUI, if labels are tiffs, then \"_masks.tif\"\n",
         "\n",
         "# list all files\n",
-        "files = [f for f in Path(train_dir).glob(\"*\") if \"_masks\" not in f.name and \"_flows\" not in f.name and \"_seg\" not in name]\n",
+        "files = [f for f in Path(train_dir).glob(\"*\") if \"_masks\" not in f.name and \"_flows\" not in f.name and \"_seg\" not in f.name]\n",
         "\n",
         "if(len(files)==0):\n",
         "  raise FileNotFoundError(\"no files found, did you specify the correct folder and extension?\")\n",


### PR DESCRIPTION
## What’s changed
The list comprehension that gathers training images was mistakenly checking "_seg" not in name—but name didn’t exist in that context. As a result, files ending in "_seg" weren’t being filtered out properly.

#### Original
```
# list all files
files = [f for f in Path(train_dir).glob("*") if "_masks" not in f.name and "_flows" not in f.nameand "_seg" not in name]
```

#### Fixed
```
# list all files
files = [f for f in Path(train_dir).glob("*") if "_masks" not in f.name and "_flows" not in f.name and "_seg" not in f.name]
```

### Why this matters
- Bug: The undefined name variable meant the "_seg" filter never ran.
- Correct behavior: Now any file whose filename contains "_seg" is properly excluded.

### Testing
Ran the script on a directory with mixed filenames (image1.png, image1_seg.png, image1_masks.png, etc.)

No regressions or new errors.