### PR TITLE
Add resample back and make default 

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -98,8 +98,6 @@ def main():
         logger.warning("the '--invert' flag is deprecated in v4.0.1+ and no longer used")
     if args.chan2_restore:
         logger.warning("the '--chan2_restore' flag is deprecated in v4.0.1+ and no longer used")
-    if not args.no_resample:
-        logger.warning("the '--no_resample' flag is deprecated in v4.0.1+ and no longer used")
     if args.diam_mean:
         logger.warning("the '--diam_mean' flag is deprecated in v4.0.1+ and no longer used")
     if args.train_size:
@@ -228,6 +226,7 @@ def _evaluate_cellposemodel_cli(args, logger, imf, device, pretrained_model, nor
                 min_size=args.min_size,
                 batch_size=args.batch_size,
                 bsize=args.bsize,
+                resample=not args.no_resample,
                 normalize=normalize,
                 channel_axis=channel_axis, 
                 z_axis=z_axis,

--- a/cellpose/cli.py
+++ b/cellpose/cli.py
@@ -134,8 +134,8 @@ def get_arg_parser():
 
     # TODO: remove deprecated in future version
     algorithm_args.add_argument(
-        "--no_resample", action="store_true", help=
-        'Deprecated in v4.0.1+, not used. ')
+        "--no_resample", action="store_true", 
+        help="disables flows/cellprob resampling to original image size before computing masks. Using this flag will make more masks more jagged with larger diameter settings.")
     algorithm_args.add_argument(
         "--no_interp", action="store_true",
         help="do not interpolate when running dynamics (was default)")

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -214,8 +214,6 @@ class CellposeModel():
 
         if rescale is not None:
             models_logger.warning("rescaling deprecated in v4.0.1+") 
-        if resample is not None:
-            models_logger.warning("resample deprecated in v4.0.1+")
         if channels is not None:
             models_logger.warning("channels deprecated in v4.0.1+. If data contain more than 3 channels, only the first 3 channels will be used")
 
@@ -326,6 +324,10 @@ class CellposeModel():
                 dP = gaussian_filter(dP, (0, flow3D_smooth, flow3D_smooth, flow3D_smooth))
             torch.cuda.empty_cache()
             gc.collect()
+
+        if resample:
+            # upsample flows before computing them: 
+            raise NotImplementedError
 
         if compute_masks:
             niter0 = 200

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -151,7 +151,7 @@ class CellposeModel():
             self.net.load_model(self.pretrained_model, device=self.device)
         
         
-    def eval(self, x, batch_size=8, resample=None, channels=None, channel_axis=None,
+    def eval(self, x, batch_size=8, resample=True, channels=None, channel_axis=None,
              z_axis=None, normalize=True, invert=False, rescale=None, diameter=None,
              flow_threshold=0.4, cellprob_threshold=0.0, do_3D=False, anisotropy=None,
              flow3D_smooth=0, stitch_threshold=0.0, 
@@ -165,7 +165,6 @@ class CellposeModel():
             batch_size (int, optional): number of 256x256 patches to run simultaneously on the GPU
                 (can make smaller or bigger depending on GPU memory usage). Defaults to 64.
             resample (bool, optional): run dynamics at original image size (will be slower but create more accurate boundaries). 
-                deprecated in v4.0.1+, resample is not used
             channel_axis (int, optional): channel axis in element of list x, or of np.ndarray x. 
                 if None, channels dimension is attempted to be automatically determined. Defaults to None.
             z_axis  (int, optional): z axis in element of list x, or of np.ndarray x. 
@@ -327,7 +326,9 @@ class CellposeModel():
 
         if resample:
             # upsample flows before computing them: 
-            raise NotImplementedError
+            dP = self._resize_gradients(dP, to_y_size=Ly_0, to_x_size=Lx_0, to_z_size=Lz_0)
+            cellprob = self._resize_cellprob(cellprob, to_x_size=Lx_0, to_y_size=Ly_0, to_z_size=Lz_0)
+
 
         if compute_masks:
             niter0 = 200
@@ -343,6 +344,10 @@ class CellposeModel():
 
         # undo resizing:
         if image_scaling is not None or anisotropy is not None:
+
+            dP = self._resize_gradients(dP, to_y_size=Ly_0, to_x_size=Lx_0, to_z_size=Lz_0) # works for 2 or 3D: 
+            cellprob = self._resize_cellprob(cellprob, to_x_size=Lx_0, to_y_size=Ly_0, to_z_size=Lz_0)
+
             if do_3D:
                 if compute_masks:
                     # Rescale xy then xz:
@@ -351,29 +356,96 @@ class CellposeModel():
                     masks = transforms.resize_image(masks, Ly=Lz_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
                     masks = masks.transpose(1, 0, 2)
 
-                # cellprob is the same
-                cellprob = transforms.resize_image(cellprob, Ly=Ly_0, Lx=Lx_0, no_channels=True)
-                cellprob = cellprob.transpose(1, 0, 2)
-                cellprob = transforms.resize_image(cellprob, Ly=Lz_0, Lx=Lx_0, no_channels=True)
-                cellprob = cellprob.transpose(1, 0, 2)
-
-                # dP has gradients that can be treated as channels:
-                dP = dP.transpose(1, 2, 3, 0) # move gradients last:
-                dP = transforms.resize_image(dP, Ly=Ly_0, Lx=Lx_0, no_channels=False)
-                dP = dP.transpose(1, 0, 2, 3) # switch axes to resize again
-                dP = transforms.resize_image(dP, Ly=Lz_0, Lx=Lx_0, no_channels=False)
-                dP = dP.transpose(3, 1, 0, 2) # undo transposition
-
             else:
                 # 2D or 3D stitching case:
                 if compute_masks:
                     masks = transforms.resize_image(masks, Ly=Ly_0, Lx=Lx_0, no_channels=True, interpolation=cv2.INTER_NEAREST)
-                cellprob = transforms.resize_image(cellprob, Ly=Ly_0, Lx=Lx_0, no_channels=True)
-                dP = np.moveaxis(dP, 0, -1) # Put gradients last
-                dP = transforms.resize_image(dP, Ly=Ly_0, Lx=Lx_0, no_channels=False)
-                dP = np.moveaxis(dP, -1, 0) # Put gradients first
 
         return masks, [plot.dx_to_circ(dP), dP, cellprob], styles
+    
+
+    def _resize_cellprob(self, prob: np.ndarray, to_y_size: int, to_x_size: int, to_z_size: int = None) -> np.ndarray:
+        """
+        Resize cellprob array to specified dimensions for either 2D or 3D.
+
+        Parameters:
+            prob (numpy.ndarray): The cellprobs to resize, either in 2D or 3D. Returns the same ndim as provided.
+            to_y_size (int): The target size along the Y-axis.
+            to_x_size (int): The target size along the X-axis.
+            to_z_size (int, optional): The target size along the Z-axis. Required
+                for 3D cellprobs.
+
+        Returns:
+            numpy.ndarray: The resized cellprobs array with the same number of dimensions
+            as the input.
+
+        Raises:
+            ValueError: If the input cellprobs array does not have 3 or 4 dimensions.
+        """
+        prob_shape = prob.shape
+        prob = prob.squeeze()
+        squeeze_happened = prob.shape != prob_shape
+        prob_shape = np.array(prob_shape)
+
+        if prob.ndim == 2:
+            # 2D case:
+            prob = transforms.resize_image(prob, Ly=to_y_size, Lx=to_x_size, no_channels=True)
+            if squeeze_happened:
+                prob = np.expand_dims(prob, int(np.argwhere(prob_shape == 1))) # add back empty axis for compatibility
+        elif prob.ndim == 3:
+            # 3D case: 
+            prob = transforms.resize_image(prob, Ly=to_y_size, Lx=to_x_size, no_channels=True)
+            prob = prob.transpose(1, 0, 2)
+            prob = transforms.resize_image(prob, Ly=to_z_size, Lx=to_x_size, no_channels=True)
+            prob = prob.transpose(1, 0, 2)
+        else:
+            raise ValueError(f'gradients have incorrect dimension after squeezing. Should be 2 or 3, prob shape: {prob.shape}')
+        
+        return prob
+
+
+    def _resize_gradients(self, grads: np.ndarray, to_y_size: int, to_x_size: int, to_z_size: int = None) -> np.ndarray:
+        """
+        Resize gradient arrays to specified dimensions for either 2D or 3D gradients.
+
+        Parameters:
+            grads (np.ndarray): The gradients to resize, either in 2D or 3D. Returns the same ndim as provided.
+            to_y_size (int): The target size along the Y-axis.
+            to_x_size (int): The target size along the X-axis.
+            to_z_size (int, optional): The target size along the Z-axis. Required
+                for 3D gradients.
+
+        Returns:
+            numpy.ndarray: The resized gradient array with the same number of dimensions
+            as the input.
+
+        Raises:
+            ValueError: If the input gradient array does not have 3 or 4 dimensions.
+        """
+        grads_shape = grads.shape
+        grads = grads.squeeze()
+        squeeze_happened = grads.shape != grads_shape
+        grads_shape = np.array(grads_shape)
+
+        if grads.ndim == 3:
+            # 2D case, with XY flows in 2 channels:
+            grads = np.moveaxis(grads, 0, -1) # Put gradients last
+            grads = transforms.resize_image(grads, Ly=to_y_size, Lx=to_x_size, no_channels=False)
+            grads = np.moveaxis(grads, -1, 0) # Put gradients first
+
+            if squeeze_happened:
+                grads = np.expand_dims(grads, int(np.argwhere(grads_shape == 1))) # add back empty axis for compatibility
+        elif grads.ndim == 4:
+            # dP has gradients that can be treated as channels:
+            grads = grads.transpose(1, 2, 3, 0) # move gradients last:
+            grads = transforms.resize_image(grads, Ly=to_y_size, Lx=to_x_size, no_channels=False)
+            grads = grads.transpose(1, 0, 2, 3) # switch axes to resize again
+            grads = transforms.resize_image(grads, Ly=to_z_size, Lx=to_x_size, no_channels=False)
+            grads = grads.transpose(3, 1, 0, 2) # undo transposition
+        else:
+            raise ValueError(f'gradients have incorrect dimension after squeezing. Should be 3 or 4, grads shape: {grads.shape}')
+        
+        return grads
 
 
     def _run_net(self, x, 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -38,14 +38,15 @@ def clear_output(data_dir, image_names):
             os.remove(npy_output)
 
 
-@pytest.mark.parametrize('compute_masks, resample', 
+@pytest.mark.parametrize('compute_masks, resample, diameter', 
                          [
-                             (True, True), 
-                             (False, True),
-                             (False, False,)
+                             (True, True, 40), 
+                             (True, True, None), 
+                             (False, True, None),
+                             (False, False, None)
                          ]
 )
-def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, compute_masks, resample):
+def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, compute_masks, resample, diameter):
     clear_output(data_dir, image_names)
         
     img_file = data_dir / '2D' / image_names[0]
@@ -53,10 +54,12 @@ def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, 
     img = io.imread_2D(img_file)
     # flowps = io.imread(img_file.parent / (img_file.stem + "_cp4_gt_flowps.tif"))
 
-    masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True, compute_masks=compute_masks, resample=resample)
+    masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True, compute_masks=compute_masks, resample=resample, diameter=diameter)
 
-    if not compute_masks:
-        return # just check that not compute_masks works: 
+    if not compute_masks or diameter:
+        # not compute_masks won't return masks so can't check
+        # different diameter will give different masks, so can't check
+        return 
     
     io.imsave(data_dir / '2D' / (img_file.stem + "_cp_masks.png"), masks_pred)
     # flowsp_pred = np.concatenate([flows_pred[1], flows_pred[2][None, ...]], axis=0)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -38,8 +38,14 @@ def clear_output(data_dir, image_names):
             os.remove(npy_output)
 
 
-@pytest.mark.parametrize('compute_masks', [True, False])
-def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, compute_masks):
+@pytest.mark.parametrize('compute_masks, resample', 
+                         [
+                             (True, True), 
+                             (False, True),
+                             (False, False,)
+                         ]
+)
+def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, compute_masks, resample):
     clear_output(data_dir, image_names)
         
     img_file = data_dir / '2D' / image_names[0]
@@ -47,7 +53,7 @@ def test_class_2D_one_img(data_dir, image_names, cellposemodel_fixture_24layer, 
     img = io.imread_2D(img_file)
     # flowps = io.imread(img_file.parent / (img_file.stem + "_cp4_gt_flowps.tif"))
 
-    masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True, compute_masks=compute_masks)
+    masks_pred, _, _ = cellposemodel_fixture_24layer.eval(img, normalize=True, compute_masks=compute_masks, resample=resample)
 
     if not compute_masks:
         return # just check that not compute_masks works: 


### PR DESCRIPTION
Add resample setting back in and make it the default so that downsampled masks when using larger diameters aren't so jagged. 

- [X] implement flows/cellprob resizing as appropriate in .eval()
- [x] put back into GUI
- [x] put back into CLI
- [X] full tests passing on ubuntu

Resolves #1186