### PR TITLE
Ansiotropy fix

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -339,8 +339,8 @@ class CellposeModel():
         
         masks, dP, cellprob = masks.squeeze(), dP.squeeze(), cellprob.squeeze()
 
-        # undo diameter resizing:
-        if image_scaling is not None:
+        # undo resizing:
+        if image_scaling is not None or anisotropy is not None:
             if do_3D:
                 # Rescale xy then xz:
                 masks = transforms.resize_image(masks, Ly=Ly_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -132,8 +132,8 @@ def test_cli_3D_diam_anisotropy_shape(data_dir, image_names_3d, diam, aniso):
     clear_output(data_dir, image_names_3d)
     use_gpu = torch.cuda.is_available() or torch.backends.mps.is_available() 
     gpu_string = "--use_gpu" if use_gpu else ""
-    anisotropy_text = f' {'--anisotropy ' + str(aniso) if aniso else ''}'
-    diam_text = f' {'--diameter ' + str(diam) if diam else ''}'
+    anisotropy_text = f" {'--anisotropy ' + str(aniso) if aniso else ''}"
+    diam_text = f" {'--diameter ' + str(diam) if diam else ''}"
     cmd = f"python -m cellpose --image_path {str(data_dir / '3D' / image_names_3d[0])} --do_3D --save_tif {gpu_string} --verbose" + anisotropy_text + diam_text
     print(cmd)
     try:

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -98,6 +98,7 @@ def test_class_3D_one_img(data_dir, image_names_3d, cellposemodel_fixture_2layer
     clear_output(data_dir, image_names_3d)
 
     img_file = data_dir / '3D' / image_names_3d[0]
+    image_name = img_file.name
     img = io.imread_3D(img_file)
     masks_pred, flows_pred, _ = cellposemodel_fixture_2layer.eval(img, do_3D=True, channel_axis=-1, z_axis=0)
 
@@ -125,12 +126,14 @@ def test_cli_2D(data_dir, image_names):
     clear_output(data_dir, image_names)
 
 
+@pytest.mark.parametrize('aniso', [None, 2.5])
 @pytest.mark.slow
-def test_cli_3D_diam(data_dir, image_names_3d):
+def test_cli_3D_diam(data_dir, image_names_3d, aniso):
     clear_output(data_dir, image_names_3d)
-    use_gpu = torch.cuda.is_available()
+    use_gpu = torch.cuda.is_available() or torch.backends.mps.is_available() 
     gpu_string = "--use_gpu" if use_gpu else ""
-    cmd = f"python -m cellpose --image_path {str(data_dir / '3D' / image_names_3d[0])} --do_3D --diameter 25 --save_tif {gpu_string} --verbose"
+    anisotropy_text = f' {'--anisotropy ' + str(aniso) if aniso else ''}'
+    cmd = f"python -m cellpose --image_path {str(data_dir / '3D' / image_names_3d[0])} --do_3D --diameter 25 --save_tif {gpu_string} --verbose" + anisotropy_text
     try:
         cmd_stdout = check_output(cmd, stderr=STDOUT, shell=True).decode()
         print(cmd_stdout)


### PR DESCRIPTION
Anisotropy was running in the CellposeModel.eval() function but was not rescaled after segmentation resulting in incorrectly sized masks. Now, rescaling runs at the end of .eval if anisotropy isn't `None`. 

Also added passing test that failed with previous implementation. The tests require 3d so they only run on local with `--runslow` pytest flag. 

Fixes #1191