### PR TITLE
fix imread_3D for gui 3d image loading

### DIFF
--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -235,7 +235,10 @@ def imread_2D(img_file):
 
 def imread_3D(img_file):
     """
-    Read in a 3D image file and convert it to have a channel axis last. Attempts to do this for multi-channel and grayscale images.
+    Read in a 3D image file and convert it to have a channel axis last automatically. Attempts to do this for multi-channel and grayscale images.
+
+    If multichannel image, the channel axis is assumed to be the smallest dimension, and the z axis is the next smallest dimension. 
+    Use `cellpose.io.imread()` to load the full image without selecting the z and channel axes. 
     
     Args:
         img_file (str): The path to the image file.
@@ -247,16 +250,23 @@ def imread_3D(img_file):
 
     dimension_lengths = list(img.shape)
 
-    # guess at channel axis:
-    channel_axis = np.argmin(img.shape)
-    del dimension_lengths[channel_axis]
-
-    # guess at z axis:
-    z_axis = np.argmin(dimension_lengths)
-
     # grayscale images:
     if img.ndim == 3:
         channel_axis = None
+        # guess at z axis:
+        z_axis = np.argmin(dimension_lengths)
+
+    elif img.ndim == 4:
+        # guess at channel axis:
+        channel_axis = np.argmin(dimension_lengths)
+
+        # guess at z axis: 
+        # set channel axis to max so argmin works:
+        dimension_lengths[channel_axis] = max(dimension_lengths)
+        z_axis = np.argmin(dimension_lengths)
+
+    else: 
+        raise ValueError(f'image shape error, 3D image must 3 or 4 dimensional. Number of dimensions: {img.ndim}')
     
     try:
         return transforms.convert_image(img, channel_axis=channel_axis, z_axis=z_axis, do_3D=True)


### PR DESCRIPTION
imread_3D was guessing at the axes incorrectly and wouldn't read gray 3D images correctly. Now it will guess better. 

fix #1158