### PR TITLE
quick fix for the raised issue #12208 regarding the functions of io.imsave() and io.save_rois()

### DIFF
--- a/notebooks/run_Cellpose-SAM.ipynb
+++ b/notebooks/run_Cellpose-SAM.ipynb
@@ -358,8 +358,8 @@
       "source": [
         "for i in trange(len(files)):\n",
         "    f = files[i]\n",
-        "    masks0 = io.imsave(dir / (f.name + \"_masks\" + masks_ext))\n",
-        "    io.save_rois(masks0, f)"
+        "    io.imsave(dir / (f.name + \"_masks\" + masks_ext), masks[i])\n",
+        "    io.save_rois(masks[i], f)"
       ]
     }
   ],


### PR DESCRIPTION
At  run_Cellpose-SAM.ipynb file, both io.imsave() and io.save_rois() should not return anything since the API specifies that these two functions return None.  Also, the `mask[i]`  is missing in the io.imsave() function. With that, I updated those codes to save images and rois in a proper way.