### PR TITLE
No masks fix

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -197,7 +197,7 @@ class CellposeModel():
             tile_overlap (float, optional): fraction of overlap of tiles when computing flows. Defaults to 0.1.
             bsize (int, optional): block size for tiles, recommended to keep at 224, like in training. Defaults to 224.
             interp (bool, optional): interpolate during 2D dynamics (not available in 3D) . Defaults to True.
-            compute_masks (bool, optional): Whether or not to compute dynamics and return masks. This is set to False when retrieving the styles for the size model. Defaults to True.
+            compute_masks (bool, optional): Whether or not to compute dynamics and return masks. Returns empty array if False. Defaults to True.
             progress (QProgressBar, optional): pyqt progress bar. Defaults to None.
 
         Returns:

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -342,11 +342,12 @@ class CellposeModel():
         # undo resizing:
         if image_scaling is not None or anisotropy is not None:
             if do_3D:
-                # Rescale xy then xz:
-                masks = transforms.resize_image(masks, Ly=Ly_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
-                masks = masks.transpose(1, 0, 2)
-                masks = transforms.resize_image(masks, Ly=Lz_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
-                masks = masks.transpose(1, 0, 2)
+                if compute_masks:
+                    # Rescale xy then xz:
+                    masks = transforms.resize_image(masks, Ly=Ly_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
+                    masks = masks.transpose(1, 0, 2)
+                    masks = transforms.resize_image(masks, Ly=Lz_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
+                    masks = masks.transpose(1, 0, 2)
 
                 # cellprob is the same
                 cellprob = transforms.resize_image(cellprob, Ly=Ly_0, Lx=Lx_0, no_channels=True)
@@ -363,7 +364,8 @@ class CellposeModel():
 
             else:
                 # 2D or 3D stitching case:
-                masks = transforms.resize_image(masks, Ly=Ly_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
+                if compute_masks:
+                    masks = transforms.resize_image(masks, Ly=Ly_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
                 cellprob = transforms.resize_image(cellprob, Ly=Ly_0, Lx=Lx_0, no_channels=True)
                 dP = np.moveaxis(dP, 0, -1) # Put gradients last
                 dP = transforms.resize_image(dP, Ly=Ly_0, Lx=Lx_0, no_channels=False)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -36,9 +36,10 @@ def clear_output(data_dir, image_names):
         npy_output = name + "_seg.npy"
         if os.path.exists(npy_output):
             os.remove(npy_output)
-        
 
-def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer):
+
+@pytest.mark.parametrize('compute_masks', [True, False])
+def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, compute_masks):
     clear_output(data_dir, image_names)
         
     img_file = data_dir / '2D' / image_names[0]
@@ -46,7 +47,11 @@ def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer):
     img = io.imread_2D(img_file)
     # flowps = io.imread(img_file.parent / (img_file.stem + "_cp4_gt_flowps.tif"))
 
-    masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True)
+    masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True, compute_masks=compute_masks)
+
+    if compute_masks:
+        return # just check that not compute_masks works: 
+    
     io.imsave(data_dir / '2D' / (img_file.stem + "_cp_masks.png"), masks_pred)
     # flowsp_pred = np.concatenate([flows_pred[1], flows_pred[2][None, ...]], axis=0)
     # mse = np.sqrt((flowsp_pred - flowps) ** 2).sum()
@@ -78,7 +83,7 @@ def test_class_2D_all_imgs(data_dir, image_names, cellposemodel_fixture_24layer)
 
 
 @pytest.mark.slow
-def test_cyto2_to_seg(data_dir, image_names, cellposemodel_fixture_24layer):
+def test_flows_to_seg(data_dir, image_names, cellposemodel_fixture_24layer):
     clear_output(data_dir, image_names)
     file_names = [data_dir / "2D" / n for n in image_names]
     imgs = [io.imread_2D(file_name) for file_name in file_names]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -49,7 +49,7 @@ def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, 
 
     masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True, compute_masks=compute_masks)
 
-    if compute_masks:
+    if not compute_masks:
         return # just check that not compute_masks works: 
     
     io.imsave(data_dir / '2D' / (img_file.stem + "_cp_masks.png"), masks_pred)


### PR DESCRIPTION
Attempted resizing on empty mask arrays failed when compute_masks was set to False in CellposeModel.eval(). Changed not resize masks if compute_masks was False, and kept returning empty array. 


fixes #1200