### PR TITLE
Bfloat16 quantization

### DIFF
--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -109,7 +109,7 @@ def assign_device(use_torch=True, gpu=False, device=0):
     return device, gpu
 
 
-def _to_device(x, device):
+def _to_device(x, device, dtype=torch.float32):
     """
     Converts the input tensor or numpy array to the specified device.
 
@@ -121,7 +121,7 @@ def _to_device(x, device):
         torch.Tensor: The converted tensor on the specified device.
     """
     if not isinstance(x, torch.Tensor):
-        X = torch.from_numpy(x).to(device, dtype=torch.float32)
+        X = torch.from_numpy(x).to(device, dtype=dtype)
         return X
     else:
         return x
@@ -137,7 +137,8 @@ def _from_device(X):
     Returns:
         numpy.ndarray: The converted NumPy array.
     """
-    x = X.detach().cpu().numpy()
+    # The cast is so numpy conversion always works
+    x = X.detach().cpu().to(torch.float32).numpy()
     return x
 
 
@@ -151,7 +152,7 @@ def _forward(net, x):
     Returns:
         Tuple[numpy.ndarray, numpy.ndarray]: The output predictions (flows and cellprob) and style features.
     """
-    X = _to_device(x, device=net.device)
+    X = _to_device(x, device=net.device, dtype=net.dtype)
     net.eval()
     with torch.no_grad():
         y, style = net(X)[:2]

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -89,7 +89,7 @@ class CellposeModel():
     """
 
     def __init__(self, gpu=False, pretrained_model="cpsam", model_type=None,
-                 diam_mean=None, device=None, nchan=None):
+                 diam_mean=None, device=None, nchan=None, use_bfloat16=True):
         """
         Initialize the CellposeModel.
 
@@ -99,6 +99,7 @@ class CellposeModel():
             model_type (str, optional): Any model that is available in the GUI, use name in GUI e.g. "livecell" (can be user-trained or model zoo).
             diam_mean (float, optional): Mean "diameter", 30. is built-in value for "cyto" model; 17. is built-in value for "nuclei" model; if saved in custom model file (cellpose>=2.0) then it will be loaded automatically and overwrite this value.
             device (torch device, optional): Device used for model running / training (torch.device("cuda") or torch.device("cpu")), overrides gpu input, recommended if you want to use a specific GPU (e.g. torch.device("cuda:1")).
+            use_bfloat16 (bool, optional): Use 16bit float precision instead of 32bit for model weights. Default to 16bit (True).
         """
         if diam_mean is not None:
             models_logger.warning(
@@ -139,7 +140,8 @@ class CellposeModel():
                 )
 
         self.pretrained_model = pretrained_model
-        self.net = Transformer().to(self.device)
+        dtype = torch.bfloat16 if use_bfloat16 else torch.float32
+        self.net = Transformer(dtype=dtype).to(self.device)
 
         if os.path.exists(self.pretrained_model):
             models_logger.info(f">>>> loading model {self.pretrained_model}")

--- a/cellpose/train.py
+++ b/cellpose/train.py
@@ -48,7 +48,7 @@ def _loss_fn_seg(lbl, y, device):
     veci = 5. * lbl[:, -2:]
     loss = criterion(y[:, -3:-1], veci)
     loss /= 2.
-    loss2 = criterion2(y[:, -1], (lbl[:, -3] > 0.5).float())
+    loss2 = criterion2(y[:, -1], (lbl[:, -3] > 0.5).to(y.dtype))
     loss = loss + loss2
     return loss
 
@@ -454,6 +454,11 @@ def train_seg(net, train_data=None, train_labels=None, train_files=None,
             # network and loss optimization
             X = torch.from_numpy(imgi).to(device)
             lbl = torch.from_numpy(lbl).to(device)
+
+            if X.dtype != net.dtype:
+                X = X.to(net.dtype)
+                lbl = lbl.to(net.dtype)
+
             y = net(X)[0]
             loss = _loss_fn_seg(lbl, y, device)
             if y.shape[1] > 3:

--- a/cellpose/vit_sam.py
+++ b/cellpose/vit_sam.py
@@ -10,7 +10,7 @@ import torch.nn.functional as F
 
 class Transformer(nn.Module):
     def __init__(self, backbone="vit_l", ps=8, nout=3, bsize=256, rdrop=0.4,
-                  checkpoint=None):
+                  checkpoint=None, dtype=torch.float32):
         super(Transformer, self).__init__()
 
         # instantiate the vit model, default to not loading SAM
@@ -48,6 +48,8 @@ class Transformer(nn.Module):
         # set attention to global in every layer
         for blk in self.encoder.blocks:
             blk.window_size = 0
+
+        self.dtype = dtype
 
     def forward(self, x):      
         # same progression as SAM until readout

--- a/cellpose/vit_sam.py
+++ b/cellpose/vit_sam.py
@@ -61,7 +61,7 @@ class Transformer(nn.Module):
         if self.training and self.rdrop > 0:
             nlay = len(self.encoder.blocks)
             rdrop = (torch.rand((len(x), nlay), device=x.device) < 
-                     torch.linspace(0, self.rdrop, nlay, device=x.device)).float()
+                     torch.linspace(0, self.rdrop, nlay, device=x.device)).to(x.dtype)
             for i, blk in enumerate(self.encoder.blocks):            
                 mask = rdrop[:,i].unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
                 x = x * mask + blk(x) * (1-mask)

--- a/cellpose/vit_sam.py
+++ b/cellpose/vit_sam.py
@@ -92,6 +92,9 @@ class Transformer(nn.Module):
         else:
             self.load_state_dict(state_dict, strict = strict)
 
+        if self.dtype != torch.float32:
+            self = self.to(self.dtype)
+
     
     @property
     def device(self):

--- a/model_quantization.ipynb
+++ b/model_quantization.ipynb
@@ -1,0 +1,1015 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "77bb9875",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "Welcome to CellposeSAM, cellpose v\n",
+      "cellpose version: \t4.0.1 \n",
+      "platform:       \tlinux \n",
+      "python version: \t3.12.3 \n",
+      "torch version:  \t2.8.0.dev20250505+cu128! The neural network component of\n",
+      "CPSAM is much larger than in previous versions and CPU excution is slow. \n",
+      "We encourage users to use GPU/MPS if available. \n",
+      "\n",
+      "\n",
+      " number of images : 68\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "from cellpose import io\n",
+    "\n",
+    "\n",
+    "data_root = Path().home() / 'projects/cellpose/test_train/'\n",
+    "image_files = list((data_root / 'test').iterdir())\n",
+    "image_files = [i for i in image_files if 'masks' not in i.name and 'flow' not in i.name and i.is_file()]\n",
+    "image_files.sort()\n",
+    "\n",
+    "print(f\" number of images : {len(image_files)}\")\n",
+    "\n",
+    "img = io.imread_2D(image_files[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a13dddd",
+   "metadata": {},
+   "source": [
+    "# Show model weight size, and dtype:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d867caf7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_memory_footprint(model, return_buffers=True):\n",
+    "    mem = sum([param.nelement() * param.element_size() for param in model.parameters()])\n",
+    "    if return_buffers:\n",
+    "        mem_bufs = sum([buf.nelement() * buf.element_size() for buf in model.buffers()])\n",
+    "    mem += mem_bufs\n",
+    "    return mem / 1024**2  # convert to MB\n",
+    "\n",
+    "def get_type_counts(model):\n",
+    "    type_counts = {}\n",
+    "    for param in model.parameters():\n",
+    "        param_type = str(param.dtype)\n",
+    "        if param_type not in type_counts:\n",
+    "            type_counts[param_type] = 0\n",
+    "        type_counts[param_type] += param.nelement() * param.element_size()\n",
+    "    return type_counts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1d4ba935",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'torch.float32': 1218515720}\n",
+      "Model size: 1162.07 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "from cellpose import models\n",
+    "\n",
+    "model = models.CellposeModel(gpu=True)\n",
+    "\n",
+    "print(get_type_counts(model.net))\n",
+    "print(f'Model size: {get_memory_footprint(model.net):.2f} MB')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1718d12c",
+   "metadata": {},
+   "source": [
+    "## Calculate the AP scores for masks with normal model weights:  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "62c404d7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.294391393661499\n",
+      "0.10566282272338867\n",
+      "0.10566210746765137\n",
+      "0.1054537296295166\n",
+      "0.1054391860961914\n",
+      "0.1054220199584961\n",
+      "0.10538077354431152\n",
+      "0.10544037818908691\n",
+      "0.1053924560546875\n",
+      "0.10545110702514648\n",
+      "0.10546135902404785\n",
+      "0.10551738739013672\n",
+      "0.14010334014892578\n",
+      "0.03056049346923828\n",
+      "0.13769793510437012\n",
+      "0.01892995834350586\n",
+      "0.13856029510498047\n",
+      "0.01896953582763672\n",
+      "0.0724632740020752\n",
+      "0.07106661796569824\n",
+      "0.07092642784118652\n",
+      "0.10555696487426758\n",
+      "0.10549330711364746\n",
+      "0.13778305053710938\n",
+      "0.018965721130371094\n",
+      "0.10743331909179688\n",
+      "0.10565423965454102\n",
+      "0.10552358627319336\n",
+      "0.13784480094909668\n",
+      "0.02016282081604004\n",
+      "0.13783907890319824\n",
+      "0.020309925079345703\n",
+      "0.07099795341491699\n",
+      "0.10557174682617188\n",
+      "0.10559439659118652\n",
+      "0.07105278968811035\n",
+      "0.10557770729064941\n",
+      "0.07100772857666016\n",
+      "0.07098531723022461\n",
+      "0.07098126411437988\n",
+      "0.10552239418029785\n",
+      "0.10556793212890625\n",
+      "0.13777732849121094\n",
+      "0.01897907257080078\n",
+      "0.07097315788269043\n",
+      "0.10598492622375488\n",
+      "0.07102131843566895\n",
+      "0.10643315315246582\n",
+      "0.10553717613220215\n",
+      "0.13783693313598633\n",
+      "0.07087469100952148\n",
+      "0.137861967086792\n",
+      "0.01903247833251953\n",
+      "0.07105255126953125\n",
+      "0.1378159523010254\n",
+      "0.01899552345275879\n",
+      "0.10564446449279785\n",
+      "0.07107090950012207\n",
+      "0.1055288314819336\n",
+      "0.10568070411682129\n",
+      "0.13799118995666504\n",
+      "0.019019603729248047\n",
+      "0.13792991638183594\n",
+      "0.019294261932373047\n",
+      "0.1056520938873291\n",
+      "0.07103753089904785\n",
+      "0.0709378719329834\n",
+      "0.10561275482177734\n",
+      "0.10563540458679199\n",
+      "0.1058347225189209\n",
+      "0.10560488700866699\n",
+      "0.10566568374633789\n",
+      "0.13782858848571777\n",
+      "0.01899266242980957\n",
+      "0.10626649856567383\n",
+      "0.10564661026000977\n",
+      "0.1378488540649414\n",
+      "0.01894855499267578\n",
+      "0.1056060791015625\n",
+      "0.10567069053649902\n",
+      "0.1056678295135498\n",
+      "0.10565543174743652\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "masks = []\n",
+    "times = []\n",
+    "for img_f in image_files:\n",
+    "    img = io.imread_2D(img_f)\n",
+    "    tic = time.time()\n",
+    "    masks_i, flows_i, _ = model.eval(img)\n",
+    "    toc = time.time()\n",
+    "\n",
+    "    img_f_out = data_root / 'quantization/fp32' / img_f.name\n",
+    "    img_f_out.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    io.imsave(img_f_out, masks_i)\n",
+    "    times.append(toc-tic)\n",
+    "    masks.append(masks_i.max())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00a69c13",
+   "metadata": {},
+   "source": [
+    "# Evaluate the model with lower precision data type: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a35c8779",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Transformer(\n",
+       "  (encoder): ImageEncoderViT(\n",
+       "    (patch_embed): PatchEmbed(\n",
+       "      (proj): Conv2d(3, 1024, kernel_size=(8, 8), stride=(8, 8))\n",
+       "    )\n",
+       "    (blocks): ModuleList(\n",
+       "      (0-23): 24 x Block(\n",
+       "        (norm1): LayerNorm((1024,), eps=1e-06, elementwise_affine=True)\n",
+       "        (attn): Attention(\n",
+       "          (qkv): Linear(in_features=1024, out_features=3072, bias=True)\n",
+       "          (proj): Linear(in_features=1024, out_features=1024, bias=True)\n",
+       "        )\n",
+       "        (norm2): LayerNorm((1024,), eps=1e-06, elementwise_affine=True)\n",
+       "        (mlp): MLPBlock(\n",
+       "          (lin1): Linear(in_features=1024, out_features=4096, bias=True)\n",
+       "          (lin2): Linear(in_features=4096, out_features=1024, bias=True)\n",
+       "          (act): GELU(approximate='none')\n",
+       "        )\n",
+       "      )\n",
+       "    )\n",
+       "    (neck): Sequential(\n",
+       "      (0): Conv2d(1024, 256, kernel_size=(1, 1), stride=(1, 1), bias=False)\n",
+       "      (1): LayerNorm2d()\n",
+       "      (2): Conv2d(256, 256, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1), bias=False)\n",
+       "      (3): LayerNorm2d()\n",
+       "    )\n",
+       "  )\n",
+       "  (out): Conv2d(256, 192, kernel_size=(1, 1), stride=(1, 1))\n",
+       ")"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import torch \n",
+    "import numpy as np\n",
+    "\n",
+    "model.net.dtype = torch.bfloat16\n",
+    "model.net.to(model.net.dtype)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "517507d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'torch.bfloat16': 609257860}\n",
+      "Model size: 581.03 MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(get_type_counts(model.net))\n",
+    "print(f'Model size: {get_memory_footprint(model.net):.2f} MB')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "60fbfa1c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.11516189575195312\n",
+      "0.058031558990478516\n",
+      "0.05804800987243652\n",
+      "0.05808424949645996\n",
+      "0.05808281898498535\n",
+      "0.058046817779541016\n",
+      "0.05802583694458008\n",
+      "0.05847907066345215\n",
+      "0.05806088447570801\n",
+      "0.0584867000579834\n",
+      "0.05828237533569336\n",
+      "0.05893754959106445\n",
+      "0.07747244834899902\n",
+      "0.045305490493774414\n",
+      "0.07477998733520508\n",
+      "0.013552665710449219\n",
+      "0.07479357719421387\n",
+      "0.013551950454711914\n",
+      "0.043792009353637695\n",
+      "0.04104137420654297\n",
+      "0.041014909744262695\n",
+      "0.058069705963134766\n",
+      "0.0580294132232666\n",
+      "0.07482671737670898\n",
+      "0.013544797897338867\n",
+      "0.05800151824951172\n",
+      "0.05847024917602539\n",
+      "0.05807852745056152\n",
+      "0.07517027854919434\n",
+      "0.013546228408813477\n",
+      "0.07479357719421387\n",
+      "0.01348733901977539\n",
+      "0.041010379791259766\n",
+      "0.05801200866699219\n",
+      "0.058434486389160156\n",
+      "0.04100942611694336\n",
+      "0.058017730712890625\n",
+      "0.0410466194152832\n",
+      "0.04103398323059082\n",
+      "0.04092764854431152\n",
+      "0.05802440643310547\n",
+      "0.05807328224182129\n",
+      "0.07480764389038086\n",
+      "0.013559579849243164\n",
+      "0.04101085662841797\n",
+      "0.05935239791870117\n",
+      "0.04103398323059082\n",
+      "0.05810737609863281\n",
+      "0.05816531181335449\n",
+      "0.07482767105102539\n",
+      "0.04098010063171387\n",
+      "0.07501530647277832\n",
+      "0.01353764533996582\n",
+      "0.04108142852783203\n",
+      "0.07491874694824219\n",
+      "0.013569116592407227\n",
+      "0.058103084564208984\n",
+      "0.04150509834289551\n",
+      "0.05811190605163574\n",
+      "0.05801248550415039\n",
+      "0.07481527328491211\n",
+      "0.013541936874389648\n",
+      "0.07481718063354492\n",
+      "0.013478994369506836\n",
+      "0.058016300201416016\n",
+      "0.04112553596496582\n",
+      "0.04111933708190918\n",
+      "0.058096885681152344\n",
+      "0.05807924270629883\n",
+      "0.05885148048400879\n",
+      "0.05804085731506348\n",
+      "0.05811619758605957\n",
+      "0.07520294189453125\n",
+      "0.013704299926757812\n",
+      "0.0581209659576416\n",
+      "0.0581517219543457\n",
+      "0.07493185997009277\n",
+      "0.013637304306030273\n",
+      "0.058087825775146484\n",
+      "0.05855107307434082\n",
+      "0.05815911293029785\n",
+      "0.058122873306274414\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from cellpose import core\n",
+    "\n",
+    "\n",
+    "masks = []\n",
+    "times_16 = []\n",
+    "times_16_net = []\n",
+    "for img_f in image_files:\n",
+    "    img = io.imread_2D(img_f)\n",
+    "    tic = time.time()\n",
+    "    masks_i, flows_i, _ = model.eval(img)\n",
+    "    toc = time.time()\n",
+    "\n",
+    "    img_f_out = data_root / 'quantization/bfp16' / img_f.name\n",
+    "    img_f_out.parent.mkdir(parents=True, exist_ok=True)\n",
+    "    io.imsave(img_f_out, masks_i)\n",
+    "    times_16.append(toc-tic)\n",
+    "    masks.append(masks_i.max())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "e3d532bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cellpose.metrics import average_precision\n",
+    "\n",
+    "ap_all = []\n",
+    "for i in range(68):\n",
+    "    true_mask = io.imread(data_root / f'test/{i:03}_masks.png')\n",
+    "    mask_bf16 = io.imread(data_root / f'quantization/bfp16/{i:03}_img.png')\n",
+    "    mask_fp32 = io.imread(data_root / f'quantization/fp32/{i:03}_img.png')\n",
+    "\n",
+    "    ap = average_precision([true_mask, true_mask],\n",
+    "                             [mask_bf16, mask_fp32], \n",
+    "                             threshold=[0.5])[0]\n",
+    "    ap_all.append(ap)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "24e1f6d0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([0.85471886, 0.85487753], dtype=float32)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ap_arr = np.hstack(ap_all)\n",
+    "np.mean(ap_arr, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "04412118",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>dtype</th>\n",
+       "      <th>AP@0.5</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bfloat16</td>\n",
+       "      <td>0.920455</td>\n",
+       "      <td>0.181792</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bfloat16</td>\n",
+       "      <td>0.845238</td>\n",
+       "      <td>0.121006</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bfloat16</td>\n",
+       "      <td>0.909091</td>\n",
+       "      <td>0.118715</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bfloat16</td>\n",
+       "      <td>0.978723</td>\n",
+       "      <td>0.115539</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>bfloat16</td>\n",
+       "      <td>0.866667</td>\n",
+       "      <td>0.113421</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      dtype    AP@0.5      time\n",
+       "0  bfloat16  0.920455  0.181792\n",
+       "0  bfloat16  0.845238  0.121006\n",
+       "0  bfloat16  0.909091  0.118715\n",
+       "0  bfloat16  0.978723  0.115539\n",
+       "0  bfloat16  0.866667  0.113421"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import seaborn as sns\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "df = pd.DataFrame({\n",
+    "    'dtype': ['bfloat16', 'float32'],\n",
+    "    'AP@0.5': [ap_arr[l, :] for l in range(2)],\n",
+    "})\n",
+    "df = df.explode('AP@0.5')\n",
+    "df['time'] = np.hstack([times_16, times])\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "efc37013",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<Axes: xlabel='dtype', ylabel='time'>"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/michael/projects/cellpose/.venv/lib/python3.12/site-packages/seaborn/categorical.py:3399: UserWarning: 8.8% of the points cannot be placed; you may want to decrease the size of the markers or use stripplot.\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/home/michael/projects/cellpose/.venv/lib/python3.12/site-packages/seaborn/categorical.py:3399: UserWarning: 7.4% of the points cannot be placed; you may want to decrease the size of the markers or use stripplot.\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAGGCAYAAACNCg6xAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAaGJJREFUeJzt3Xt8U/X9P/BX0tKk9EqB3gsFyrgJxQHtUBQvlYKMweYm4JRSFb8qOLBTsRNhqFvFCxaF2X39AaJ+RXRj6nQruiIqk7UIIoJQKFIKtE2hpU1b6IXk/P7oEpom5+QkzfXk9Xw8+lDOLSfnk5zzzvtzUwmCIICIiIiI7FJ7+wSIiIiI/AUDJyIiIiKZGDgRERERycTAiYiIiEgmBk5EREREMjFwIiIiIpKJgRMRERGRTAyciIiIiGQK9vYJeJrRaER1dTUiIiKgUqm8fTpEAUEQBDQ3NyMxMRFqNX+vSeE9isjzHLlHBVzgVF1djZSUFG+fBlFAOn36NJKTk719Gj6N9ygi75Fzjwq4wCkiIgJA18WJjIz08tkQBQa9Xo+UlBTz94/E8R5F5HmO3KMCLnAypb4jIyN5UyLyMFY92cd7FJH3yLlHsbEBERERkUwMnIiIiIhkYuBEREREJBMDJyIiIiKZGDgRERERycTAiYiIiEgmBk5EREREMnk1cPriiy8wa9YsJCYmQqVS4f3337e7z65du/DjH/8YGo0GaWlpeP31191+nkRERESAlwOn1tZWpKenY8OGDbK2P3nyJGbOnIkbb7wRBw4cwLJly3Dvvfdix44dbj5TIiIiIi+PHD5jxgzMmDFD9vZFRUUYMmQIXnzxRQDAqFGjsHv3brz00kvIzs5212n6hIq6FuytbEB9Szv6h2swKTUGabHhbltHrmHvGrPsiMgf8J5zhV+1cdqzZw+ysrIslmVnZ2PPnj1eOiPPqKhrwd+/rUZtUxs6DQJqm9rw0cFqVNS1uGUduYa9a8yyIyJ/wHuOJb+aq662thZxcXEWy+Li4qDX63Hp0iWEhoZa7dPe3o729nbzv/V6vdvP09X2VjZYLRME28tdsS5Qf0W4mlS5pcWGu6VcWXZE5Gr27mWBxq8CJ2cUFBRg9erV3j6NXqlvabe5vKG1A4IguHwduYZUudlbz7IjIl9h714WaPyqqi4+Ph46nc5imU6nQ2RkpM1sEwDk5+ejqanJ/Hf69GlPnKpL9Q/X2FweExbilnXkGvauMcuOiPwB7zmW/Cpwmjx5MkpKSiyWffrpp5g8ebLoPhqNBpGRkRZ//mZSagxUKstlKlXXcnesI9ewd41ZdkTkD3jPseTVqrqWlhZUVFSY/33y5EkcOHAAMTExGDRoEPLz83H27Fm88cYbAID7778f69evx2OPPYa7774bO3fuxLvvvouPP/7YW2/BI9Jiw/HTcYnYW9mAhtYOxISFWPRocMc66j175eauciUiciV796qAI3jRZ599JgCw+svJyREEQRBycnKEqVOnWu0zfvx4ISQkRBg6dKiwefNmh16zqalJACA0NTW55k34kOO6ZuHt0lPCKyXHhLdLTwnHdc3ePiWSSell58vfu/Xr1wuDBw8WNBqNkJGRIZSWlsrab+vWrQIAYfbs2RbLc3JyrO5p2dnZss/Hl68VkVI58r1TCYJIS1OF0uv1iIqKQlNTk19W24kxdRftTqXqykwE7K8CPxEIZeer37tt27ZhwYIFKCoqQmZmJgoLC/Hee++hvLwcsbGxovtVVlZiypQpGDp0KGJiYixmPVi4cCF0Oh02b95sXqbRaNCvXz9Z5+Sr14pIyRz53vlVGycS52jXdvIdLDvvWbt2LRYtWoTc3FyMHj0aRUVF6Nu3LzZt2iS6j8FgwK9//WusXr0aQ4cOtbmNRqNBfHy8+U9u0EREvo+Bk0Kwu6j/Ytl5R0dHB/bt22cxqK5arUZWVpbkoLpPPfUUYmNjcc8994hus2vXLsTGxmLEiBF44IEHUF9f79JzJyLvUfw4ToGif7gGtU1tVssDtbuoP2HZecf58+dhMBhsDqp79OhRm/vs3r0bGzduxIEDB0SPO336dPziF7/AkCFDcOLECfzud7/DjBkzsGfPHgQFBVltr4RBeokCCQMnP9Vz3qC4SC10+jZ0b7EWyN1FfZHYXE+TUmPw0cFqlp2Pa25uxl133YXXXnsNAwYMEN1u3rx55v8fO3Ysxo0bh2HDhmHXrl24+eabrbZXwiC9RIGEgZMf6tmYuLapDTp9G8YlR0Onb2N3UR9kq8w+OlhtbgDOrr6eN2DAAAQFBdkcVDc+Pt5q+xMnTqCyshKzZs0yLzMajQCA4OBglJeXY9iwYVb7DR06FAMGDEBFRYXNwCk/Px95eXnmf+v1eqSkpDj9vojIvRg4+SGxxsQ6fRvmZwzywhmRPfbmejL92cJZyd0jJCQEEyZMQElJCebMmQOgKxAqKSnBkiVLrLYfOXIkvvvuO4tlK1asQHNzM9atWyca7Jw5cwb19fVISEiwuV6j0UCjsT0yMxH5HgZOfsheY2JPPGj5MHeMs2VmL1NFvZOXl4ecnBxMnDgRGRkZKCwsRGtrK3JzcwEACxYsQFJSEgoKCqDVanHVVVdZ7B8dHQ0A5uUtLS1YvXo1brvtNsTHx+PEiRN47LHHkJaWhuzsbI++NyJyDwZOXtKbwEOqMbEnHrR8mDvO2TLjrOTuNXfuXJw7dw4rV65EbW0txo8fj+LiYnOD8aqqKqjV8jsfBwUF4eDBg9iyZQsaGxuRmJiIadOm4emnn2ZWiUghOACmF/R2wMOKuhabjYlND1pbD+j4KK1T1Xi2AjxXv0YgcLbM6lva0Wmw/oqGBKux+MY0d56yS/nC985f8FoReZ4j3ztmnLzAXhbBXjZKqjFx8aEam68pNiaQ1GuJZUKaLnUiUttH9msojTPZQmfLzN5QBawyJSLyLAZOXiDV3sVeNVjPB2X2mHiLB6UjYwLZey2xAK/xou3AKRDGHXK0fHpO6msrqJEqM6mhClhlSkTkeRw53Av6h9tu6xATFiKZjTI9KGub2tBpEMwPyoq6FvO2k1JjoFJZ7i82JpC9qT7EArx+ffvIfg2l6W352CJVZqZMVXyUFiHBasRHae0GtpyqhYjIfRg4eYHUg1IqGyXnQSn2oAWArWVVWL/zOLaWVaGirsVuTy+xAG94XITow1zpels+tkgFR5bHsmzrxKlaiIg8j1V1XiDV3kWq2sbRLu2majyxKp2ewVv31wIgWU0kNe6QkrmyfORU40lVx3GqFiIiz2Pg5CViD0qpYEWs95WzXdpVUEGlEkSn+uCI1tbcUT5SbaOkslicqoWIyPMYOPkYe8GK1EO7J9MDViwTEhykQvaYBMnAKFAzS2LcUT4ARIMqqSwWA1siIs9j4OSDxIIVd3RpZ2DkOFeXj1RQZa86juVHRORZDJz8jKu7tJNrOVM+Ulml7DHxLDsiIh/CwEkh7DXkllOlw8EUHSf3mjnbNorVcUREvoWBk49yNIix94C1V6XDwRQdJ+eadS9HFVRQqQUEq9Wy20YBrI4jIvIlDJx8kLNBTG8esJxM1nFyps6xmpMQsBgmYmtZVVdQperq5RgcpGJWiYjIhzFw8kHOBjFyslRi23AwRcfZu2aO9KQDAJVKQPaYBKugytYcgqxSJSLyDo4c7oOcCWLkTPchtY3UNDBkm71r5uwo41Ll5Oy0LkRE5BoMnHyQ1APZlInoPnUKYD+7YW8bR+a4oy72rplUOTobVHF+OiIi72Lg5IPEHshxkVrRbIOcLJWcwRQDcf45Z9m7ZlKBlbNBFatUiYi8i22cfJBYD7neDJQISI8lZHpdBkqOkbpmvRllXKqcOD8dEZH3MHDyUbYeyFKjT8sZKJEDYXpe93I0NeouPlSD/uEajEuOhk7f5lBQZW8dERG5FwMnP2Jv6pSe2Y24SK3Fg3pSagwHU/QSW0NM6PRtVpP8ygmqWIZERN7DwMmP2MsY9cxuiI0FNT9jkEfPmxwbmqBnUNUTq1SJiLyHjcP9iK3GyOOSo7G3ssGpXnbkOc72oiMiIt/CjJOPEhvkUG5Wib2vfIuzk/yacNBLIiLfwIyTD5I7yKG9Xna2sPeVdzg7NAEg//NARETux4yTD5I75YpUpkJOLzsTZjPcx2KSX4n56KTKivMIEhH5DgZOPkhuNZujvezE5q5zZkJhss/mJL/d5qMzsVdWrHYlIvIdDJx8kFRA1D2DYTACFy52oF/fK9VvYr3sxDCb4T72rq3cTJ+cwU2JiMgzGDj5ILFhB0xTrvSkVgPBarXkmD5iD2lmM9xH6to6kunjwKVERL6DjcN9kNgcaDq9ddahX98QxEZosfjGNPN0HT2HJpBqXMxG5O4jdW3tDUHQfTLnvZUNGJcczXkE3WTDhg1ITU2FVqtFZmYmysrKZO33zjvvQKVSYc6cORbLBUHAypUrkZCQgNDQUGRlZeH48eNuOHMi8gYGTj4qLTYc8zMGYfGNaZifMchudkgqOJJ6SEv19qLekbq2jpblwTONmJQaY/F5oN7btm0b8vLysGrVKuzfvx/p6enIzs5GXV2d5H6VlZV45JFHcN1111mte+655/Dyyy+jqKgIpaWlCAsLQ3Z2NtrarH/4EJH/YeDkR5zNYEg9pMWyW3ww957Ute1NNopcZ+3atVi0aBFyc3MxevRoFBUVoW/fvti0aZPoPgaDAb/+9a+xevVqDB061GKdIAgoLCzEihUrMHv2bIwbNw5vvPEGqqur8f7777v53RCRJ7CNkx+RausiNQGwvcbFnMLDfcSurbNlSa7T0dGBffv2IT8/37xMrVYjKysLe/bsEd3vqaeeQmxsLO655x58+eWXFutOnjyJ2tpaZGVlmZdFRUUhMzMTe/bswbx586yO197ejvb2Kz9u9Hp9b94WEbkZM05+xNkMBqvjfI+zZUmuc/78eRgMBsTFxVksj4uLQ21trc19du/ejY0bN+K1116zud60nyPHLCgoQFRUlPkvJSXF0bdCRB7EjJOXODvopDMZDLljOpFnmcrS9FkoPlSD/uEaxEVqodO3ubUXHQc9dVxzczPuuusuvPbaaxgwYIDLjpufn4+8vDzzv/V6PYMnIh/GwMkL7HVFd+ahZi84YnWcb7L1WdDp2zAuORo6fVuvAl2xzxEHPe0yYMAABAUFQafTWSzX6XSIj4+32v7EiROorKzErFmzzMuMRiMAIDg4GOXl5eb9dDodEhISLI45fvx4m+eh0Wig0djOMhKR72Hg5AX2Gv86+1BjcOR+rs7UiH0WdPo2zM8Y1KvzFPsccdDTLiEhIZgwYQJKSkrMQwoYjUaUlJRgyZIlVtuPHDkS3333ncWyFStWoLm5GevWrUNKSgr69OmD+Ph4lJSUmAMlvV6P0tJSPPDAA+5+S0TkAQycvECqlxsfar7LHZkadw1A6mwvy0CTl5eHnJwcTJw4ERkZGSgsLERraytyc3MBAAsWLEBSUhIKCgqg1Wpx1VVXWewfHR0NABbLly1bhmeeeQbDhw/HkCFD8OSTTyIxMdFqvCci8k9eD5w2bNiA559/HrW1tUhPT8crr7yCjIwMm9t2dnaioKAAW7ZswdmzZzFixAisWbMG06dP9/BZ945ULzd3PdSkMiVs7yKPnKDW0WvZ2+lUnBkRnlO4XDF37lycO3cOK1euRG1tLcaPH4/i4mJz4+6qqiqo1Y71oXnsscfQ2tqK++67D42NjZgyZQqKi4uh1Wrd8RaIyMNUgtC9Capnbdu2DQsWLEBRUREyMzNRWFiI9957D+Xl5YiNjbXafvny5Xjrrbfw2muvYeTIkdixYwfy8vLw1Vdf4eqrr5b1mnq9HlFRUWhqakJkZKSr35IsFXUtNhtym6pRbD3U4qO05pHBHQ1wbE822/V6AETXMXiytH7ncXQarL8uIcFqLL4xTfI6i11Lqc+CvWBM6vXsfY7svaar+cL3zl/wWhF5niPfO68GTpmZmZg0aRLWr18PoKt9QUpKCh566CE8/vjjVtsnJibiiSeewOLFi83LbrvtNoSGhuKtt96S9Zq+clMyPQx7Nv4Ve5COS47Gt6cbLY4h9wG7taxK9CEKQHRdb9rYKJHUdZyfMcjueqkASKxRv7uCI6nXdAdf+d75A14rIs9z5Hvntao6Zwafa29vt0p3h4aGYvfu3aKv46uDy4k15BbrHWevmkiq/Y1UtY1Y3ByI7V3ssTfZbm8n9TUFVaayTosN7/WI8OxlSUTkWl4LnKQGnzt69KjNfbKzs7F27Vpcf/31GDZsGEpKSrB9+3YYDAbR1ykoKMDq1atdeu7uZuuhZm80aakHrL02LWzvIo+9YETqOjvbk7I3bZUYHBERuZ5fjRy+bt06DB8+HCNHjkRISAiWLFmC3Nxcycab+fn5aGpqMv+dPn3ag2fsOvZGk5Z6wEqNHM5RxR1ja/JlE2cn9bUX9NrCEeGJiLzDa4GTo4PPAcDAgQPx/vvvo7W1FadOncLRo0cRHh5uNdFmdxqNBpGRkRZ//sjeQ1LqASs1vQcn+XUdZ6dRcTboZdkREXme16rqHB18rjutVoukpCR0dnbir3/9K26//XYPnLHniDUilqomstf+RqzahkMRuEfPtmNS5SPWyLt70CvWkYBlR0TkWV4fjiAnJwd//vOfzYPPvfvuuzh69Cji4uIsBp8DgNLSUpw9exbjx4/H2bNn8fvf/x4nT57E/v37zQPR2ePrPVac6dLefV9Hekr15rXImr3r6WhPSnvDGPhT2fn6986X8FoReZ5f9KoDHB98rq2tDStWrMAPP/yA8PBw3HrrrXjzzTdlB03+oDcjhzuaVeIo5a5l73o62pNSKqvEsiMi8g6vjxy+ZMkS0aq5Xbt2Wfx76tSp+P777z1wVt7j6pHDnR2mgBzXm+tpK6hi2RER+R6vB05kSaqLuTNtWnozTAE5hmVHRKR8fjUcQSAQ60UVF6nF37+tRm1TGzoNgjn7UFHXYt6uoq4FW8uqsH7ncWwtq0JFXYvTPbbIcSw7IiLlY+DkY8S6mOv01tmF7gMomqp1ej6cDSJt/+0NU0COY9kRESkfq+p8kCtHDldBBZVKcHiYAnIOy46ISNmYcfITzo4cHhykYmbCy1h2RETKwYyTn7A3wKVUY2FmJryLZUdEpBzMOPkJe21a2FjYd7HsiIiUgxknPyKVfbA3JQt5F8uOiEgZGDj5oSlTpuDMmTNWy0+dOmXx78GDB1v8Ozk5Gbt373bruZE0lh0RkX9j4OSjpAZMPHPmjNWD1hY525BnseyIiPwb2zj5ILFxfboPmEhERESex4yTD7I3gWtycrLN/SSreyLiEP2jiVi/87hVBsuZ6UDImr3rWFHXgugJM4HRl4G2ZuDcCaBZB0BeVR0REXmfShBEhidWKL1ej6ioKDQ1NSEyMtLbp2PT+p3H0WmwLpaQYDUW35hmcx9BEJCYmIja2loAQGRkJHbs2IHMzEycONdqMVks0NVr66fjEgFAdB2DJ/l6TsgLWF5HqfXDBoaJlp2qZ3c7P+UP3ztfwWtF5HmOfO+YcfJBYuP6XDYasbWsyiqjcfjwYSxcuBDnO4IRnp4Ndd8oGC824bqZv8L4ofGY98QrUIdZdm3vPuVHT92zWySPvSyh2PoPvjqEd/7wkGjZvf7669AMHMyMIBGRj2AbJx9ka1yfCxc7cL65w6rdU/FX32DKlCk48EMtwkZdj6Dw/lCpgxEU3h9ho67DgR9q8fzLr+LcuTqr12lo7ZCcSJbks3cdba0/d64Oz7/8qmTZXf/TX2HTvw6wvRsRkY9g4OSDbA2Y2D9MY56iw0QQBDyypgiNjY3QpoyxcSQVtClj0Nqgw/sffADAsvovJizE7nQgJI+962i9XsD773+A1gadZNl1RA2yKjupbCEREbkXAycflRYbjvkZg7D4xjTMzxiEIBsldebMWZyuuwAAUPeNsnkcdWgk2k4fRvXZszh79qx5uWlkao5a7Rr2rmPP9WfOnEV19Vm0nT4sWXbqvlGoPlttUXYAM4JERN7CwMlP2MpolJeXw3hJDwAwXmyyuZ/xkh6XG86g9ciXOHX0oNWUH/amAyF57F3Hnuuryg+i9ciXuNxwRrLsTOuOHi23WMeMIBGRdzBw8hO2Mhptly6h7fThrv8/fRg9q+IAwbz+csMZ9G88as5gdQ+Mema3GDQ5x9517L6+f+NRXG7oGkFcquxM6y61XTKvYUbQtTZs2IDU1FRotVpkZmairKxMdNvt27dj4sSJiI6ORlhYGMaPH48333zTYpuFCxdCpVJZ/E2fPt3db4OIPISBk5+wldEYEdpifviaskqGlnoIhk4YWurNGQ2Tfv36eev06b8q6lqwtawK1dFjEZ6ejeCYZMmyM62L0aqZEXSDbdu2IS8vD6tWrcL+/fuRnp6O7Oxs1NVZd6YAgJiYGDzxxBPYs2cPDh48iNzcXOTm5mLHjh0W202fPh01NTXmv61bt3ri7RCRB3A4Aj/Sc6LYIcZp+NOaVeZ/X244g5YG63nQgmOSoU0ZA+OoadhaVsXu7F7SfSyn4SNG4YvdXyFs1HXmIEmq7IaOTufkv26wdu1aLFq0CLm5uQCAoqIifPzxx9i0aRMef/xxq+1vuOEGi38vXboUW7Zswe7du5GdnW1ertFoEB8f79ZzJyLvYMbJj2VmZmLixImS2wTHJCNs1PVIGTEW8QmJ7M7uRd17wiUnJyExMRGm3nO2sOzcq6OjA/v27UNWVpZ5mVqtRlZWFvbs2WN3f0EQUFJSgvLyclx//fUW63bt2oXY2FiMGDECDzzwAOrr60WP097eDr1eb/FHRL6LgZMfU6lUeP311xEdHS26jTZlDLRaLebMng2gq5EUu7N7h+VYTirMmTMbWq0W6lDbo9Sy7Nzr/PnzMBgMiIuLs1geFxdnHsXdlqamJoSHhyMkJAQzZ87EK6+8gltuucW8fvr06XjjjTdQUlKCNWvW4PPPP8eMGTNgMBhsHq+goABRUVHmv5SUFNe8QSJyC1bV+bkxY8Zg9+7dWLhwIQ78UAttyhjz6NNtpw9j0PAxmP3zn2PgwFiL/did3fN6jgg/cGAs7r47Fx9uexPl/62SY9n5voiICBw4cAAtLS0oKSlBXl4ehg4daq7GmzdvnnnbsWPHYty4cRg2bBh27dqFm2++2ep4+fn5yMvLM/9br9czeCLyYQycFGDMmDHY+tFO3JDzCFpauqpx+vZPxP8sW47k5CTYmo2Q3dk9b1JqDH6x9Bnom7tVxQgA6k8jbNSVqp6g8P6ImzQDra2tePvttwEAEZGRuDv3bgAsO1cZMGAAgoKCoNPpLJbrdDrJ9klqtRppaV1zRo4fPx5HjhxBQUGBVfsnk6FDh2LAgAGoqKiwGThpNBpoNLYHUCUi38PAyUdV1LWIzk82ZcoUnDnToyHx0GvQ0nFlvIL29nb85S/vAUYjoFIDqisPX3Zndy+xskuLDYf+0GeoD+oHdWgkjJf0aDt9GNqUMQjq0d67paUVgtEIlVoFUzUdwKEIXCkkJAQTJkxASUkJ5syZAwAwGo0oKSnBkiVLZB/HaDSivd32lDsAcObMGdTX1yMhIaG3p0xEPoCBkw/q3vsKgLlRsKkb+pkzZ3Dq1CmLfSITM6FSWxZnY2MTBEMnLh7b09UAOXEw4qO07JnlRvbKDs06tJyyHCdIPeIa2wcTDGg98t+yiwxn2blBXl4ecnJyMHHiRGRkZKCwsBCtra3mXnYLFixAUlISCgoKAHS1R5o4cSKGDRuG9vZ2/OMf/8Cbb76JV199FQDQ0tKC1atX47bbbkN8fDxOnDiBxx57DGlpaRa97ojIfzFw8kG2Gv+aGgWLPTSNF5sQFN7fevl/Rw5vaTiD/o2DMT/jzy4/X7rCXtklJydb76QNQmOPZkvR0VHAxUb0iwgCGo8iObwF8zMGuemsA9fcuXNx7tw5rFy5ErW1tRg/fjyKi4vNDcarqqqgVl/pQ9Pa2ooHH3wQZ86cQWhoKEaOHIm33noLc+fOBQAEBQXh4MGD2LJlCxobG5GYmIhp06bh6aefZnUckUKoBMFWCxjl0uv1iIqKQlNTEyIjbfdm8rb1O4+j02BdLCHBaiy+Mc12VV1EHBqjhqF7tU50VBRQta/rHwOHITI2Gfl5S6yyFlLVguQYqbLLHhNv8zpX1LXgo4PVFm3RVCrgp+MSAUARZeMP3ztfwWtF5HmOfO8YOPmgrWVVFr2vTExVNWIPUlMA1NDaYR4sEYBF1RFw5aFsemhLrSfHiJWdWt3V3Ky7nuXgaNn5E3/43vkKXisiz3Pke8eqOh80KTXGZgYiLlIr2X6m58jiQNeDvKfuVUfOVAuSOLGyg6BCz/noul9nZ8qOiIg8j4GTDzLNS9czA2EvyLFV5WY56OIVprGA7K0nx4iVXfGhGhhtjH9ous7OlB0REXkeAycfZSsDUXyoxua2Da0dor25VN3aPHVnGguo56CMPdeT42yVndR1drbsiIjI8zjlih/pH267V05MWIhoNgoqoauqqJvuYwFNSo2RXE+uIXWdnS07IiLyPAZOfkTq4StWrROsVuOn4xIRH6VFSLAa8VFai8bFpqolsfXkGlLX2dmyIyIiz2NVnR8Raz+TFhsuWRVkq+qo53H5MHY/sevcm7IjIiLPYuDkZ8QepGK9uVit4/tYdkRE/oNVdQrBKjf/xbIjIvIfDJwUKMDGNFUUlh0RkW9j4KQQpi7ttU1t6DQI5i7tFXUt3j41soNlR0TkPxg4KYTU4Jjk21h2RET+g4GTQnCUaf/FsiMi8h8MnBRCanBM8m0sOyIi/8HASSE4Arj/YtkREfkPrwdOGzZsQGpqKrRaLTIzM1FWVia5fWFhIUaMGIHQ0FCkpKTg4YcfRlub9eCBgYZd2v0Xy46IyH94dQDMbdu2IS8vD0VFRcjMzERhYSGys7NRXl6O2NhYq+3ffvttPP7449i0aROuueYaHDt2DAsXLoRKpcLatWu98A58C0eZ9l8sOyIi/+DVjNPatWuxaNEi5ObmYvTo0SgqKkLfvn2xadMmm9t/9dVXuPbaa3HHHXcgNTUV06ZNw/z58+1mqYiIiIhcwWuBU0dHB/bt24esrKwrJ6NWIysrC3v27LG5zzXXXIN9+/aZA6UffvgB//jHP3DrrbeKvk57ezv0er3FHxEREZEzvFZVd/78eRgMBsTFxVksj4uLw9GjR23uc8cdd+D8+fOYMmUKBEHA5cuXcf/99+N3v/ud6OsUFBRg9erVLj13IiIiCkxebxzuiF27duGPf/wj/vSnP2H//v3Yvn07Pv74Yzz99NOi++Tn56Opqcn8d/r0aQ+eMRERESmJ1zJOAwYMQFBQEHQ6ncVynU6H+Ph4m/s8+eSTuOuuu3DvvfcCAMaOHYvW1lbcd999eOKJJ6BWW8eBGo0GGo3tcXKIiIiIHOG1jFNISAgmTJiAkpIS8zKj0YiSkhJMnjzZ5j4XL160Co6CgoIAcHJUIiIicj+vDkeQl5eHnJwcTJw4ERkZGSgsLERraytyc3MBAAsWLEBSUhIKCgoAALNmzcLatWtx9dVXIzMzExUVFXjyyScxa9YscwBFRERE5C5eDZzmzp2Lc+fOYeXKlaitrcX48eNRXFxsbjBeVVVlkWFasWIFVCoVVqxYgbNnz2LgwIGYNWsW/vCHP3jrLXhcRV0L9lY2oL6lHf3DNZiUGsPxf/wEy46IyP+phACr49Lr9YiKikJTUxMiIyO9fToOqahrwd+/rbZYplKBo0z7gUAvO3/+3nkarxWR5znyvfNqxokcs7eywWqZIHQtT4sNZ0bDh9kru+5YjkREvsuvhiMIdPUt7TaXN7R2mDMatU1t6DQIqG1qw0cHq1FR1+LhsyRbpMquO5aj5zkyX+b27dsxceJEREdHIywsDOPHj8ebb75psY0gCFi5ciUSEhIQGhqKrKwsHD9+3N1vg4g8hIGTH+kfbntYhZiwEMmMBnmfVNl1x3L0LNN8matWrcL+/fuRnp6O7Oxs1NXV2dw+JiYGTzzxBPbs2YODBw8iNzcXubm52LFjh3mb5557Di+//DKKiopQWlqKsLAwZGdnczJyIoVg4ORHJqXGQKWyXKZSdS2Xm9Eg75Aqu+5Yjp7l6HyZN9xwA37+859j1KhRGDZsGJYuXYpx48Zh9+7dALqyTYWFhVixYgVmz56NcePG4Y033kB1dTXef/99D74zInIXBk5+JC02HD8dl4j4KC1CgtWIj9KaGxfLzWiQd9gqu3HJ0dhb2YD1O49ja1kVKupaWI4e5Mx8md0JgoCSkhKUl5fj+uuvBwCcPHkStbW1FseMiopCZmam6DE5nyaRf2HjcD+TFhtus6HwpNQYfHSwGt37SNrKaJD3dC+7nr3sTG2ZxiVHQ6dvYzl6gDPzZQJAU1MTkpKS0N7ejqCgIPzpT3/CLbfcAgCora01H6PnMU3reuJ8mkT+hRknhZDKRpHvEWvLpNO3sRx9XEREBA4cOIC9e/fiD3/4A/Ly8rBr1y6nj8f5NIn8i9MZJ0EQsGvXLlRUVCAhIQHZ2dno06ePK8+NHCSWjSLfI9WWieXoGc7Mlwl0VeelpaUBAMaPH48jR46goKAAN9xwg3k/nU6HhIQEi2OOHz/e5vE4nyaRf5Gdcbr11lvR1NQEAGhoaMDkyZNx880344knnjA3gjx37pzbTpR6r6KuBVvLqiza1JB3SLVlYjl5hjPzZdpiNBrR3t4VCA8ZMgTx8fEWx9Tr9SgtLXXomETku2QHTsXFxeabw4oVK9Dc3IwTJ06grq4Op06dQlhYGFauXOm2EyV5xB66HB/It4j1souL1LKcPCgvLw+vvfYatmzZgiNHjuCBBx6wmi8zPz/fvH1BQQE+/fRT/PDDDzhy5AhefPFFvPnmm7jzzjsBACqVCsuWLcMzzzyDDz/8EN999x0WLFiAxMREzJkzxxtvkYhczKmqup07d+K5557DkCFDAADJyclYs2YNFi1a5NKTI8eINTj+6bhEh0auJvcztUnbW9mAhtYOxISFYFJqDMvJwxydL7O1tRUPPvggzpw5g9DQUIwcORJvvfUW5s6da97mscceQ2trK+677z40NjZiypQpKC4uhlar9fj7IyLXkz1XnVqthk6nw8CBAxEXF4edO3dizJgx5vWnTp3CiBEjfH6QNyXPA7W1rAq1TdbXPz5Ki/qWdnQarIs6JFiNxTemeeL0SIb1O48rspyU/L1zNV4r8kVKnwrKbXPVLVy4EBqNBp2dnTh58qRF4FRbW4vo6GinTpgcI/YBlmpw3D9cYzOo4vhAvoXlRES+Rqo2Q0nBk1yy2zjl5OQgNjYWUVFRmD17Ni5evGix/q9//atorxFyHam2SlINjuWOXE3exXIiIl/DqaAsyc44bd68WXL9qlWrEBQU1OsTImlSH2CpQTDF2tQE4q8Fb7CX5u6+XqUCVFAhOEjFciIir+NUUJZcNnJ4WFiYqw5FEuyN/yMVHHF8IO+wl+buuR4AVCoB2WMSWF5E5HVsQmDJZYHTBx98gKamJixYsMBVhyQb7H2AGRz5Hns95diTjoh8Gaf0suSywGn58uU4fvw4Ayc3k/oAK73Xg7+yl+ZmGpyIfBmbelhyWeAkNSkmuY7YBxgAez34KHtZQqbBHXfixAls3rwZJ06cwLp16xAbG4t//vOfGDRokEVvXyJyDdZmXMFJfv1QWmw45mcMwuIb0zA/Y5Dd6h7yLns95diTzjGff/45xo4di9LSUmzfvh0tLV2jqn/77bdYtWqVl8+OiJTO4YxTWVkZ9uzZg9raWgBAfHw8Jk+ejIyMDJefHMnH6h7fJafRPtPg8j3++ON45plnkJeXh4iICPPym266CevXr/fimRFRIJAdONXV1eG2227Dv//9bwwaNMg8JYFOp8PDDz+Ma6+9Fn/9618RGxvrtpMlcazu8W320txMg8v33Xff4e2337ZaHhsbi/Pnz3vhjIgokMiuqnvwwQdhMBhw5MgRVFZWorS0FKWlpaisrMSRI0dgNBqxePFid54rSWB1DwWK6Oho1NTUWC3/5ptvkJSU5IUzIqJAIjtw2rFjBzZs2IARI0ZYrRsxYgRefvllFBcXu/TkSD5TdU98lBYhwWrER2nZMJwUad68eVi+fDlqa2uhUqlgNBrx73//G4888gh79RKR28muqtNoNNDr9aLrm5ubodHYnvKDPIPVPRQI/vjHP2Lx4sVISUmBwWDA6NGjYTAYcMcdd2DFihXePj0iUjjZGae5c+ciJycHf/vb3ywCKL1ej7/97W/Izc3F/Pnz3XKSREQmISEheO2113DixAl89NFHeOutt3D06FG8+eabnPaJiNxOdsZp7dq1MBqNmDdvHi5fvoyQkK5Gxx0dHQgODsY999yDF154wW0nSkTU3aBBgzBo0CBvnwYRBRiHqupeffVVrFmzBl9//TV0Oh2AruEIJkyYgMjISLedJBGRiSAI+Mtf/oLPPvsMdXV1MBqNFuu3b9/upTMjokDg8DhOkZGRuOmmm9xxLkREdi1btgx//vOfceONNyIuLg6qnt1JiYjcyOHAyWAw4K233sKOHTtw4cIFpKWlYcmSJTZ72xERudqbb76J7du349Zbb/X2qRBRAHIocDp37hxmzJiBsLAw5OTkICEhAfv27cNNN92E9957D9dcc427zpOICAAQFRWFoUOHevs0iChAye5VZzAYMH36dMycOROff/457r77bsyYMQMrVqzAa6+9hqVLlwIA1q1bh8uXL7vthIkosP3+97/H6tWrcenSJW+fChEFINkZp40bN0Kr1WL16tV44IEH0N5+ZW40o9GIb775Bnq9HiUlJejs7MQjjzzilhMmosB2++23Y+vWrYiNjUVqair69OljsX7//v1eOjMiCgSyA6dt27bh/vvvBwAkJSXhueeew7x58xAeHo533nkHixYtQnBwMB5//HEsWLCAgZMXVNS1YG9lA+pb2tE/XMOJYkmRcnJysG/fPtx5551sHE5EHqcSBEGQs2FycjI+/vhjpKenY8aMGbjrrrtwxx13AACOHj2KadOmobKyEoIgQKPRoK6uDjExvjdPml6vR1RUFJqamhQ1hEJFXQv+/m21xTKVCpx2hXyCK793YWFh2LFjB6ZMmeKis/MtSr1HEfkyR753DrVx6uzsBNCVCh89erR5XVpaGmpqalBXV4egoCCo1WqLqjxyv72VDVbLBMH2ciJ/lpKSwoCCiLxGduCUlpaGo0ePAgAmTZqE1atXQ6fTobm5GU888QQSEhIQHx+PEydOICQkBHFxcW47abJW32I7UG1o7fDwmRC514svvojHHnsMlZWV3j4VIgpAsgOnOXPm4LXXXgMA/PnPf4Zer0dCQgKio6Pxz3/+0zxa7xtvvIEZM2ZArZZ9aHKB/uG2J1iOCQvx8JkQudedd96Jzz77DMOGDUNERARiYmIs/oiI3El24/D7778fL7/8MjZt2oS7774bJSUluHjxIjo7OxEVFQUA+Oabb/Dyyy/jyy+/dNsJk22TUmPw0cFqdG+xplJ1LSdSksLCQm+fAhEFMNmBU1hYGLZv346ZM2fixIkTePTRRxEdHQ2gq/3Tm2++iUcffRTr1q3DVVdd5a7zJRFpseH46bhE7K1sQENrB2LCQtirjhQpJyfHpcfbsGEDnn/+edTW1iI9PR2vvPIKMjIybG772muv4Y033sChQ4cAABMmTMAf//hHi+0XLlyILVu2WOyXnZ2N4uJil543EXmHQyOHT5gwAaWlpcjPz8fgwYMxZMgQhIaGory8HOnp6fjwww8xefJkd50r2ZEWG85AiRRJr9ebG4Tr9XrJbR1pOL5t2zbk5eWhqKgImZmZKCwsRHZ2NsrLyxEbG2u1/a5duzB//nxcc8010Gq1WLNmDaZNm4bDhw8jKSnJvN306dOxefNm8781GttV6UTkf2QPR9BTa2srjh07hsuXL2Po0KHo37+/q8/NLdjVl8jzevu9CwoKQk1NDWJjY6FWq22O3SQIAlQqFQwGg+zjZmZmYtKkSVi/fj2ArsF8U1JS8NBDD+Hxxx+3u7/BYEC/fv2wfv16LFiwAEBXxqmxsRHvv/++7PPojvcoIs9z5HvnUMZJr9ejtLQUHR0dyMjIwNVXX92rEyUikmPnzp3mht+bN29GSkoKgoKCLLYxGo2oqqqSfcyOjg7s27cP+fn55mVqtRpZWVnYs2ePrGOY2nn2bJS+a9cuxMbGol+/frjpppvwzDPPiP64bG9vtxi+xV5GjYi8S3bgdODAAdx6663Q6XQQBAERERF49913kZ2d7c7zIyLC1KlTzf9/9913m7NP3dXX1yMrK0t2G6jz58/DYDBYDZ0SFxdnHnrFnuXLlyMxMRFZWVnmZdOnT8cvfvELDBkyBCdOnMDvfvc7zJgxA3v27LEK9gCgoKAAq1evlvV6ROR9sscMWL58OYYMGYLdu3dj3759uPnmm7FkyRKXnMSGDRuQmpoKrVaLzMxMlJWViW57ww03QKVSWf3NnDnTJedC5C4VdS3YWlaF9TuPY2tZFSrqWtyyj9KZquR6amlpgVar9dh5PPvss3jnnXfwt7/9zeJ1582bh5/97GcYO3Ys5syZg48++gh79+7Frl27bB4nPz8fTU1N5r/Tp0976B0Q2cd7kDXZGad9+/bhk08+wY9//GMAwKZNmxATE2PRaNMZjjbO3L59Ozo6rgzqWF9fj/T0dPzqV79y+hz8Beei8189p8SpbWrDRwerJafEcWYfJcvLywMAqFQqPPnkk+jbt695ncFgQGlpKcaPHy/7eAMGDEBQUBB0Op3Fcp1Oh/j4eMl9X3jhBTz77LP417/+hXHjxkluO3ToUAwYMAAVFRW4+eabrdZrNBo2HiefxHuQbbIzTg0NDUhOTjb/Ozo6GmFhYaivr+/VCaxduxaLFi1Cbm4uRo8ejaKiIvTt2xebNm2yuX1MTAzi4+PNf59++in69u2r+MDJ9AGubWpDp0Ewf4C7R//8ZeC7nJkSh9PoWPrmm2/wzTffQBAEfPfdd+Z/f/PNNzh69CjS09Px+uuvyz5eSEgIJkyYgJKSEvMyo9GIkpISyd7Bzz33HJ5++mkUFxdj4sSJdl/nzJkzqK+vR0JCguxzI/IFvAfZ5lDj8O+//x61tbXmfwuCgCNHjqC5udm8zN6vr+5c0Thz48aNmDdvHsLCwmS/rj+S+gCnxYbzl4GPc2ZKHE6jY+mzzz4DAOTm5mLdunUu6XGWl5eHnJwcTJw4ERkZGSgsLERraytyc3MBAAsWLEBSUhIKCgoAAGvWrMHKlSvx9ttvIzU11Xw/DA8PR3h4OFpaWrB69Wrcdttt5imoHnvsMaSlpbE9KPkd3oNscyhwuvnmm9Fz9IKf/vSn5v93tCtwbxtnlpWV4dChQ9i4caPoNkrpsWLvA2wvsCLv6h+uQW1Tm9Vy05Q4tqph7e0TqLqPj9Rbc+fOxblz57By5UrU1tZi/PjxKC4uNt+TqqqqLKaPevXVV9HR0YFf/vKXFsdZtWoVfv/73yMoKAgHDx7Eli1b0NjYiMTEREybNg1PP/00q+PI7/AeZJvswOnkyZN2t+meefKEjRs3YuzYsaKj/ALK6bFi7wPMXwa+TWpKHLFs4bjkaOj0bZxGx82WLFki2tGlZ4NuexMLh4aGYseOHS46MyLvcnQqr0Bphyu7jdPgwYNt/sXExGDHjh24/fbbkZ6e7tCL96ZxZmtrK9555x3cc889ktsppcfKpNQY9OxI1P0DzEl+fZtpSpz4KC1CgtWIj9Kaq1HFsoU6fZvoPkRE7iZ13+pJTjtcpXCoqq67L774Ahs3bsRf//pXJCYm4he/+IV59F25ujfOnDNnDoArjTPtDXXw3nvvob29HXfeeafkdkrpsWJvLjpO8uv7xKbEkcoWchodIvKmnvcgUyeknlmlQGou4lDgVFtbi9dffx0bN26EXq/H7bffjvb2drz//vsYPXq0UyfgaONMk40bN2LOnDl+M9WLK0g9RDnJr/9iOwIi8gdSnZACqbmI7MBp1qxZ+OKLLzBz5kwUFhZi+vTpCAoKQlFRUa9OwNHGmQBQXl6O3bt345NPPunVaysNsxP+idlCIvIHUlmlQPoBKHuS3+DgYPzmN7/BAw88gOHDh5uX9+nTB99++63TGSdP4wSa5ItMjSqVmi3k904+XivyBHsNuW2tLz5Ug06DdcgQEqxG9ph4mz8A/aVdplsm+d29ezc2btyICRMmYNSoUbjrrrswb968Xp8sETFbSESeY2/cP7H1KlhPdQR0ZZUCqbmI7MDpJz/5CX7yk5+gsLAQ27Ztw6ZNm5CXlwej0YhPP/0UKSkpiIiIcOe5EhERUS/Za8gttl6lFqD67/+bdG9WECg/AGUPR2ASFhaGu+++G7t378Z3332H3/72t3j22WcRGxuLn/3sZ+44RyIiInIRew25xdYHq9VWwxOMS47G3sqGgJrqy+HAqbsRI0bgueeew5kzZ7B161ZXnRMRERG5ib1x/6TWp8WGY37GICy+MQ2TUmPw7enGgBi7qbteBU4mQUFBmDNnDj788ENXHI6IiIjcxN6AyvbWmwTqJMBOD4BJRK4TKFMVEJH32WvIbWt9XKQWeysbUHyoxnyPCqSxm7pj4ETkZfZ6uBAROULODzF7Dbm7r3eml52SMXAi8rJAmqqAiNzLHT/EnO1lp9RMOgMnIi8L1HQ3EbmevR9izgQzUr3sssfE26zyU3ImnYGTgig1ule6QJqqgIjcS+qHmLPBjNQ9SqzKT8mZdJf0qiPvM30hAq1bqBLI7cFCRGSP1FACzvaCk7pHVdS1YGtZldU4TkrOpDNwUohA7RaqBKYeLN0HlVNCOpuIPE8qyHE2mBG7RwEQ/cFub6wof8aqOoVQcnQfCAJlqgIici+poQakqtzkNvUQurUEl/rBPik1xuakv0rIpDNwUgi2kyEiIkD8h5hYMBMXqXVq0t+mS52I1Paxep2G1g5FT/rLwEkhlBzdK4G9X3Ns2E9E7iYWzDg76W/jRduBk+kHu1Iz6QycFELJ0b2/s9eTRcnddonIt9gKZooP1djc1t6kv/369oFKJT6Ok1IxcFIQpUb3/s7ZX3NK6LZLRL7PXlMPsfXD4yLMGatA+sHOwInIzew13GfDfiLyJntNPaTWB+IPdgZOfojtYfyLs7/m2LCfiDzBmUl/A/m5w8DJz7A9jP/pza85IiJPcGTS30DHwMnPsD2M/+GvOaIuzJaTEjBw8jNsD+Of+GuOAh2z5aQUnHLFz0gNYy82ZxARiduwYQNSU1Oh1WqRmZmJsrIy0W1fe+01XHfddejXrx/69euHrKwsq+0FQcDKlSuRkJCA0NBQZGVl4fjx4+5+Gz6P00KRUjBw8jNi8xCZRn7lJL9E8m3btg15eXlYtWoV9u/fj/T0dGRnZ6Ours7m9rt27cL8+fPx2WefYc+ePUhJScG0adNw9uxZ8zbPPfccXn75ZRQVFaG0tBRhYWHIzs5GW5t1B4BAwmw5KYVK6D7xTADQ6/WIiopCU1MTIiMjvX06TjG1E+g58qutnlnxUVrMzxjkhbMkusJXv3eZmZmYNGkS1q9fDwAwGo1ISUnBQw89hMcff9zu/gaDAf369cP69euxYMECCIKAxMRE/Pa3v8UjjzwCAGhqakJcXBxef/11zJs3z+4xffVa9dbWsireo8hnOfK9Y8bJD6XFhmN+xiAsvjEN8zMGIS02nL/miBzU0dGBffv2ISsry7xMrVYjKysLe/bskXWMixcvorOzEzExXT0gT548idraWotjRkVFITMzU/SY7e3t0Ov1Fn9KJJYtZ+9R8jcMnBRCqu0TEVk7f/48DAYD4uLiLJbHxcWhtrZW1jGWL1+OxMREc6Bk2s+RYxYUFCAqKsr8l5KS4uhb8Qum3qPxUVqEBKsRH6Vlw3DyS+xVpxAcC4jIs5599lm888472LVrF7RardPHyc/PR15envnfer1e0cETAyXyd8w4KQR/zRE5ZsCAAQgKCoJOp7NYrtPpEB8fL7nvCy+8gGeffRaffPIJxo0bZ15u2s+RY2o0GkRGRlr8EZHvYuCkILbaPhGRbSEhIZgwYQJKSkrMy4xGI0pKSjB58mTR/Z577jk8/fTTKC4uxsSJEy3WDRkyBPHx8RbH1Ov1KC0tlTwmEfkPVtURUcDKy8tDTk4OJk6ciIyMDBQWFqK1tRW5ubkAgAULFiApKQkFBQUAgDVr1mDlypV4++23kZqaam63FB4ejvDwcKhUKixbtgzPPPMMhg8fjiFDhuDJJ59EYmIi5syZ4623SUQuxMCJiALW3Llzce7cOaxcuRK1tbUYP348iouLzY27q6qqoFZfScy/+uqr6OjowC9/+UuL46xatQq///3vAQCPPfYYWltbcd9996GxsRFTpkxBcXFxr9pBEZHv4DhOROR2/N7Jx2tF5Hkcx4mIiIjIDRg4EREREcnENk5ERETkEqYpwepb2tE/XINJqTGK6+HNjBMRERH1WkVdS0BMNs+MExEROSUQsgtkTazc91Y2WG0rCMDeygZFfS4YOBERkcNM2QUTU3bBVTMWMCjzTVLlHiiTzbOqjoiIHCaVXeitQKny8UdS5R4ok80z40RERA6zl12QkzEK9CofXzRlyhScaeoEBg4DtBFAWzNw7gROHSoDAEROvh0qdTCio6Ms9osMD8P2l1cFxGTzzDgREZHDpLILcjJGUtsESpWPLzrT1InGqDQ0dqjQqG/p+m/UMATHJAMAjBebAACNjU0Wf/q6swEz2TwzTkRE5LBJqTGi2QU5GSN7VT61TW1W65VW5eOTBg4DrOJTFbQpY9DScAZtpw8jbNR1AFTd1gvAuRMAuiabV1qg1BMzTkQ+oKKuBVvLqrB+53FsLatiWw7yeVLZBTkZI6ltJqXGQKWyXK7EKh9fFBmbjOjoKERHRyEiIsJcDurQrmlILjecQeuRL2FoqYdg6IShpR5h9eVIjurjxbP2LK8HThs2bEBqaiq0Wi0yMzNRVlYmuX1jYyMWL16MhIQEaDQa/OhHP8I//vEPD50tkeuxISz5q7TYcMzPGITFN6ZhfsYgc6ZBTiNhqW0CpcrHUxz5YZaftwRLly7D0qVLERERYc4oGi/pERyTjPD0bPQdcQ0A4OKxPWj5dgeSIoLw5ZdfeuKt+ASvVtVt27YNeXl5KCoqQmZmJgoLC5GdnY3y8nLExsZabd/R0YFbbrkFsbGx+Mtf/oKkpCScOnUK0dHRnj95IhdhQ1hSGqlqPLnbKL3Kx1PDLTg6bISpXE6fPovqatN+Ai7rzyNs1PXm7YLC+yNs1HVoPfIl9u7di7KyMmRmZrr8/KV4a8gKr2ac1q5di0WLFiE3NxejR49GUVER+vbti02bNtncftOmTWhoaMD777+Pa6+9FqmpqZg6dSrS09M9fOZErsOGsKQ0YhkjAObMx97KBoxLjg7IrJIns8yODhthKruq8oPmqrjWI18iOHKAja272j4BwPvvv+/Cs7bPm5l6r2WcOjo6sG/fPuTn55uXqdVqZGVlYc+ePTb3+fDDDzF58mQsXrwYH3zwAQYOHIg77rgDy5cvR1BQkKdOncil2BCWlKhnxshW5kOnbwuYYKm7jw/W4NDZJlzsuIy+IcFIjA5FTFiIOcvsykyKMz/M0mLD0b/xKPT/ec+8TP3f6rmeTG2fLly4AMD1WSBfHLLCa4HT+fPnYTAYEBcXZ7E8Li4OR48etbnPDz/8gJ07d+LXv/41/vGPf6CiogIPPvggOjs7sWrVKpv7tLe3o739ygdHr9e77k34GI6065/kVGsQ+TtWSXepqGvBf36oh/G/X/iW9ss4pmvGj+IiEBKstlu15uh9XuqHmdSx+vXrZ7G98WITgsL7Wx3HeElv3t7Vo8n76ijlXm8c7gij0YjY2Fj87//+LyZMmIC5c+fiiSeeQFFRkeg+BQUFiIqKMv+lpKR48Iw9hw2M/RcbwlIgYJV0l72VDegbYl1DUt14yZx16skUYNq7z9tqBC7WQzEuUit5rIk3/RTh6dmInHw7wtOzcVl/HoDQ88zQdvowAGDOnDkuH03eV0cp91rGacCAAQgKCoJOp7NYrtPpEB8fb3OfhIQE9OnTx6JabtSoUaitrUVHRwdCQqwvWH5+PvLy8sz/1uv1igye+GvOvym9ISwRq6S71Le0IzE6FMd0zRbLL3UaMCk1BsWHamzu19DaYTcwEcvO/HRcIvZWNqChtQMxYSGSY2398oHlaDz2NTB4AkKiYmEwGBAU3h9B4TForz6G4MgBXdVz6iBAAPqOuAaq9hb8ZsUfcFf+i6Ln7gypYDt7TLxkpt6dNTBeC5xCQkIwYcIElJSUYM6cOQC6MkolJSVYsmSJzX2uvfZavP322zAajVCru5Jlx44dQ0JCgs2gCQA0Gg00GtuRqZLw1xwR+TJnq6SV1gShf7gGx3QtqGtuQ+PFTgSpVUiKDsVNo2K72hZJBJhS93mpoKr7UBEmYgFa46XLqA/qh6DGph5rVAiOHICWb3cgOCa5q4edCgDUQGg0dCFRMAg9M1JXzl2qHMXWSV0LU6a+Z0Boqs505wTUXh2OIC8vDzk5OZg4cSIyMjJQWFiI1tZW5ObmAgAWLFiApKQkFBQUAAAeeOABrF+/HkuXLsVDDz2E48eP449//CN+85vfePNt+AT+miMiX2bvQWfrwenuB6A3GI0C9p26AEAwV9nVt3ZgQFjXD3x7I7I7E1TZur5izwy0NUPdN8p6Oa40BDf1pLOgAiCooFIJVuduqhY06V6OgHimzNEhK0xVlZ8drYP+Uqd5e1MDfFfVwHg1cJo7dy7OnTuHlStXora2FuPHj0dxcbG5wXhVVZU5swQAKSkp2LFjBx5++GGMGzcOSUlJWLp0KZYvX+6tt+Az2MCYiHyBVGbBVpW0VHCkxCYIX5+6gP5hIWhu60SnsSvIEAQB/1d6Cmq1CpNSY0QDTAAOB1WXjUab13dccjR0+jbrICeoBdCGAz2Cp8bGJnNDcHXfKISHhyM4+EqzmYjISAQHqZA9JkF2taBY26fumTKpa9Fd989RXXMbzjW3A1Chf1gIjAJwTNeMPkEqq/2c4fW56pYsWSJaNbdr1y6rZZMnT8Z//vMfN5+V/5H6NUdE5AnOZIikHqpKbIJwrrkNoSFBCA0JwqUOA+pbu95jS/tli+s1P2OQOQgtPlRjDkJN9/njumZcuNiJ6L59sLeyAXGRWpuBEAQVejbqFgSYh4Lo+cxY9umHqKhrsRmgmcpxa1mV3RoOodvOUuUoiFTvmcpYLKskNTxBW6fRdBZobutE6H8zexcudtp8LUd5PXAi12EDYyLyJmcyRFIPVSU2QRgYoUV14yUAQHPblQd535Cux7Gcxt6TUmNQ29SGCG0f8zqdvs2cReoeCBUfqoHRYH0eDa0dFs+MnkFaz2PFRWrN6w2CgAsXO9Cv75VykKqSU8F2psdUjnLLWO7wBNo+ajT/95CdxiuBWb++rplPj4ETERG5hL0MkSNtbUwPfqU1QZiVnoj//eIEBAHoNJjemAo/ioswbyOnB52tdTp9G+ZnDLJYLif4tDc4ac/1JmqVCsFBKrtVciq10NUESqQc5ZaxveEJTO+zf5gGRmNXYKpSqxCu6WrjNLzbNe4NBk5EROQS9gZbdKStjakKRmlNEG4a2TUP69+/rUZ9SweCg7qCpiEDwszb2Gvsba96qzs5wae9TKGt9f36hiA2UmMRqIn11AtWq5E9Jt6iHE0ZrPqWdqhUgApXgrDu2a3u1XFyhydIjA5FS/tlhIYE4UdxEYgJC3FpwM3AiYiIXMJej7CepNraSDUo93c3jYzFTSNjRdsS2etBB0hXb/XM7Nmqwut+Te1lCuW2NbM3fED3asGeGSyVSkD2mAQA4lWUcocnCAlWY0C4BlAJCFarXR5wM3BSEKWNdxJIWHbes2HDBjz//POora1Feno6XnnlFWRkZNjc9vDhw1i5ciX27duHU6dO4aWXXsKyZcsstvn973+P1atXWywbMWKE6FRS/krsMysWBEkN7CgVHCn5u2EvoyaVKRJbJ6farWc2x151nty2ZnKrVp3tZefo8ATuwsBJIZQ43kmgYNl5z7Zt25CXl4eioiJkZmaisLAQ2dnZKC8vR2xsrNX2Fy9exNChQ/GrX/0KDz/8sOhxx4wZg3/961/mfwcHK+tWa+8za+tz60xD70D4bohdL3tBldi6rWVVVsey1+BcqroUkA6I7GW3bFW7OVsN6StVt8r6NgcwJY53EihYdt6zdu1aLFq0yDzoblFRET7++GNs2rQJjz/+uNX2kyZNwqRJkwDA5nqT4OBg0amjlMCZz6wjD19bXczlvo6SSGVQxNY5M7q4nOpSW+sB60BMqlG5uZedyHBKcqohfaHq1q8m+SVxShzvJFCw7Lyjo6MD+/btQ1ZWlnmZWq1GVlYW9uzZ06tjHz9+HImJiRg6dCh+/etfo6rKOgvgz5z5zIpNZg1AdLJZfjccJzX5rZzrKZbxSYsNx/yMQVh8Y5p5Chd7VW5i67tGGLdcbgqixSYl9qWelMw4KYQSxzsJFCw77zh//jwMBoN5pgKTuLi4XrVHyszMxOuvv44RI0agpqYGq1evxnXXXYdDhw4hIsK6O3R7ezva26880PR6vdOv7Sn2es85MnK4VNUSvxuOc2bKlssGwW6VqK1ydbZRudgI4/aqIX0FAyeFUOJ4J4GCZacsM2bMMP//uHHjkJmZicGDB+Pdd9/FPffcY7V9QUGBVWNyXyf2mZWak8yZATC7dzHv/jr8bohzpsE5VELPwcUtqkRFq9zsDGwpt5edrffgS4FSTwycFMJXGs2R41h23jFgwAAEBQVBp9NZLNfpdC5tnxQdHY0f/ehHqKiosLk+Pz8feXl55n/r9XqkpKS47PXdQewza69NkqMDYPK74RxHG5wXH6qBsWfkhCuZI2cHtlTqj0IGTgri61E6iWPZeV5ISAgmTJiAkpISzJkzBwBgNBpRUlIiOn+mM1paWnDixAncddddNtdrNBpoNLbbpfgyW59ZqSEHnBkAU+x1yHm2rqe9KlHRKjcbA1vKaVTu7+XJwElBlDzeidKx7LwjLy8POTk5mDhxIjIyMlBYWIjW1lZzL7sFCxYgKSkJBQUFALoalH///ffm/z979iwOHDiA8PBwpKWlAQAeeeQRzJo1C4MHD0Z1dTVWrVqFoKAgzJ8/3ztv0oOkHsDO9ugi97OXGXK2yg1QZuDLwEkhAmG8E6Vi2XnP3Llzce7cOaxcuRK1tbUYP348iouLzQ3Gq6qqoFZf6XxcXV2Nq6++2vzvF154AS+88AKmTp2KXbt2AQDOnDmD+fPno76+HgMHDsSUKVPwn//8BwMHDvToe/MGqQewswNgkvvZywwptcrNWSpBrO+hQun1ekRFRaGpqQmRkZHePh2X2VpWZfMXQXyU1mrSR/ItgVB2Sv3euYO/XytT9tTWwIxK/5wrmVi5KoUj3ztmnBSC4534L5YdKYlY9she1oLV1b6NWcErGDgpBMc78V8sO1IKe2M4iVUHsbra9zGwvYIjhyuEP4y2Srax7EgJTMGPrRHATetND96eVT2OTvpKnmWvbAMNAyeFEJvOIFB/EfgTlh0pgVTwY+/By+pq38bA1hKr6hSEddD+i2VH/s6ZyWVNA2Oyutq77FXDMbC1xIwTERH1Wm8ml2V1tffIqYaTKttAxMCJiIh6TSr4sffgZXW198iphrMX2FbUtWBrWRXW7zyOrWVVim/7xKo6IiLqNWcml42L1GJrWRV7anmRnGo49oi0xMCJyAewqy8pgSOTy8ZFavHt6UbzNoHwwPVFUu3L5NyX7LVfUyIGTkReFoi/2Mi9fDEQHzYwDOd/OISDn3yA7y5cQH30SAwaMQ7JyUkAuuqBfOGB64vXzp3EBiaNi9TKui8FYsNxBk5EXhaIv9jIfXwxED98+DAWLlyIr7/+2rwscvLtUO3ei8TERMyZMxsDB8YC8O4D1xevnbuJVcPJvS8FYo9IBk5EXhaIv9jIfXwhEJ8yZQrOnDkDAOgM7Q+9ZiDUfYciPL0/2k4fxuWGMzBebEJQeH9UV1fj1VdfRXh4BKL7ReN3yx70yDna4gvXzhtsVbFKTcrcXSBOAMzAicjLAvEXG7mPvUBcqirKVdVUZ86cwalTpxAck4yw5JEI+u/yoPD+CBt1HVqPfIm204cRNuo6ACoIAtDc3IwgtdojD1yx98kfMVc40vZpXHI0dPo2xU4A3BMDJwUJtLp5pQjEX2zUe2Lfd3sPPLGqKAB2q6kcvcdoU8bYWKqCNmUMWr7dgdYjX0KbMgbq0EgYL+nRce57yeO54h4ndQ16XruG1g5UN15CkFqFrWVVAXVPdaTtk07fpujqzJ4YOClEINbNK4W9btxEPVXUtWDLV5WobryEix2X0TckGEdq9FgwOVUyEHd06ozu1VT27jHdg5roCTOBiK9xqV8s2jsNVsdVh0YCAC43nEFLwxnz8ujRE0SHJ5B7j7MXXEldg+7XrqG1A9+ebkRzeyeiQvvgX9/rzNc4EL6bvW37pGQMnBSCH2b/xilXyBEfH6zpeqi3daLTYESfIDXOtbSjf1gNlmYNFw3EpdqtCN0jrR7rAPsDJXYPanLuXwqVCvjo73/H1/v2W+1nvKS3WhYck4wf3XKHOePTMzCSc4+TE1xJVcd1Dxa+rmxAc1snIrR9oAkOQkv7ZZTXNuPjg13XWOnEAlC5bZ+UjIGTQrBunihwlJ6sR33rle98h8GI+pZ2lJ2sBzBcNBC3155Oap0jc9Ft2rwJzXo9Ll68CECAabiBLgLaTh+2Oo42ZQyOHzsOzOy2ZbfASM49Tk5wZe8amK7dZ0frEKHtg+a2TjS0tqNPkBoR2j44XN1k8zyUxJHqTJNAapPJKVcUgnMJEQWOxotdwUKnQUBr+2Xo2y6jtf0yavXWD7TupKbOsDethiNz0TXr9WhsbEL7pYtoPfIlDC31EAydMLTUo736GLQpYxA5+XaEp2cjOCYZAKDuGwWj0Wh1fFNgJOceJye4svU+L1zsQF1zm8WUIS3tl1Hf2o4OgxEC/huctrajtf2yzddQEnvVmYE+ryAzTgrBBsZEgaNf3z6ob+nApY4rD3EDVOi4bERFXYtVm6PuVS22RvA2baeCCiq1gGC12qqtnb22U7ayEMZLeot2TMExyQgbdb15ffdedsaLTQiO6W91DFNgJOceJ7cnmEoFqKBCcJAKlw0CBAEwGgEjrkxy21V1qUJXxsz8iggNCbI6vtLIrc50pk2mEjoxMXBSCDYwJgocGUP7o7L+IoLUKhgFQK0CQoLVSOoXarPNUc+2PmJtgoCuUCF7TLw5+OreWFuq23n3oCYiMrIr3miqQGRiImpqaiAIgmQvu8j2c4iMGG+5psd8dt0Dnu5BX/GhGvQP1yAuUgudvs1uT7Cu5QKyxyRgb2UDjD3adwkCoFap0D8spKsdmVFAH7UKEdo+GBTTV14h+TG51ZmOUkonJgZOCsIGxkSBYebYRHx29BxCgjquPNRD+2B4bITNNkeA7c4ijjT47tnt3JQ5MAUt3YOqe+++B1AJCFKp0D9cg36X6/Hk0vtwrE+U1eslJiXilz9/EE/Nu9Z8TLH57IArAY/Y+dkK7qTep1h2JUwTjKEDw7t6LnYa0LdPEBKjQzE8LsLm9r6mN5kdd9VgKKUTEwMnIiI/kxYbjhtHxOLgmUZc6jQg9L8P9ZiwEJttjkx6dhZxpME3IC+oMq8TrlR96VRh2PrRTrz72X58deB7XGq7hFBtKEaOHIGkpCTER4Wa31f3B+jWsirJc7C1Tqdvw/yMQRbLpXqCiWVXxiRFQhAs21D5S/MHOZkdqcBKqkrXFCg7U6OhlE5MDJyIiPzQzHEJECA41OaoZ2cRqSqZ3gRVNteduoDbb5qAvgMSbFal2Rq/Seoc7A2f0J3U+xTLrswc2xUE+mPzB3uZHTmBlVSVrrNVbErpkcfAiYjID9lr19gzGLhwsQNqlQrrdx43ByfONPi2F1RJBTRimYzu1XGOdH2X+xCWep/2rqM/BEo92cvsOFpl5kwVm62MllI6MTFwIiLyU2LtGnsGA5eNxq6eY4IAo8EyOHEk+JKb0ZI7x5m99kf2HrRS6xyZT01p7UPtBZyOVpk5ur1UhkoJnZgYOBERKVD3YGBrWRV6DpFkCk7mZwySFXzJDarE1tma4+yjg9VoutSJSG0fq9eX0/VdbJ2tB3cgzadmL+B0ZALfSakxottfNhptVrFKBcNinzd/wsCJiEjh7GUMxBoKy81oyQloxB6mjRdtB05yur6LrVNK7y1n2SsfRybw/ehgtTlb17Pq1zT+VfdtfzouUTGNwMUwcCKigLZhwwY8//zzqK2tRXp6Ol555RVkZGTY3Pbw4cNYuXIl9u3bh1OnTuGll17CsmXLenVMT7CXYZA7ea+coAqwHdCI9Wzr17cPVCo43e7F1vkp/cEth73ycSS4NWXrum+vVqlsjn+1t7JBMY3AxXDKFSIKWNu2bUNeXh5WrVqF/fv3Iz09HdnZ2airq7O5/cWLFzF06FA8++yziI+Pd8kxPUFqmgyp7IwpqKptakOn4cqo2hV1LQ6fg9iUKcPjIvDTcYmIj9IiJFiN+Cit7Co1sfMziDRQV8qD2xXSYsMxP2MQFt+YZq4+szdiePftg0Sih4bWDsVPy6ISxLpAKJRer0dUVBSampoQGRnp7dMhCgi++r3LzMzEpEmTsH79egCA0WhESkoKHnroITz++OOS+6ampmLZsmVWGafeHBNw37XqObikKXO0fudxdBqsHwMhwV3TrtjKHMRHac1jJckdaLGirsVm9ZCcIEnsNbaWVdk8P7VKZXOohkBp4+QssesZH6U1B9mmMqjTt1tlnEzbzs8YJPp581WOfO98oqrOkbT266+/jtzcXItlGo0GbW3Sk1sSEXXX0dGBffv2IT8/37xMrVYjKysLe/bs8ZljuopY1Y2zYzkB9sf3kduzTSr4knoNsfMLDlKZp1Pxlwe3L3Ck7dOF/0403a+v7QFCldZTsTuvB06mtHZRUREyMzNRWFiI7OxslJeXIzY21uY+kZGRKC8vN/9b1TMnSERkx/nz52EwGBAXF2exPC4uDkePHvXYMdvb29HefiUA0Ov1Tr22s5wdywno3ZQtJvaCL6nXkAr6lPzgdhdH2j716xsCtRqIjdAGXHDq9cBp7dq1WLRokTmLVFRUhI8//hibNm0STWurVCrR9gVERP6koKAAq1ev9trr92bYAWdHF5c7X569djfZY+IVMaCiL3GkYX+wWm01vU0g8GrjcFNaOysry7xMTlq7paUFgwcPRkpKCmbPno3Dhw+Lbtve3g69Xm/xR0Q0YMAABAUFQafTWSzX6XRO/zBz5pj5+floamoy/50+fdqp1+4NWw2FTculGm6LNfh21Xx59l7D3vmRa0iVQSDyauAkldaura21uc+IESOwadMmfPDBB3jrrbdgNBpxzTXX4MyZMza3LygoQFRUlPkvJSXF5e+DiPxPSEgIJkyYgJKSEvMyo9GIkpISTJ482WPH1Gg0iIyMtPjzJWJBFSDdW0/uw9bedvZ6aEmdH7mG0nvJOcrrVXWOmjx5ssUN6JprrsGoUaPw5z//GU8//bTV9vn5+cjLyzP/W6/XM3giIgBAXl4ecnJyMHHiRGRkZKCwsBCtra3mpgMLFixAUlISCgoKAHRlyb///nvz/589exYHDhxAeHg40tLSZB1TSZyp5us5oW9cpNZqcMWegZESpunwZywDS14NnFyRKu/Tpw+uvvpqVFRU2Fyv0Wig0dj+RUNEgW3u3Lk4d+4cVq5cidraWowfPx7FxcXmLHhVVRXU6iuJ+erqalx99dXmf7/wwgt44YUXMHXqVOzatUvWMZXGkdHFbU3oq9O3Sc4jJ/Ua5Dksgyu8Po5TZmYmMjIy8MorrwDoSmsPGjQIS5YskTXmicFgwJgxY3Drrbdi7dq1drf31fFkiJSM3zv5lHytpMYJCsRGxuQ7/GocJ0dT5U899RR+8pOfIC0tDY2NjXj++edx6tQp3Hvvvd58G0RE1A2nQiGl8nrg5Giq/MKFC1i0aBFqa2vRr18/TJgwAV999RVGjx7trbdARETdiI3NJDbkXqD2ziL/5PWqOk9TchqcyFfxeyefEq4Vp0Ihf+NXVXVERKQszkyFInfOOyJvY+BEREQu5ehUKPamXSHyJQyciIhIlL0JeG2tk5r/zha507MQ+QIGTkREZJNUJgiwnsS3e5bI1oCJACwGvzQFWuxtR/6EgRMREdkklQmypXuWqGeVnFQQJlW1R+RrGDgREZFNUpkgsQ7ZYlkiqSBMrGqv5/QsbDBOvsCrk/wSEZHvkpqAV+4kviZSQZipai8+SouQYDXio7QYlxyNb083orapDZ0GwZyhqqhrce7NELkIAyciIrJpUmqM1aCVpkbeYutMWaL1O49ja1mVOdCRCrS6NzI3tYfS6a2r7qSqCYk8hYETERHZZCsTZGr87WiWSCrQ+vu31Vb7HNM12zwnNhgnb2MbJyIiEmVr3CWxdVvLqqy2MWWJ5mcMstnTTqztU+PFTkRq+1itY4Nx8jYGTkRE5BL2hhWwFYQVH6qxuU+/vn2gUkH2WFBEnsLASUE4ZYH/YtmREtgbVsDW51xsn+FxEeaMVM/pWYi8iYGTQnDKAv/FsiOlkBoxXOxzPi45Gjp9m819pKoJibyFjcMVwtGB6sh3sOxIKaQak4t9znX6NtF9iHwRM04KwSkL/BfLjpRELEtkbxwnBkrkL5hxUghHB6Mj38Gyo0DAzzkpBQMnhZAaqI58G8uOAgE/56QUDJwUQqptAfk2lh0FAn7OSSnYxklB2E7Af7HsKBDwc05KwIwTERERkUwMnIiIiIhkYuBEREREJBMDJyIiIiKZGDgRERERycTAiYiIiEgmBk5EREREMjFwIiIiIpKJgRMRERGRTAE3crggCAAAvV7v5TMhChym75vp+0fieI8i8jxH7lEBFzg1NzcDAFJSUrx8JkSBp7m5GVFRUd4+DZ/GexSR98i5R6mEAPsJaDQaUV1djYiICKh6TtWtAHq9HikpKTh9+jQiIyO9fTrkACWXnSAIaG5uRmJiItRqthCQwnsU+Soll50j96iAyzip1WokJyd7+zTcLjIyUnEf7ECh1LJjpkke3qPI1ym17OTeo/jTj4iIiEgmBk5EREREMjFwUhiNRoNVq1ZBo9F4+1TIQSw7CgT8nPsvll2XgGscTkREROQsZpyIiIiIZGLgRERERCQTAycPuOGGG7Bs2TLR9RcvXsRtt92GyMhIqFQqNDY2IjU1FYWFhR47R5JPEATcd999iImJgUqlQnR0tGT5Evk63qOUg/cn92Pg5AO2bNmCL7/8El999RVqamrcNt6NrRtdW1sbFi5ciLFjxyI4OBhz5syxuW97ezueeOIJDB48GBqNBqmpqdi0aZNbztPXFRcX4/XXX8dHH32EmpoaXHXVVS5/DVsPsvr6ekyfPh2JiYnQaDRISUnBkiVLLKbm2L59O2655RYMHDgQkZGRmDx5Mnbs2OHy86PAwnuU/+D9yf0CbgBMX3TixAmMGjXKLR9wewwGA0JDQ/Gb3/wGf/3rX0W3u/3226HT6bBx40akpaWhpqYGRqPRg2fqO06cOIGEhARcc801AIDgYM98jdRqNWbPno1nnnkGAwcOREVFBRYvXoyGhga8/fbbAIAvvvgCt9xyC/74xz8iOjoamzdvxqxZs1BaWoqrr77aI+dJysN7lP/g/ckDBHK7qVOnCosXLxYWL14sREZGCv379xdWrFghGI1GYerUqQIA89/UqVMFQRCEwYMHCy+99JL5GKdOnRJ+9rOfCWFhYUJERITwq1/9SqitrTWvr6ioEH72s58JsbGxQlhYmDBx4kTh008/tTiH7q9jq+hzcnKE2bNnWy3/5z//KURFRQn19fUuuyb+Kicnx+IaDh48WJg6daqwdOlS8zYNDQ3CXXfdJURHRwuhoaHC9OnThWPHjpnXnz9/Xpg3b56QmJgohIaGCldddZXw9ttvi74GAOHkyZM2z2fdunVCcnKy5DmPHj1aWL16da/eNykb71HKwPuTZ7CqzkO2bNmC4OBglJWVYd26dVi7di3+3//7f9i+fTsWLVqEyZMno6amBtu3b7fa12g0Yvbs2WhoaMDnn3+OTz/9FD/88APmzp1r3qalpQW33norSkpK8M0332D69OmYNWsWqqqqAHSlSJOTk/HUU0+hpqYGNTU1ss/9ww8/xMSJE/Hcc88hKSkJP/rRj/DII4/g0qVLvb8wfmbdunV46qmnkJycjJqaGuzdu9dqm4ULF+Lrr7/Ghx9+iD179kAQBNx6663o7OwE0FX1MGHCBHz88cc4dOgQ7rvvPtx1110oKyszv8bkyZOxaNEic1nZmvC1uroa27dvx9SpU0XP12g0orm5GTExMS66AqRUvEf5P96fPMTbkVsgmDp1qjBq1CjBaDSaly1fvlwYNWqUIAiCsHTpUvOvOJPuv+Y++eQTISgoSKiqqjKvP3z4sABAKCsrE33dMWPGCK+88orNY9oi9msuOztb0Gg0wsyZM4XS0lLh448/FgYPHiwsXLhQ4l0r10svvSQMHjzY/O/uv+iOHTsmABD+/e9/m9efP39eCA0NFd59913RY86cOVP47W9/a/OYPc2bN08IDQ0VAAizZs0SLl26JHrcNWvWCP369RN0Op28N0cBifco5eD9yf2YcfKQn/zkJxYznU+ePBnHjx+HwWCwu++RI0eQkpJiEdWPHj0a0dHROHLkCICuX3OPPPIIRo0ahejoaISHh+PIkSPmX3O9YTQaoVKp8H//93/IyMjArbfeirVr12LLli0B94vOniNHjiA4OBiZmZnmZf3798eIESPMZWUwGPD0009j7NixiImJQXh4OHbs2CG7rF566SXs378fH3zwAU6cOIG8vDyb27399ttYvXo13n33XcTGxvb+zZGi8R6lfLw/uQYbhyvEI488gk8//RQvvPAC0tLSEBoail/+8pfo6Ojo9bETEhKQlJRk0ZNm1KhREAQBZ86cwfDhw3v9GoHk+eefx7p161BYWIixY8ciLCwMy5Ytk11W8fHxiI+Px8iRIxETE4PrrrsOTz75JBISEszbvPPOO7j33nvx3nvvISsry11vhUg23qP8A+9P9jHj5CGlpaUW//7Pf/6D4cOHIygoyO6+o0aNwunTp3H69Gnzsu+//x6NjY0YPXo0AODf//43Fi5ciJ///OcYO3Ys4uPjUVlZaXGckJAQWb8ee7r22mtRXV2NlpYW87Jjx45BrVYjOTnZ4eMp2ahRo3D58mWL8q6vr0d5eblFWc2ePRt33nkn0tPTMXToUBw7dsziOHLLytRrqL293bxs69atyM3NxdatWzFz5kxXvC0KALxHKR/vT67BwMlDqqqqkJeXh/LycmzduhWvvPIKli5dKmvfrKwsjB07Fr/+9a+xf/9+lJWVYcGCBZg6dSomTpwIABg+fDi2b9+OAwcO4Ntvv8Udd9xh1RU3NTUVX3zxBc6ePYvz58+bl3///fc4cOAAGhoa0NTUhAMHDuDAgQPm9XfccQf69++P3NxcfP/99/jiiy/w6KOP4u6770ZoaGjvL46CDB8+HLNnz8aiRYuwe/dufPvtt7jzzjuRlJSE2bNnm7f59NNP8dVXX+HIkSP4n//5H+h0OovjpKamorS0FJWVlTh//jyMRiP+8Y9/YPPmzTh06BAqKyvx8ccf4/7778e1116L1NRUAF3p7wULFuDFF19EZmYmamtrUVtbi6amJk9fCvIzvEcpH+9PLuLtRlaBYOrUqcKDDz4o3H///UJkZKTQr18/4Xe/+525Iaa9hpeCYL+r78mTJ4Ubb7xRCA0NFVJSUoT169dbNeDbs2ePMG7cOEGj0Vh09R08eLBV99KeH40jR44IWVlZQmhoqJCcnCzk5eUJFy9edN1F8iNSjS8F4Up336ioKCE0NFTIzs626O5bX18vzJ49WwgPDxdiY2OFFStWCAsWLLBo9FpeXi785Cc/MTeyPHnypLBz505h8uTJQlRUlKDVaoXhw4cLy5cvFy5cuGBxLrbKMicnx30XhPwe71HKwfuT+6kEQRA8F6YRERER+S9W1RERERHJxMCJiIiISCYGTkREREQyMXAiIiIikomBExEREZFMDJyIiIiIZGLgRERERCQTAyciIiIimRg4kdfccMMNWLZsmbdPg4jIJt6jyBYGTuQTUlNTUVhY6O3TICKyifcoMmHgRERERCQTAyfyiNbWVixYsADh4eFISEjAiy++aF53ww034NSpU3j44YehUqmgUqnQ2tqKyMhI/OUvf7E4zvvvv4+wsDA0NzejsrISKpUK77zzDq655hpotVpcddVV+Pzzzy32OXToEGbMmIHw8HDExcXhrrvusph5nYiI9yiSi4ETecSjjz6Kzz//HB988AE++eQT7Nq1C/v37wcAbN++HcnJyXjqqadQU1ODmpoahIWFYd68edi8ebPFcTZv3oxf/vKXiIiIsDj2b3/7W3zzzTeYPHkyZs2ahfr6egBAY2MjbrrpJlx99dX4+uuvUVxcDJ1Oh9tvv91zb56IfB7vUSSbQORmzc3NQkhIiPDuu++al9XX1wuhoaHC0qVLBUEQhMGDBwsvvfSSxX6lpaVCUFCQUF1dLQiCIOh0OiE4OFjYtWuXIAiCcPLkSQGA8Oyzz5r36ezsFJKTk4U1a9YIgiAITz/9tDBt2jSL454+fVoAIJSXl7v6rRKRH+I9ihzBjBO53YkTJ9DR0YHMzEzzspiYGIwYMUJyv4yMDIwZMwZbtmwBALz11lsYPHgwrr/+eovtJk+ebP7/4OBgTJw4EUeOHAEAfPvtt/jss88QHh5u/hs5cqT5vIiIeI8iRwR7+wSIpNx7773YsGEDHn/8cWzevBm5ublQqVSy929pacGsWbOwZs0aq3UJCQmuPFUiCkC8RwUeZpzI7YYNG4Y+ffqgtLTUvOzChQs4duyY+d8hISEwGAxW+9555504deoUXn75ZXz//ffIycmx2uY///mP+f8vX76Mffv2YdSoUQCAH//4xzh8+DBSU1ORlpZm8RcWFubKt0lEfor3KHIEAydyu/DwcNxzzz149NFHsXPnThw6dAgLFy6EWn3l45eamoovvvgCZ8+etehN0q9fP/ziF7/Ao48+imnTpiE5Odnq+Bs2bMDf/vY3HD16FIsXL8aFCxdw9913AwAWL16MhoYGzJ8/H3v37sWJEyewY8cO5Obm2rwJElHg4T2KHMHAiTzi+eefx3XXXYdZs2YhKysLU6ZMwYQJE8zrn3rqKVRWVmLYsGEYOHCgxb733HMPOjo6zDeanp599lk8++yzSE9Px+7du/Hhhx9iwIABAIDExET8+9//hsFgwLRp0zB27FgsW7YM0dHRFjdFIgpsvEeRXCpBEARvnwSRlDfffBMPP/wwqqurERISYl5eWVmJIUOG4JtvvsH48eO9d4JEFNB4jwosbBxOPuvixYuoqanBs88+i//5n/+xuCEREXkb71GBiXlA8lnPPfccRo4cifj4eOTn53v7dIiILPAeFZhYVUdEREQkEzNORERERDIxcCIiIiKSiYETERERkUwMnIiIiIhkYuBEREREJBMDJyIiIiKZGDgRERERycTAiYiIiEgmBk5EREREMv1/J+OkeTc2IdkAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 600x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, ax = plt.subplots(1, 2, figsize=(6, 4), tight_layout=True)\n",
+    "\n",
+    "sns.swarmplot(y='AP@0.5', x='dtype', data=df, alpha=0.5, ax=ax[0], )\n",
+    "sns.pointplot(x='dtype', y='AP@0.5', data=df, errorbar='se', linestyle=\"none\", color='black', capsize=.1, ax=ax[0])\n",
+    "\n",
+    "sns.swarmplot(y='time', x='dtype', data=df, alpha=0.5, ax=ax[1], )\n",
+    "sns.pointplot(x='dtype', y='time', data=df, errorbar='se', linestyle=\"none\", color='black', capsize=.1, ax=ax[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "dc4dcda9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>AP@0.5</th>\n",
+       "      <th>time</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>dtype</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>bfloat16</th>\n",
+       "      <td>0.854719</td>\n",
+       "      <td>0.121736</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>float32</th>\n",
+       "      <td>0.854877</td>\n",
+       "      <td>0.171985</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            AP@0.5      time\n",
+       "dtype                       \n",
+       "bfloat16  0.854719  0.121736\n",
+       "float32   0.854877  0.171985"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.groupby('dtype').mean()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "250fa8da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.2858448968254887"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(0.172814 - 0.123416) / 0.172814 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "635b7714",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAHHCAYAAABDUnkqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjEsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvc2/+5QAAAAlwSFlzAAAPYQAAD2EBqD+naQAAfi1JREFUeJzt3Xd4VFX+x/H3lMxMOmmkk9B7RxCQpigIIiAiVlBX1F11Vda69vLTbaLsri52dEVRELDAoogiKiBIkxY6JEASEkLaJJlJZu7vD5ZZIwkmSDJJ+LyeZ57HOfecO997DZlvzj3FZBiGgYiIiEgTYfZ3ACIiIiJnkpIbERERaVKU3IiIiEiTouRGREREmhQlNyIiItKkKLkRERGRJkXJjYiIiDQpSm5ERESkSVFyIyIiIk2KkhsRERFpUpTciEideumllzCZTPTr16/K4yaTyfcym80kJCRw0UUXsXz58hqd3+12U1ZWVqO6Xq+Xv/zlL7Rs2RKHw0G3bt147733atR21qxZlWL96SsrK6tG5xCR+mH1dwAi0rTNnj2b1NRU1qxZw+7du2nTps1JdS688EImT56MYRjs27ePl156ifPPP59FixZx8cUXn1R/x44dPP/88yxatIiDBw8C0Lx5c0aPHs3tt99Or169qozloYce4k9/+hNTp07lnHPO4aOPPuLqq6/GZDJx5ZVX1uh6nnzySVq2bFmprFmzZjVqKyL1xBARqSN79+41AGP+/PlGTEyM8fjjj59UBzBuu+22SmU//vijARgXXXTRSfWffvppw2q1Gj169DCefvppY+HChcZHH31kTJ8+3TjvvPMMi8Vi/PGPfzyp3cGDB42AgIBKn+X1eo1BgwYZSUlJRkVFxSmv5c033zQAY+3atTW9fBHxE/XciEidmT17NhEREYwePZrLL7+c2bNn89hjj/1iu65duxIdHc2+ffsqlT/88MM899xzvP7660yePPmkdnfffTeLFy/m2muvxev18uyzz/qOffTRR5SXl/O73/3OV2Yymfjtb3/L1VdfzapVqzjvvPNqdF1FRUUEBQVhsVhqVF9E6pfG3IhInZk9ezaXXXYZNpuNq666il27drF27dpfbHfs2DGOHTtGVFSUr2zFihX86U9/4tNPP62U2BQXF2MYhq/dhRdeyLJly5gxYwarV6/21duwYQPBwcF07Nix0mf17dvXd7wmhg0bRlhYGEFBQVx66aXs2rWrRu1EpP4ouRGROrFu3TrS0tJ8Y1nOO+88kpKSmD179kl1y8rKyM3NJScnhzVr1jBx4kQ8Hg8TJ0701Xnssce44447uOCCCwBYtWoV7dq1IzQ0lNjYWP7973/Ts2dPvvvuO3r27Mmtt97KP/7xD1/7zMxMYmNjMZlMlT47Pj4egMOHD5/yeoKCgrj++ut58cUXWbBgAffddx/Lli1jwIABZGRknN5NEpG64e/nYiLSNN19991GbGxspbEsf/jDH04qA056ORwOY9q0aYbH4zEMwzCOHDlimM1mY8+ePYZhGEZxcbERHx9vDBo0yPjggw+MV155xUhJSTHsdrvx1VdfGYZhGF9//bWRkJDg+5zzzz/f6Nix40lxejweAzDuvPPOWl/jN998Y5hMJuOWW26pdVsRqTsacyMiZ5zH42HOnDkMGzas0riZfv368dxzz7Fs2TIuuugiX/nYsWO5/fbbMZlMhIaG0rlzZ4KDg33H169fT3JyMq1atQJg0aJFlJSU8OmnnxIWFgZA27ZtGTZsmK9NbGwsOTk5vveBgYG4XK6TYj0xjTwwMLDW13neeefRr18/vvjii1q3FZG6o+RGRM64L7/8kszMTObMmcOcOXNOOj579uxKyU1SUhLDhw+v9nxHjx4lISHB937//v20b9/el9jA/8bOnJCRkVFpzE58fDxfffUVhmFUejSVmZkJUOn8tZGcnMyOHTtOq62I1A0lNyJyxs2ePZvmzZvz4osvnnRs/vz5LFiwgJkzZ9a4tyQsLIyCggLf+7i4ONLT06moqMBqPf5rbO/evZXavPrqq5USph49evDaa6+xfft2OnXq5Cv//vvvfcdPx969e4mJiTmttiJSR/z9XExEmpaSkhIjNDTUuPHGG6s8/t133xmAMWfOHMMwql7n5ud2795tWK1W49ixY4ZhGEZmZqYRHBxs3HTTTcbOnTuNdevWGeeee65hMpmMl19+2bj55puN0NBQY8eOHb5zZGRkVLvOTWJiYqVxQIcPHza2b99uuN1uX9mRI0dOimvRokUGYPz+97//5RsjIvVGyY2InFFz5swxAGPhwoVVHvd4PEZMTIwxZswYwzBqltwYhmF06NDBeP75533v33rrLcPhcBiAYTKZjHvvvddISUkxAKNv377G+vXrTzrHvffeawDGzTffbLz66qvG6NGjDcCYPXt2pXpTpkwxAGPfvn2+sjZt2hgTJ040/vznPxszZ840br75ZsNqtRrJyclGVlZWDe6MiNQXJTcickaNGTPGcDgchtPprLbO9ddfbwQEBBi5ubk1Tm7efPNNIzIy0ti7d6+vLDc311ixYoWRnp5uGIZhrF271sjIyKj2HB6Px3jmmWeMlJQUw2azGZ07dzbeeeedk+pVldw89NBDRo8ePYzw8HAjICDAaNGihfHb3/5WiY1IA2QyjP+ufiUi0oAZhsGYMWPYsWMHn3zyCR06dKiy3qeffsrQoUMJCQmp5whFpKHQIn4i0iiYTCbmzJlD+/bt6dGjB7/73e9YunQp+/btY/fu3cydO5eLL76Y8ePH8+WXX/o7XBHxI/XciEij4vV6efvtt/nb3/7G1q1bfeVWq5URI0bwxBNP0Lt3bz9GKCL+puRGRBqtQ4cOkZ6ejsVioX379oSHh/s7JBFpAJTciIiISJOiMTciIiLSpCi5ERERkSblrNt+wev1cvjwYUJDQyvtLyMiIiINl2EYFBUVkZCQgNl86r6Zsy65OXz4MMnJyf4OQ0RERE5DRkYGSUlJp6xz1iU3oaGhwPGb89MdhUVERKThKiwsJDk52fc9fipnXXJz4lFUWFiYkhsREZFGpiZDSjSgWERERJoUJTciIiLSpCi5ERERkSZFyY2IiIg0KUpuREREpElRciMiIiJNipIbERERaVKU3IiIiEiTouRGREREmpSzboViEREROfPyS9wUlJazMSOfrIIy4sId9EhuRnhgAM2CbPUai197blasWMGYMWNISEjAZDKxcOHCX2yzfPlyevXqhd1up02bNsyaNavO4xQREZHqZRWU8sEPGYx98TvunLORZ/+Txp1zNjL2xe/44IcMsgpK6zUevyY3TqeT7t278+KLL9ao/r59+xg9ejTDhg1j48aN3HXXXdx000189tlndRypiIiIVCW/xM3Hmw7zzOI08kvKf3asnGcWp/HxpsMUlrrrLSa/Ppa6+OKLufjii2tcf+bMmbRs2ZLnnnsOgI4dO/Ltt9/y/PPPM2LEiLoKU0RERKqRX1LOS8v3nLLOS8v3cFGnOMIC6+fxVKMaULxq1SqGDx9eqWzEiBGsWrWq2jYul4vCwsJKLxERETkzNh3MP6nH5ufyS8r58WB+/QREI0tusrKyiI2NrVQWGxtLYWEhpaVVP8979tlnCQ8P972Sk5PrI1QREZGzQlZBGd7yMrzuslPWyy489fEzqVElN6fjwQcfpKCgwPfKyMjwd0giIiJNhtmZS/GGxZTs/A7D8FZbLzbMUW8xNaqp4HFxcWRnZ1cqy87OJiwsjMDAwCrb2O127HZ7fYQnIiLSJLkqPOQ53aRlFpFT7CImxE77uBC2bfiebV9/gc1w43aVYLjLMNmDTmrfLCiAbknN6i3eRpXc9O/fn8WLF1cqW7p0Kf379/dTRCIiIk1bQambJVuyWbD+IE63B4AKVwnHtn5LkrWI1jHBjL9gAIsL4jFZAqo8x21DWxMZXPWxuuDX5Ka4uJjdu3f73u/bt4+NGzcSGRlJixYtePDBBzl06BBvv/02ALfeeiv//Oc/ue+++7jxxhv58ssv+eCDD1i0aJG/LkFERKTJclV4WLIlm3dWH/CVlRw9TObGr6lwlZJvsXLO0BHcfckQem46zEvL91QaXBwRFMDvhrVhTLf4epspBX5Obn744QeGDRvmez9t2jQApkyZwqxZs8jMzCQ9Pd13vGXLlixatIi7776bGTNmkJSUxGuvvaZp4CIiInUgz+lmwfqDvveG18uRraupcJViD40gvsdQNhSHMxm48pxkLuoUx48H88kuLCM2zEG3pGZEBgfUa2IDYDIMw6jXT/SzwsJCwsPDKSgoICwszN/hiIiINFhfpR1h+tKdlcrKCo9SkJ5GTMd+mC3H+0imXdiOYR2a12kstfn+blRjbkRERKRu/HzQcJuYELIKSinKOYin1EmzFu0BcIRF4egysFLbXKfLHyFXS8mNiIjIWa6qQcMpEQ6C89LYu/ILHDYLjvAoHOHRVbaPDm5Ys5KV3IiIiJwlft47kxoVRKvoEDLySnh39QFOrFJTXurk21WL6BFZgcfrxRLTloDg8CrPGWyz0CE+tP4uogaU3IiIiJwFTvTOLNxwkD4pkfRJjWDr4UK+2ZVLi8ggnpnQlc82Z/Hpt+vJ/HEFHreLI/ZmXHPVJBZlWPCaLFiqOO9lvZOIUs+NiIiI1KcTU7pnrz7Atf1TOHislHvn/UhRWQUer0G510vLqGC6mTKIyl7PIbcLR3gU3vbD6NOzK3GppXy5vfIiusF2CxN6JXFR51hs1oa14YGSGxERkSYuz+lm4fqDXNYrkZwiF2+t3I+74vhDKIPjk6bT80o4VpBP89IKBg3sT2ZIW8wWK++sOsCQdjH8+fJuHCl0ket0ER1sp0N8KFHB9gaX2ICSGxERkSYvp9DFw5d0JNgewDOLtxNssxARFECJ28OxohIwWfAYBvbEjuSFRvPgxAuY/vlODMAAlu/MoVdKRJ1P9z5TGl66JSIiImdMvtNNiMPKriNOvtieTd+WkTw9vgsDW0VQsHMtnm1fgOf4qsJeAyqCoth/1ElK1P/2iGqIg4ZPRT03IiIiTVROkYtPNh3ilRV7KSqrINBmIbfYTbBRSofSbXSy5rGmOJ/wkiOUhiZiMZtwVUBesZsg2/9ShIY4aPhUlNyIiIg0Ma4KD/kl5Xz642H+tXwPVrOZ5mEO3BUe3LnpFOxazSFPOQPaxTP2ssvZVhpKVkEZDquZ/JJyIkNs7Mt1NuhBw6ei5EZERKQJyXO6WbIlk8SIQGZ8sYvCsgoAzIaH0KPbcO3cDF4Da1gMB5oP5A8X9GPjwi00D3PgCLDQOiaYc1IjSYkMbtCDhk9FyY2IiEgTkV/iZv76g3y+NYuLOsf5EhsADv1I4ZHdBAZY8DZvT2BKN8otVg4cddI2NoScYjcWk4nr+qfQtnkonROqXrSvMWhcqZiIiIhUyVXh4eCxUl5ZsZcQh5WjxW5M/z0WF+agWctuFJmCiO4xnMQu/TBMZtweL7nFbiKDbYQ5rEzun8KIRvYIqirquREREWkCCkvLWXcgj6KyCgpLKwh3mHDn7CcmpS0er5e8cgvBPUaRbzIR5TVIigjCXeGlZXQwvVMi6BgfRnRI43sEVZXGfwUiIiJCRl4pOcVuAH7ck0Ha8oVU7FmFJf8gR53Hy02m4305BaXlHDxWgsfwkhwZxGebMzGZaBKJDSi5ERERaRJyil1EBdsoy97LsXWL2bDjAP3aJeAxB+A1Tq5vAJP6tOCbnUfYnl1MWmZRvcdcV/RYSkREpJH5+e7eMSF2EkID2LH6S9y7V2N4vOwqDWTGnTeR6zLzr+V7Kg0ubhYYwJX9WpAcEcjs1ekA5Dpd/rqcM07JjYiISCPhrvBwrKScJVsyeXdNBq5yD44ACxXOfHI3LyfJUcHILnF8URBNYHIXZq87wh3nt+Uvl3fnwFEneU43zUPttI4JYe3+PGZ9t5/Scg/lXoPAAAs5RWWEBQZgt1a1/3fjoeRGRESkgTu+KJ+b3GI3Ww8X8vLXe7FZzZS4PeQUubA7j1Gcf4wtFjuDRl3O+A5tePKTbew8UkyF1+D+DzeRHBFEUkQg6cdKmL/+IPmlFeSXuPEaEOqwEmK38vt3NzCuVxIju8QSHmjz92WfNpNhGFU8iWu6CgsLCQ8Pp6CggLCwMH+HIyIickr5JW4O5ZeyZm8emKDc46VFZDBLt2by7e6jWK1m8ord2PL3E5vcElNAIH+e0JX80nL2H3USHWwns7CM99dmYLOYMJlM5JeUk/ffQcYAUwe3wus1+HpnDgDXnpvC+J6JDWqAcW2+v9VzIyIi0kDlOY8vyvfy13sodnkIDwwgq7CMwIpCOlXs4coLL2HOxlxCHFZKIlIx2wKxmk3kFLsIDwwgoVkg0cF2zmkZQajDysL1h8gvLSe/5HhiE+awcmXfFiRGBPLOqgO+z12w/iCD20UTHx7or0v/VZTciIiINECuCg9LtmTy/NKdlHsMbFYz5R4Prsxd5O9bR6bXgyMomPN6DGPdgWMUl1VQVu4h1BFAfmk5F3aKq3S+y3omMaRdDOsOHGNnVhGRITZSo4L5Yf8x3ll1gJ8+xnG6PaRlFim5ERERkTMnz+nm3e/T8RpgYFDuduHatY7S9F0ABEQmssnUims7xbJqz1FsVjMV/53zHV3FDt42q5n48EACLAVkF7rYl+tk/rpDVDc2pTHPnlJyIyIi0gClZRZxrLQcAE/xMfK2rSCEMkwmM/aUHtgTO1DsMXHgaAmp0cFszyzEajYRbLPQIT602vPaLGa2ZRb+4udXlSA1FkpuRERE/KCqtWo6xIcSGWzDbrWQU+wiwGzCfSyLwi3L8Hq8VASH0uLcwRRY/repZZ7TTajj+Ne5I8DCZb2TiDpFYtIhPpRgmwWn21NtnV9KkBo6JTciIiL1rKDUzZIt2SxYf7BSkhFsszC+VxKjusYRHWzDbjVjDYvC7AjD6gghsF1/giNCsXm8HHUen8YdFWxj95EiYsMc3Hhey1/c+DIy2Mb4Xkm8s/pAtXV+KUFq6JTciIiI1KPjA4Wzq0wunG4P76w+wLGjOQzt3poKj0F4cCBlXc7HZLXjwcSRIhfhQQEkRQRhs5g5t1UUSRGBdE9uRvNQxy9O37ZbLYzsEgtwcnJltzChVxIXNfKdwZXciIiI1KM8p5sF6w9WecwwDPL2beFvi3/A/pvLuKR7W+atP0hsRDh5Tjcew8DjNSgsLafE5eHeEe1IjgykU3wYAbVIRsIDbYzvmcjgdtGkZRaR63QRHXz8sVhUcOPfGVzJjYiISD3afriQ/NJyyv677UGA2YQjwAIVbo5s+ZbCrAMUlJbzw479jB7Tk8t7JfHJpsME2Sy4Krx4vAYRQQFMGZDKxV3iiQg+vZWET8yeaqzTvU9FyY2IiEg9KXFVcCCvhOzCMsrKvb5yT2EO5XtWYa0oxWOYCG5zDq36XMCKnbnEhNp5dEwn9h91UlRaQXSonZZRQQTZraed2DR1Sm5ERETqmKvCw9FiN9szCwm2W3EEWAgPDMDpquDI7h8p2bcRwzBoFhFBdOfBFFtCiQq1s/9oCVt3FvL1zhxSooIIslnZmV3Ee9+XcN2AFLolNfP3pTVISm5ERETqUFFZOWv25bHox8Ms3Z7N3y7vgdNdQU6RhzBTGcbhrRiGgb15KsGdziUoJBhTuYfUqGDmrzsEgAHsP1pS6byNeR2auqbkRkREpA6c6K1Zd+AY+3KL6ZwYzsgu8eQWu7imbwtmrtjLMcNOaNtzCDEMvJEtcRsmbFYz43sl8sP+Y9WuHtzY16Gpa0puREREzrA8p5slWzKZvTqdnGIXFvPxpMXj8dLFcpjRA3ty6+BWzF6TTokphaSIQLILXYQ5rFzXP4WuieE89tHWas/f2NehqWtKbkRERM6g/JLjO3mf2PCy3PvfgcPlZZj2r2H/sUwO7d7GxGtv4K8TunPgqBPTf7dNSGgWSGSwjZSoIK45N6XJrkNT15TciIiInCGuCg8Hj5Xyyoq9vg0vAcrzsyhJW4m3vJRgh52DjpbERoQxbe5G2sSEcFXfFmQWlPHJxsNMv7JHk1+Hpq4puRERETlDCkvLWXcgj6KyiuMFhkHpgR9xZWzBMAwsQc2wdjyP0MR4DuQ5aRMTws7sYsoqPOzNKWb8Tx43NeV1aOqakhsREZEzJCOvlJxiNwDeCjfFW5bjOpaFAdhjWxPYug8msxV3hZfisgpC7FZCHVZax4QQbLPqcdMZojsofmUYBjfffDORkZGYTCY2btzI0KFDueuuu/wdmohIreUUu4j678J6JksAJqsVszWA4PYDCGp3LiaLFUzgNQziwh1YLSZ+N7Q1HeJCGdsjkfBALcp3Jii5Eb9asmQJs2bN4tNPPyUzM5MuXbrUyedUlTAdPXqUkSNHkpCQgN1uJzk5mdtvv53CwkJfnfnz53PhhRcSExNDWFgY/fv357PPPjutGF588UVSU1NxOBz069ePNWvW/GKbF154gfbt2xMYGEhycjJ33303ZWVlvuOPP/44JpOp0qtDhw6nFV9tzJ07lw4dOuBwOOjatSuLFy/+xTbLly+nV69e2O122rRpw6xZsyodX7FiBWPGjCEhIQGTycTChQvrJniRM8BV4SGnqIz1B47x2dYsvko7Qk5RGRYMksNthDqOJzEh7foT0etiguJaHW/437nd4YEBtG4ewiXdEhjfK5GYGmx4KTWnOyl+tWfPHuLj4xkwYABxcXFYrfX3pNRsNjN27Fg+/vhjdu7cyaxZs/jiiy+49dZbfXVWrFjBhRdeyOLFi1m3bh3Dhg1jzJgxbNiwoVaf9f777zNt2jQee+wx1q9fT/fu3RkxYgRHjhypts27777LAw88wGOPPcb27dt5/fXXef/99/njH/9YqV7nzp3JzMz0vb799ttaxXb99dfz+OOP17j+ypUrueqqq/jNb37Dhg0bGDduHOPGjWPLli3Vttm3bx+jR49m2LBhbNy4kbvuuoubbrqpUqLodDrp3r07L774Yq3iF6lv+SVudh8pZvHmTL7ccYTD+aWYTfDmV9tZ9dl83pu3kCv7JuPxGlSYbXjsoRgGBJjNWC0mbBYzUwak0io6WL01dcRkGEZ1awQ1SYWFhYSHh1NQUEBYWJi/wzmrXX/99bz11lu+9ykpKezfv5+hQ4fSo0cPXnjhBQCOHTvGnXfeySeffILL5WLIkCH8/e9/p23btsDxHpjbb7+dFStWcOzYMVq3bs0f//hHrrrqqio/B45/2aampp4U09///nf++te/kpGRUW3cnTt3ZtKkSTz66KM1vtZ+/fpxzjnn8M9//hMAr9dLcnIyd9xxBw888ECVbW6//Xa2b9/OsmXLfGV/+MMf+P77730JzOOPP87ChQvZuHFjjWP5ueuvv57U1NQaJziTJk3C6XTy6aef+srOPfdcevTowcyZM6tsc//997No0aJKCdCVV15Jfn4+S5YsOam+yWRiwYIFjBs3rlbXIlLXCkrKWbErh/fWpLMxI58T36ABxVm0KN5K80AT+S6DkROv41h5ALPXpP9vcDHQzBHAb4e14YIOzUmODPL11rgqPOQ53aRlFpFT7CIm5PjMqMhgG3arxR+X2uDU5vtbPTfiNzNmzODJJ58kKSmJzMxM1q5dW2W966+/nh9++IGPP/6YVatWYRgGo0aNory8HICysjJ69+7t+/K8+eabue6663yPfWbMmEH//v2ZOnWqr3cjOTn5pM85fPgw8+fPZ8iQIdXG7PV6KSoqIjIy0lc2a9YsTCZTtW3cbjfr1q1j+PDhvjKz2czw4cNZtWpVte0GDBjAunXrfNexd+9eFi9ezKhRoyrV27VrFwkJCbRq1YprrrmG9PT0as95JqxatarStQCMGDHilNdyOm1EGhJXhYfD+aV8vSuHndlFDGkXwwuTenBJl+Y4963n8LovWL0jkyJTCFNvmootMJQSt4e/TujOgyM7cPOgVjw0qiNv3HAOnRPCeGTBZo46XQAUlLpZuOEwd8/ZyPSlO/n3qgNMX7qTu+dsZOGGwxSUuv189Y2PZkuJ34SHhxMaGorFYiEuLq7KOrt27eLjjz/mu+++Y8CAAQDMnj2b5ORkFi5cyMSJE0lMTOSee+7xtbnjjjv47LPP+OCDD+jbty/h4eHYbDaCgoKq/JyrrrqKjz76iNLSUsaMGcNrr71Wbcx/+9vfKC4u5oorrqh0He3bt6+2TW5uLh6Ph9jY2ErlsbGxpKWlVdvu6quvJjc3l/POOw/DMKioqODWW2+t9FiqX79+zJo1i/bt25OZmckTTzzBoEGD2LJlC6GhVS/NPnv2bG655Rbfe5fLhclk4m9/+5uv7D//+Q+DBg2qsn1WVlaV15KVlVXttVTXprCwkNLSUgIDNdVVGq5jTjdLtmYxZ006R4pcGAbYrWbcpUUkHvuRHgE5rDKBI6E9+6P6Yg8JJ8UEHeJCScsuwhFgoXtyODGhdpZtP8KKnTkYQFpmEZHBNpZsyead1QdO+lyn2+MrH98zUWNyakHJjTRo27dvx2q10q9fP19ZVFQU7du3Z/v27QB4PB6eeeYZPvjgAw4dOoTb7cblchEUFFSjz3j++ed57LHH2LlzJw8++CDTpk3jpZdeOqneu+++yxNPPMFHH31E8+bNfeXjx49n/Pjxv/JKT7Z8+XKeeeYZXnrpJfr168fu3bu58847eeqpp3jkkUcAuPjii331u3XrRr9+/UhJSeGDDz7gN7/5TZXnvfTSSyvdz/vvv5/ExER+//vf+8oSExPP+PWINDauCg/HnG4Wb87ilRV7sVhMBNmOPyLKc7rI+2EpGSUFdG0RzaXjJ7DyaCDF5Qb7jjoJMJvZdrgQp7uCIJuVEncFB46WVNorKtfpIs/pZsH6g6eMY8H6gwxuF631bmrB72lgbWaQlJeX8+STT9K6dWscDgfdu3ev8nm9nF3++te/MmPGDO6//36++uorNm7cyIgRI3C7a9aVGxcXR4cOHbj00kt5+eWX+de//kVmZmalOnPmzOGmm27igw8+OOnxyi+Jjo7GYrGQnZ1dqTw7O7vaHiuARx55hOuuu46bbrqJrl27Mn78eJ555hmeffZZvCeWc/+ZZs2a0a5dO3bv3l3teUNDQ2nTpo3vFRoaSmRkZKWyU/WkxMXF1fpaqmsTFhamXhtpkApK3cxff4jtmUW88MVOsgrLOHSslH25TgpLKwgPtBHRri/W0GjyWwzhiuH9OfF0Oq/YTXSoDae7gv1HS9iWWcj+nyU2ACmRQaRlFlXaXqEqTreHtMyiurnQJsqvyU1tZ5A8/PDDvPzyy/zjH/9g27Zt3HrrrYwfP77WM1ek8ejYsSMVFRV8//33vrKjR4+yY8cOOnXqBMB3333H2LFjufbaa+nevTutWrVi586dlc5js9nweE79CwTwJQ0ul8tX9t5773HDDTfw3nvvMXr06Fpfg81mo3fv3pUGBnu9XpYtW0b//v2rbVdSUoLZXPmfqMVy/K/G6uYBFBcX+2ag1ZX+/ftXuhaApUuXnvJaTqeNyC9xVXjILCjlq7QjfPBDBl+lHSGzoBRXxS//W/+l8/5nSxb/2ZzJjqwiCv87INhTVowrL5OcYhdOVwWhzROJ6DmCgOAwDuQ5ads8BIDmYQ5iQx0cOFpS7WcE2yy0igkhp9hVbZ2fynXWrJ4c59fHUtOnT2fq1KnccMMNAMycOZNFixbxxhtvVDmD5N///jcPPfSQb0Dlb3/7W7744guee+453nnnnXqNXepH27ZtGTt2LFOnTuXll18mNDSUBx54gMTERMaOHeurM2/ePFauXElERATTp08nOzvbl/wApKam8v3337N//35CQkKIjIxkyZIlZGdnc8455xASEsLWrVu59957GThwoG8m1bvvvsuUKVOYMWMG/fr1840rCQwMJDw8HIAFCxbw4IMPnnL8zLRp05gyZQp9+vShb9++vPDCCzidTt/PPsDkyZNJTEzk2WefBWDMmDFMnz6dnj17+h5LPfLII4wZM8aX5Nxzzz2MGTOGlJQUDh8+zGOPPYbFYvHNFKtKaWkpBQUFvvd/+tOfACqNmYmMjMRmq3p66p133smQIUN47rnnGD16NHPmzOGHH37glVde8dV58MEHOXToEG+//TYAt956K//85z+57777uPHGG/nyyy/54IMPWLRoka9NcXFxpR6nffv2sXHjRiIjI2nRokW11yNnp4JSN0u2ZJ+8saTNwvheSYzsEnvaU6zznG7m/pCBI8DCUefxHmB3bjqlu1YDENLjYo6aQkmOCCI00HbSasO9UyLILyk/qafmpy7rnUS4I4CYkJrt7B2tHcBrxW/JzYkZJA8++KCv7JdmkLhcLhwOR6WywMDAU67r4XK5Kv0V/tMF2qRxePPNN7nzzju55JJLcLvdDB48mMWLFxMQEAAc79Hbu3cvI0aMICgoiJtvvplx48ZV+gK/5557mDJlCp06daK0tJR9+/YRGBjIq6++yt13343L5SI5OZnLLrusUmL9yiuvUFFRwW233cZtt93mK58yZYpvEbqCggJ27NhxymuYNGkSOTk5PProo2RlZdGjRw+WLFlSaZBtenp6pZ6ahx9+GJPJxMMPP8yhQ4eIiYlhzJgx/N///Z+vzsGDB7nqqqs4evQoMTExnHfeeaxevZqYmJhqY3n//fcrJVVV+eqrrxg6dGiVxwYMGMC7777Lww8/zB//+Efatm3LwoULKy3AmJmZWWnWVsuWLVm0aBF33303M2bMICkpiddee40RI0b46vzwww8MGzbM937atGlA5XstAsd7VupyEG5aZhFHi92E2K00c5gp3bMWV+bx3mBLaAwmsxmvAa4KLxaLCZMJYkLtlLgruGVIK5IiA0mODOTaX9jVO8BqpkN8KME2yykfTQXbLHSIr3qCgFTNb+vcHD58mMTERFauXFmpa/q+++7j66+/rvQY4oSrr76aTZs2sXDhQlq3bs2yZcsYO3YsHo+nUgLzU48//jhPPPHESeVa50ZEpHHKLCjl7jkbfzEheP7KHqc1CPeDHzKYsWwX2dk5XBxygA9W/Iirwos9sROOlG6YzMd7TqNDbNgsZsKDAnj0kk7szy1hZJc4Iv67/YK7wstRp+uUu3q7Kjws3HC4ykTthOv6pzCuh2ZL1Wadm0Y1W2rGjBlMnTqVDh06YDKZaN26NTfccANvvPFGtW1OzH45obCwsMo1TkREpHGozSDcUyU3Tlc5R51uNmUUkF1YRmyYgx7JzWjfPAT3kf0UbFjBD9EOerWK40drOwIiK88itJrNWMwmru2XQpvmIfROiayUgNRkV2+71cLILsd7cE/Vy3O2Jza15bfk5nRmkMTExLBw4ULKyso4evQoCQkJPPDAA7Rq1araz7Hb7djtelYpItJUnIlBuDlFZXz6YyazvttPfmk57orjkwnCA63cNqwtF6UG8MoPFewtC+SBG65liMnOu9+n+wYXm00QFWLjqr4tGNU13tdbczrCA22M75nI4HbRp+zlkZrzW3Lz0xkkJ5ZYPzGD5Pbbbz9lW4fDQWJiIuXl5Xz44YeVFlQTEZGm7dcOwi3872DkV1bspcJrEGSzEBEUgNNVQUFpBf/4che/GdiPce4AVhwL5V8rDzOmWwJ/vrwbB46WkOd006Z5CN2TwokNd9DsDOwNVZNeHqk5vz6W+qUZJD+fPfL9999z6NAhevTowaFDh3j88cfxer3cd999/rwMERGpR79mEG5RWTmHC8p4afkusgtdvhlNFTn7sRUcJLbXBRwrqWDBxiz+duXFZHywiYxjJSz6MZNPf8ykR3I4l/VKomtCGM1Dz0xiI2eeX5ObX5pB8vPZI2VlZb6ZMSEhIYwaNYp///vfNGvWzE9XICIi9S0y2Mb4XkmnHIR7We8kon7Sc+Oq8FBQUk5GXsnxlYINE8kRQeQXl5C1dTWu7D0AODJ2EpLYjgNHS8jIK+Ht3/Rl08F8DueXER4UQMe4MCKDAwgPtOlxUQOmXcFFRKTRqXadm58Mwj2xzk1+iZtD+aWs3Z+HxWSixO1h9vfpHDuaQ+G2b/CUFOB0e7AndyE4pSvJkcFkF7q4Z0Q7fnNe9WM6pX412dlSIiIiUPNBuHlON/PXH+SVFXvJLymndfNgLu2WwJ7tmyFjAybDgynAQXy38yh1ROHl+Po1NquZ2DDHqYOQBkvJjYiINEq/NAj3+GJ/mTy/dCdeAwwMdmQXUbh/ExX71uCq8BIZl0xoh4GEh4Vy8Njx/Z88XoNmgQF0TQyv3wuSM0bJjYiINEl5Tjfvfp+O97+DL0yYMAyDfZ4IeqbGsLE8DiO5M+FhwbgrvNitFsoqPFjMJq4fmFrjWVnS8Ci5ERGRJikts4hjpeUYhoHHeQxLcAQm4PO9pdx19U0M9Zh59/t03BVeTCYwmyEiMIDbhrVhROdYguz6imys9H9ORESapJxiFxZvOUVp3+LOSSes2wVYwppT4TV4Yfl+xvVI5M+Xd6OorAKnq5wAi5keyRGkRAYRGhjg7/DlV9A8NhERaZLMJfnkrF2EO+f4lHFvaREWswmr2QQGLNhwiNveXY/VZKJ/62iahzpIjgxUYtMEqOdGRESaFMMwWLt2LWs++xSz20lIaBiWVv0JCI8BwGIGi8mE14AQh4U2sSFEBdtoFR2itWuaCCU3IiLSZJSVlfHxxx+zbds2bBa44Nye7LC3p9hjIb/Ejdc4PrAYEwSY4bZhbWgRFaSVhpsYJTciItJkpKWlsW3bNiwWCyNHjqRDt558tvUI89dlEOqwUlbuoeK/U72v6ZfCyC5xSmyaICU3IiLSKDhd5Rx1utmUUUB2YRmxYQ66J4cTFWwj2H58nEz37t3Jzs6mS5cuJCYmAmjH7bOQkhvxq6FDh9KjRw9eeOGFauuUlJRw3XXXsXTpUoqKijh27Bg9evTgrrvu4q677qq3WEXEf3KKyvho42Fe+2YvBaUVvvJQq4dzA7O494YJJMc0w2QyMWLEiEptteP22UcpqzR4b731Ft988w0rV64kMzOT8PC6WTU0NTX1pCSrrKyM66+/nq5du2K1Whk3blyVbV0uFw899BApKSnY7XZSU1N54403ah3D3Llz6dChAw6Hg65du7J48eJfbDN79my6d+9OUFAQ8fHx3HjjjRw9etR3fNasWZhMpkovh6Pul5Vfvnw5vXr1wm6306ZNG2bNmvWLbX788UcGDRqEw+EgOTmZv/zlL5WOv/rqqwwaNIiIiAgiIiIYPnw4a9asqaMrkIYiv8TNRxsP8+claRx1uqnwevEaBu6CIxz47mPe/fQrnpn5LiWuil8+mZwVlNxIg7dnzx46duxIly5diIuLw2Qy1dtnezweAgMD+f3vf8/w4cOrrXfFFVewbNkyXn/9dXbs2MF7771H+/bta/VZK1eu5KqrruI3v/kNGzZsYNy4cYwbN44tW7ZU2+a7775j8uTJ/OY3v2Hr1q3MnTuXNWvWMHXq1Er1wsLCyMzM9L0OHKh+N+WqPP7441x//fU1rr9v3z5Gjx7NsGHD2LhxI3fddRc33XQTn332WbVtCgsLueiii0hJSWHdunX89a9/5fHHH+eVV17x1Vm+fDlXXXUVX331FatWrSI5OZmLLrqIQ4cO1ep6pPHIKSrjaLGbf361m3KPQbnHwF3hpWD/FvI3fo6nrBhLYCjfO6PIKXb5O1xpKIyzTEFBgQEYBQUF/g5FDMMYMmSIcdtttxm33XabERYWZkRFRRkPP/yw4fV6fccB32vIkCGGYRhGSkqK8fzzz/vOc+DAAePSSy81goODjdDQUGPixIlGVlaW7/ju3buNSy+91GjevLkRHBxs9OnTx1i6dGmlOH76OVX905gyZYoxduzYk8r/85//GOHh4cbRo0d/1b244oorjNGjR1cq69evn3HLLbdU2+avf/2r0apVq0plf//7343ExETf+zfffNMIDw//VbE99thjxpQpU2pc/7777jM6d+5cqWzSpEnGiBEjqm3z0ksvGREREYbL5fKV3X///Ub79u2rbVNRUWGEhoYab731Vo1jk8ajuMxtLN2aZcz9IcNIuf9TI+X+T43kafOMqEv+YIQPvMoIH3iVETf+QaPtAx8ZHR7+j/HJpkP+DlnqUG2+v9VzI3731ltvYbVaWbNmDTNmzGD69Om89tprAMyfP5+pU6fSv39/MjMzmT9//kntvV4vY8eOJS8vj6+//pqlS5eyd+9eJk2a5KtTXFzMqFGjWLZsGRs2bGDkyJGMGTOG9PR03+ckJSXx5JNP+no3aurjjz+mT58+/OUvfyExMZF27dpxzz33UFpa6quzfPlyTCYT+/fvr/Y8q1atOql3aMSIEaxataraNv379ycjI4PFixdjGAbZ2dnMmzePUaNGVapXXFxMSkoKycnJjB07lq1bt9b4+k7H6VzLqlWrGDx4MDabrVKbHTt2cOzYsSrblJSUUF5eTmRk5JkJXBqU3GI3GzKOcaSoDABP8TGKN/yHimOHwWwhsE0/bG0HYLIcH0ycXVjmz3ClAdGAYvG75ORknn/+eUwmE+3bt2fz5s08//zzTJ06lcjISIKCgrDZbMTFxVXZftmyZWzevJl9+/aRnJwMwNtvv03nzp1Zu3Yt55xzDt27d6d79+6+Nk899RQLFizg448/5vbbbycyMhKLxUJoaGi1n1OdvXv38u233+JwOFiwYAG5ubn87ne/4+jRo7z55psABAUF0b59ewICql/5NCsri9jY2EplsbGxZGVlVdtm4MCBzJ49m0mTJlFWVkZFRQVjxozhxRdf9NVp3749b7zxBt26daOgoIC//e1vDBgwgK1bt5KUlFTleb/55hsuvvhi33u3241hGMybN89X9vLLL3PNNdfU6loKCwspLS0lMPDkgZ1ZWVm0bNnypDYnjkVERJzU5v777ychIeGUjwyl8frxYAEZeSUMbtccAJP9+M+NOTCM4A7nYQk+/jPhNQzMJhOxYXU/lkwaByU34nfnnntupXE0/fv357nnnsPj8WCxWH6x/fbt20lOTvYlNgCdOnWiWbNmbN++nXPOOYfi4mIef/xxFi1aRGZmJhUVFZSWlvp6bn4Nr9eLyWRi9uzZvsHO06dP5/LLL+ell14iMDCQvn37kpaW9qs/6+e2bdvGnXfeyaOPPsqIESPIzMzk3nvv5dZbb+X1118Hjt/P/v37+9oMGDCAjh078vLLL/PUU09Ved4+ffqwceNG3/u///3vHDp0iD//+c++sp8nL/XtT3/6E3PmzGH58uX1MkBa6l92YRlLtxzkd0PbEB5opQAHwZ2HYXYE+3prTggPtNI1sW4mG0jjo+RGzgr33HMPS5cu5W9/+xtt2rQhMDCQyy+/HLfb/avPHR8fT2JiYqVZXB07dsQwDA4ePEjbtm1rdJ64uDiys7MrlWVnZ5+yJ+nZZ59l4MCB3HvvvQB069aN4OBgBg0axNNPP018fPxJbQICAujZsye7d++u9ryBgYG0adPG9z4yMpLCwsJKZadzLWFhYVX22pyqzYljP/W3v/2NP/3pT3zxxRd069atRjFJ3XJVeMhzuknLLCKn2EVMyPG1ZCKDbditv/xHSlWMoiMc/f5j5newcuuQdvx5yQ4swc2qrDt1cCtiQuy/4gqkKdGYG/G777//vtL71atX07Zt2xr12sDxRCIjI4OMjAxf2bZt28jPz6dTp07A8VlF119/PePHj6dr167ExcWdNP7FZrPh8XhqHf/AgQM5fPgwxcXFvrKdO3diNpurfexTlf79+7Ns2bJKZUuXLq3U6/JzJSUlmM2V/xmfuG+GYVTZxuPxsHnz5ioTnzPldK6lf//+rFixgvLy8kpt2rdvX+mR1F/+8heeeuoplixZQp8+fc588FJrBaVuFm44zN1zNjJ96U7+veoA05fu5O45G1m44TAFpbX7I8Lr9bJ8+XK2ff0JNsPNPz/4jJ7Jzbh/ZHvCAyv/TR4RFMADF3fg0u4JBNn197ocp+RG/C49PZ1p06b5plD/4x//4M4776xx++HDh9O1a1euueYa1q9fz5o1a5g8eTJDhgzxffm1bduW+fPns3HjRjZt2sTVV1+N1+utdJ7U1FRWrFjBoUOHyM3N9ZVv27aNjRs3kpeXR0FBARs3bqz0yObqq68mKiqKG264gW3btrFixQruvfdebrzxRl8vxZo1a+jQocMppyzfeeedLFmyhOeee460tDQef/xxfvjhB26//XZfnQcffJDJkyf73o8ZM4b58+fzr3/9i7179/Ldd9/x+9//nr59+5KQkADAk08+yeeff87evXtZv3491157LQcOHOCmm26qNha3201WVpbvdeutt/KnP/2pUtlPB0z/3K233srevXu57777SEtL46WXXuKDDz7g7rvv9tX55z//yQUXXFDpPtpsNt+09vfff58ZM2Ywbdo0X50///nPPPLII7zxxhukpqb6YvlpYin1y1XhYcmWbN5ZfQCnu/IfB063h3dWH2DJlmzcFd6T2mUWlPJV2hE++CGDr9KOkFlQSu6xfP7973+zfPlyAgPMjLtgIGFdh/Obt38gPDCA92/uz/SJ3bl/ZHumT+zOvFsHMLF3EjGhejQp/6M0V/xu8uTJlJaW0rdvXywWC3feeSc333xzjdubTCY++ugj7rjjDgYPHozZbGbkyJH84x//8NWZPn06N954IwMGDCA6Opr777+fwsLCSud58sknueWWW2jdujUul8vX8zFq1KhK68L07NkT+F/PSEhICEuXLuWOO+6gT58+REVFccUVV/D000/72pSUlLBjx45KvRI/N2DAAN59910efvhh/vjHP9K2bVsWLlxIly5dfHUyMzMrjRO6/vrrKSoq4p///Cd/+MMfaNasGeeff36lsTHHjh1j6tSpvkG5vXv3ZuXKlb5eraqsXLmSYcOGVXsc4M0336x27ZuWLVuyaNEi7r77bmbMmEFSUhKvvfZapZVjc3Nz2bNnj+99eHg4n3/+Obfddhu9e/cmOjqaRx99tNLPwr/+9S/cbjeXX355pc977LHHePzxx08Zr9SNPKebBesPnrLOgvUHGdwu2rdCcEGpmyVbslmw/mClhMgoyKTZkY0khZoJCw5k/PjRJLRqT4//rkz81KfbMZvhgg7NSYoIpF1sKGGBVsK0N5T8jMmoru+6iSosLCQ8PJyCggLCwsL8HY6ISKP2VdoRpi/d+Yv1pl3YjmEdmuOu8PDNrlwWbjjEgaMlnPgCcpcUsf/reRiGwaBubXjq7ptIiDs+S6rEVUFOsYvNh/63p1TXxHBiQux6FHUWqc33t34qRETktNVkVWCLCZoFWcksKGXLoQI2HyqgV0oEl/dO4of9x/h6Zw62oFAiW3XFU+6iKGUApsBQX/sgu5UUu5WUqOC6vBRpQpTciIjIaTvVDCWzCQa3jWF0t3hW7snl/R+2UOKuwGIyUeL2UJZ7kCsGdeba/im8s+oAUe16YzKZKPVAWmaRNrqU06bkRkRETluH+FCCbZaTBhObgGvOTSHIZuGTTYd5/dt9mEym45teejxYs7dRkrGNF3du4A933MrgdjF8vTPH1z7XqX2i5PRptpSIiJy2yGAb43tVXvLABFzWK5GcIhc2i5n31qYfLwS8ZSUU/PgF2bs24fUahEQ15/016fRJjeCnW+JGB2vNGjl96rkREZHTZrdaGNnl+GrVCzccpE9KJH1SI4hv5mDBukMUl1VQ8t9eHdfRgxSlrcTjLsNktWFpcy6JbduTXehi/1EnKVFB7D9aQrDNQof40FN9rMgpqedGRER+lfBAG+N7JjJ9Ug96pTTDZjWz+WAhtgAz5V4vz13ejS7efRRu/QqjwkVAWDShPS/GEpWMq8KLzWomr9hNkO3439uX9U4iSj038iuo50ZERH41A4OsgjI2ZBSwYP1Byiq8FJdVEB4YgLPMRduiHPq3imKjK4aglj3xYsbjNfB4DcwmiAyxkVVYxuT+KVzUORabVX97y+lTciMiIqftxJ5S5RVevko7wsyv9+IIMBNst1JWXkFMqJ0j5QZrzR2Y2D+EjhGJfPJjFiYMLCYT9gAzMaF2+reKZkTnOKKC7Ups5FfTT5CIiJyWE3tKvfD5TvJLy5m1aj/lXi9FpS6Kd63Blb6ZorJyooJtWBwhfHHYyvkd4zCZwIQJi9lEsM3KlAGptIwOJj48UImNnBH6KRIRkVr76Z5Scc0CScsqoqisAk9pEUWbPidn3zZM2WkczcvDajETE2Kj2FXBgaNO2jYPASA5Mogbz2vJCD2GkjNMj6VERKTWfrqnlAmDghI37pwDlOz+HqOiHG+AnRY9hmKLjCanyEWow0pSRBBmE1zdrwV2q4U+qRE0D3UosZEzTsmNiIjUWlpmkW/hvl2Z+UQVpFG64zsMw8AaFkNwh/MotAURaRgkRQTiqvBSVu4hoVkgA9pEE2KzEqCkRuqIkhsREam1E3tKGYbBd0sW0K+5QXigjdKoNjhSumEymTGAgtJynC4PNquZpIhAeraIICJIu3hL3VLaLCIitXZiTymTyURYcnsOFxvcfONkWnTph9Vs8dUzYcJsglCHlevOTSH6FHtRiZwp6rkREZGTnJjinZZZRE6xi5gQOx3iQ4kMtmE2vMQElPn2lApPaou3eQtat2nDjXFuPv3xMEedbjxeg0CbhZgQO1eck6yBw1JvTIZhGP4Ooj4VFhYSHh5OQUEBYWFh/g5HRKTBKSh1s2RLNgvWH6y0IWawzcIFLQMp3LYCT7mbuHMvZe7GI77jJmBIuxj6pEZwKL+Uco9BckQgHRPCtH6N/Gq1+f5Wz42IiPj8dIr3zx3em8Zzn6yiS3wwfdom0DfBht2R4kuCDGD5zhx+OJDHDQNbMqBNFCH2gPq/CDnrKbkRERGfn07xPsFbUU721lUUHtoNQEZFKH+65nraJMbQKsXL4HbRpGUWket0ER18/PGVemrEn5TciIiIz0+neAO4CvM4vPEr3MUFmEwmotr2JLJ1dzKKDNoANquZ+PBA4sMD/Re0yM8ouREREZ8TU7xPyNu3GXdxAVZHEPE9hhIUGQdArtNVVXORBkHJjYiI+MT8bKp2807nYjJbiG7XG6v9f70z0cGa0i0Nlx6IioiIT4SpmKLdP3BiIq0lwE5c1/MqJTbBNgsd4kP9FaLIL1JyIyIiGIbB2rVrWTDn30SXHKDw4K5q617WO4ko9dxIA+b35ObFF18kNTUVh8NBv379WLNmzSnrv/DCC7Rv357AwECSk5O5++67KSsrq6doRUSanrKyMubOncuiRYswGQYXn9eLqWMGEWyzVKoXbLcwuX+KFuOTBs+vY27ef/99pk2bxsyZM+nXrx8vvPACI0aMYMeOHTRv3vyk+u+++y4PPPAAb7zxBgMGDGDnzp1cf/31mEwmpk+f7ocrEBFp3A4dOsS8efM4duwYFouF4cOHc+6551LuMRjeLUlTvKVR8usKxf369eOcc87hn//8JwBer5fk5GTuuOMOHnjggZPq33777Wzfvp1ly5b5yv7whz/w/fff8+2339boM7VCsYjIcRs2bODTTz/F4/HQrFkzJk6cSGJior/DEqlSbb6//ZZ+u91u1q1bx/Dhw/8XjNnM8OHDWbVqVZVtBgwYwLp163yPrvbu3cvixYsZNWpUtZ/jcrkoLCys9BIREYiMjMTr9dKxY0duvfVWJTbSZPjtsVRubi4ej4fY2NhK5bGxsaSlpVXZ5uqrryY3N5fzzjsPwzCoqKjg1ltv5Y9//GO1n/Pss8/yxBNPnNHYRUQaq7KyMhwOBwApKSlMnTqV+Ph4TCaTnyMTOXMa1YPT5cuX88wzz/DSSy+xfv165s+fz6JFi3jqqaeqbfPggw9SUFDge2VkZNRjxCIiDYNhGKxcuZIXXniB3NxcX3lCQoISG2ly/NZzEx0djcViITs7u1J5dnY2cXFxVbZ55JFHuO6667jpppsA6Nq1K06nk5tvvpmHHnoIs/nkXM1ut2O3a8qiiJy9SkpKWLhwITt37gRg06ZNXHDBBX6OSqTu+C25sdls9O7dm2XLljFu3Djg+IDiZcuWcfvtt1fZpqSk5KQExmI5PlXRj+OiRUT8zlXhIc/pJi2ziJxiFzEhx2c3FR/N4pOFCygsLMRqtTJy5Eh69+7t73BF6pRfp4JPmzaNKVOm0KdPH/r27csLL7yA0+nkhhtuAGDy5MkkJiby7LPPAjBmzBimT59Oz5496devH7t37+aRRx5hzJgxviRHRORsU1DqZsmWbBasP+jb9NIwDErTtxBVtJtW0UEkxjVn4sSJ1faMizQlfk1uJk2aRE5ODo8++ihZWVn06NGDJUuW+AYZp6enV+qpefjhhzGZTDz88MMcOnSImJgYxowZw//93//56xJERPzGVeGhoKScxZszefXbfQSYTTgCLFjMJooO7iJr61oygOTW7bnhN5MJCXL4O2SReuHXdW78QevciEhTcKK3JiHcwR/mbqKorAIAswmaBdkIs5vJWv8FofGtiG/VgReu6kl8eOAvnFWk4WoU69yIiMjpcVV4WLIlm2935bA7p5iisgoMw0tZ5i48nuNjbwpdXhL6XER4cjtKyr2kZRb5O2yReqPkRkSkkclzulmw/iBBditHnW687lIKf1xG0c7vce7bCEB+iRvPT/rlc50u/wQr4gd+HXMjInI2q26GU2SwDbu1+kkSaZlFON0eSlwVeDzHOLZuEV53GSaLBWtIBABeA8rKPQRYjv8NG61dvOUsouRGRMQPqprhBBBsszC+VxIju8QSHmirsm1OsQvD62Xdqm8o5hABXjeekGaEdhyENSjcV6/Ca/jO2SE+tG4vSKQBUXIjIlLPToyZeWf1gZOOOd0eX/n4nolV7sAdhJuDa/5DSV42IVFBjBw6gO/KkjBZKv9Kt5qPrzx8We8kotRzI2cRjbkREalnJ8bMVMcErNufR2FZeZXHW0U78JbkY7ZacSefw4hRo7l5WDtCHf9LbswmiA6xM7l/CiM6x1aZJIk0Veq5ERGpZyfGzPyc2QSD28bQJzWCvblOPtl0mNSoYDrEhxIRFIAj4Piv7NZJcfzmuqtZvLMQW3A476w6wJB2Mfzl8m7sP+okr9hNq5gQ+raMJDrErsRGzjpKbkRE6llO8ckzl0zANeemcPBYKffO+5GisgqiQmxEBNkI8JQSm/cjt145mu6dOmC3Wrj+4n7EJf9vzM7ynTl8vTOHDvGhjOwSxzmpkYQ6Aur/4kQaACU3IiL1LCbk5PEvQ9rFcPBYKa+u2Osrs5pNFGenk/XjN2wpd1FW4uRfz/wRh81KeKCN8T0TGdwumrTMInKdLqKDj8+2igpWb42c3ZTciIjUsw7xoQTbLL5HUyagd2oE98370VfHZHgo3rOOwgPbAHCER1OQ0I9jpeXE247/6rZZzcSHB2rlYZGfUWovIlLPIoNtjO+V5HufEhXEvlynbwsFT1kx7u1fUnhgKwARqZ1JPncU5QHBWmlYpAbUcyMiUs/sVgsjuxzfIPinKw0DGC4n5Vs+w0oFlgA7cd0GERKb4murlYZFfpmSGxGROnSqVYhPjJnJyCvhcH4Zic0cmE0ODmUn4youIKr7UOxh4XgNA7Pp+Jo1WmlY5JcpuRERqSM1WYU4PjwQu6eUCJsdi9nMwWMleBJ7YTWZOFpu4VheCc2CbIQHWglzBGilYZEaUHIjIlIHaroKcXtbPp98+jGeoBgu6jyE177ZV2mlYa9xfNE/gCkDWmqlYZEa0IBiEZE68EurEHs9Fbw4633+/d4c8otK+M+GA8QGm5k6uFWllYYBwhxWruiTxOB20ZriLVID6rkREakD1a1CDOB2FpC54SvKCvPIbR1F33MHsCM+ig/WZ5+00nBkiI3UqGB+2H+MtMwiTfsWqQElNyIidaCqVYgBCg/tJnvrSrwVFVjtDvoMv5SOHdqxZOkuDPCtNJwSFUSQzcq+XCfz1x3CAFKig+r1GkQaKyU3IiJ1oKpViL2eCnJ3rsdbUUFQVBzx3YfSpUN7gu2WSvUMYP/RkpPaa6aUSM0ouRERqQM/X4UYwGyxEt9zGM6cg0S17k7IT2Y//bzuzwXbLJopJVJDGpkmIlIHTqxCXHBwFwUZO33lgc1iiG7bE5PZzGW9k4gKtp+0YnFVTtQVkV+mnhsRkTpg8noo37Oa5nk/suOIk8DIWGzB4QAE2y1M6JXERZ1jfbOffrpicaU1caqoKyKnZjIMw/B3EPWpsLCQ8PBwCgoKCAsL83c4ItIEZWdnM3fuXHJzc/Ea0LPfQMJSu5JXWn7KnbvdFV6OOl3a5VukCrX5/lbPjYjIGWIYBhs2bGDx4sVUVFQQGhrKhAkTSE1NrVF77fItcmYouREROQMMw2DhwoVs2rQJgDZt2jB+/HiCg4P9HJnI2UfJjYjIGWAymYiMjMRsNnP++eczcOBATP/d7FJE6peSGxGR02QYBmVlZQQGHn+MNGjQINq3b09cXJyfIxM5u2mEmojIaSgrK2PevHnMmjWL8vJyAMxmsxIbkQagVsnNpk2bePrpp3nppZfIzc2tdKywsJAbb7zxjAYnItIQHT58mJdffpmtW7eSk5NDRkaGv0MSkZ+o8VTwzz//nDFjxtC2bVuKiopwOp3MnTuXYcOGAcenPiYkJODxVL/CZkOgqeAicroMw2DNmjV8/vnneDwemjVrxuWXX05S0qkX4BORX68239817rl5/PHHueeee9iyZQv79+/nvvvu49JLL2XJkiW/OmARkYautLSU999/n//85z94PB46dOjALbfcosRGpAGq8YDirVu38u9//xs4PivgvvvuIykpicsvv5w5c+Zwzjnn1FmQIiL+tmjRItLS0rBYLFx00UX07dtXs6FEGqgaJzd2u538/PxKZVdffTVms5lJkybx3HPPnenYREQajAsvvJBjx44xevRoEhIS/B2OiJxCjZObHj168NVXX9G7d+9K5VdeeSWGYTBlypQzHpyIiL+UlJSwc+dOevToAUB4eDg33XSTemtEGoEaJze//e1vWbFiRZXHrrrqKgzD4NVXXz1jgYmI+Et6ejrz5s2jsLCQwMBA2rdvD6DERqSR0MaZIiL/ZRgG3333HV9++SVer5eoqCgmTpyotWtEGoB63TgzOzsbl8tFixYtfu2pRET8xul0smDBAnbv3g1A165dueSSS7Db7X6OTERqq8ZTwYuKirj22mtJSUlhypQpuN1ubrvtNuLj42nZsiVDhgyhsLCwLmMVEakT+/fvZ+bMmezevRur1cqll17KZZddpsRGpJGqcXLzxz/+kXXr1nHPPfeQnp7OFVdcwYoVK/jmm2/46quvyM3N5c9//nNdxioiUieKi4spKioiJiaGm2++mV69eml8jUgjVuMxNy1atOCtt95i2LBhHD58mKSkJD7++GMuueQS4PgaEH/4wx9IS0ur04B/LY25ERE4Pr7mpwnMpk2b6NixIzabzY9RiUh16mSF4iNHjtCmTRsAEhISCAwMpF27dr7jXbp00f4qItIo7N27l5dffpni4mJfWffu3ZXYiDQRNU5uoqKiyMnJ8b0fO3YszZo1870vLi7W82kRadC8Xi9fffUV//73v8nKymL58uX+DklE6kCNZ0t169aNtWvX0qtXLwDefffdSsfXrl1Lx44dz2x0IiI14KrwkOd0k5ZZRE6xi5gQOx3iQ4kMtmG3WoDjkyI+/PBD9u/fD0CvXr0YMWKEH6MWkbpS4+Rm9uzZmM3Vd/TExsbyf//3f2ckKBGRmioodbNkSzYL1h/E6fb4yoNtFsb3SmJkl1hyDqUzf/58SkpKsNlsjBkzhq5du1Y6T00SJBFpHGq9iF96ejrJycknzSQwDIOMjIwGv96NBhSLNB2uCg8LNxzmndUHqq0zJKaMgm3fYDGbiIuLY+LEiURFRVWqU5MEKTxQ43FE/KlOBhSf0LJly0pjb07Iy8ujZcuWtT0dAC+++CKpqak4HA769evHmjVrqq07dOhQTCbTSa/Ro0ef1meLSOOV53SzYP3BU9b5PjcAe0g455xzDjfddNNJiY2rwsOSLdm8s/pApcQGwOn28M7qAyzZko27wnvG4xeRulHr5Obn0ydPKC4uxuFw1DqA999/n2nTpvHYY4+xfv16unfvzogRIzhy5EiV9efPn09mZqbvtWXLFiwWCxMnTqz1Z4tI45aWWYTT7cFrGJR7vBSVlZNX4iY36zDuiuPlZYaFc0ZOZPTo0VitJz+Jr0mCtGD9QY46XXV1GSJyhtV4zM20adOA4xvHPfLIIwQFBfmOeTwevv/+e9/uubUxffp0pk6dyg033ADAzJkzWbRoEW+88QYPPPDASfUjIyMrvZ8zZw5BQUFKbkTOQjnFLjxeLwWlFeSXuPF4PJTs20jJwe2EtulNQrvuhAdaKSyv/hwnEqRTcbo9pGUWER8eeIavQETqQo2Tmw0bNgDHe242b95caT0Im81G9+7dueeee2r14W63m3Xr1vHggw/6ysxmM8OHD2fVqlU1Osfrr7/OlVdeSXBwcJXHXS4XLtf//uLSFhEiTUd0sI2C0grynG48ZcUUbf+W8sJcADxlJeQ53QBEBVU/XianuGY9MrnquRFpNGqc3Hz11VcA3HDDDcyYMeOMDMbNzc3F4/EQGxtbqTw2NrZGKx2vWbOGLVu28Prrr1db59lnn+WJJ5741bGKSMPTunkIHq8XV24GxTtW4a1wY7baCGnfH3t0MgAer5fWzUOqPUdMSM3W54oO1jpeIo1FrcfcvPnmmw1mltHrr79O165d6du3b7V1HnzwQQoKCnwvraIs0nQcLSylq7GPwq1f461wExAWTbPeo3yJDcAV57SgoLT651Id4kMJtp16qnewzUKH+NAzFreI1K0a99z81A8//MAHH3xAeno6bre70rH58+fX+DzR0dFYLBays7MrlWdnZxMXF3fKtk6nkzlz5vDkk0+esp7dbtfKySJN1Nod+ylIT6N3SgT7LYmYErtiMh9PVMIcVq7s24LEiEB2ZBfRLalZleeIDLYxvlfSKaeTX9Y7iSj13Ig0GrXuuZkzZw4DBgxg+/btLFiwgPLycrZu3cqXX35JeHh4rc5ls9no3bs3y5Yt85V5vV6WLVtG//79T9l27ty5uFwurr322tpegog0Ee1SW5AV1pGeQ0fz8oM38sDoTkwd1JL7L27Pny/vhsdr8M6qA6d8pGS3WhjZJZZrz005qQcn2G5hcv8URnSOxWat9a9LEfGTWvfcPPPMMzz//PPcdttthIaGMmPGDFq2bMktt9xCfHx8rQOYNm0aU6ZMoU+fPvTt25cXXngBp9Ppmz01efJkEhMTefbZZyu1e/311xk3btxJa1aISNNVUVHB0qVL6dWrF7GxsXSIDyWhTWe2lnjY9vlOUqKCCLJZ2ZfrZP66QxjU7JFSeKCN8T0TGdwumrTMInKdLqKDj69QHBVsV2Ij0sjUOrnZs2ePb8E8m82G0+nEZDJx9913c/7559d68O6kSZPIycnh0UcfJSsrix49erBkyRLfIOP09PSTtn3YsWMH3377LZ9//nltwxeRRuro0aPMnTuXrKws9uzZw+9+97tKj5QMYP/RkpPa1fSRks1qJj48UNO9RZqAWic3ERERFBUVAZCYmMiWLVvo2rUr+fn5lJSc/IulJm6//XZuv/32Ko9VtWtv+/btqeWuESLSiG3evJlPPvkEt9tNcHAwI0eOxGw2YzfDyC7H/xA6aesEu4UJvZK4SI+URM46tU5uBg8ezNKlS+natSsTJ07kzjvv5Msvv2Tp0qVccMEFdRGjiJylysvL+c9//sP69esBSE1NZcKECYSG/u8xkx4picjP1XrjzLy8PMrKykhISMDr9fKXv/yFlStX0rZtWx5++GEiIiLqKtYzQhtnijQOxcXFvP322xw5cgSTycTgwYMZMmTISY+pReTsUJvv71r33Px0+wOz2VzlFgkiIie4KjzkOd2kZRaRU+wiJuR4r0pksA27tfr1ZYKCgggODiYkJITLLruMVq1a1WPUItKYndY6Nx6Ph4ULF7J9+3YAOnfuzKWXXorFcuqFsETk7FJQ6mbJluyTx8PYLIzvlcTILrGEB/5vawS3243ZbMZqtWI2m5kwYQIAISHVrzAsIvJztU5udu/ezejRozl48CDt27cHjm9xkJyczKJFi2jduvUZD1JEGh9XhYclW7KrXBzP6fb4ysf3TMRmNXPkyBHmzp1LSkoKl1xyCaCkRkROT60fXv/+97+nVatWZGRksH79etavX096ejotW7bk97//fV3EKCKNUJ7TzYL1B09ZZ8H6g+QWl7F+/XpeeeUVcnJy2LFjx2nPvBQRgdPoufn6669ZvXp1pbE3UVFR/OlPf2LgwIFnNDgRabzSMosqPYqqSqGzlFfffh8j73gvTps2bRg/fjxBQUH1EaKINFG1Tm7sdrtvnZufKi4uxmazVdFCRM5GOcWuUx4vKzxK5oavCI400TUpgvPPP5+BAwdiMpnqKUIRaapq/Vjqkksu4eabb+b777/HMAwMw2D16tXceuutXHrppXURo4g0QjEh1a8K7PVUcOiHpbidhcRERnD99ddz3nnnKbERkTOi1snN3//+d1q3bk3//v1xOBw4HA4GDhxImzZtmDFjRl3EKCKNUIf40JM2ojzBbLES23kAUQkp/OHO22jRokU9RyciTVmtH0s1a9aMjz76iF27dpGWlgZAx44dadOmzRkPTkQar5/u+wRQVpCLp9xNcHQCACGxLbh17HkkxzTshT9FpPE5rXVuANq2bUvbtm3PZCwi0oTYrRZGdonFMAxen/856ZtXY7YEkHLeWJo1C9e+TyJSZ2qU3EybNq3GJ5w+ffppByMiDcepVhYGarTqsA0Pnt3f0Y19JLSMICIhlZEXdaR7y+ba90lE6kyNkps333yTLl26YLVaMZlM1e7IrcGAIk3DqVYWHtszkQ5xofzlP2kUn2LV4YMHDzJv3jzy8/NpFuzgivGX0rdvX/2eEJE6V6ONM81mM1lZWTRv3pxWrVqxdu1aoqKi6iO+M04bZ4qcmqvCw8INh6tcWdhrGOSXlDOhdxJer8HXO3NOqnNNvxYkuDJY/tUyvF4vERERTJw4kYSEhPoIX0SaqNp8f9eoTzgiIoJ9+/YBsH//frxe76+PUkQapFOtLOzxGuSXuJmzJp0+qRFU1QezcMMh9h3KxOv10rlzZ2655RYlNiJSr2r0WGrChAkMHjyYhIQETCYTffr0qXaTzL17957RAEWkfp1qZeGycg9eA4rKKth/1ElKVBD7jx7fKsEwDEwmE063h4TO/enZqR1du3bVYygRqXc1Sm5eeeUVLrvsMnbv3s3vf/97pk6dSmhoaF3HJiJ+cKqVhcu9/3uKnVfsJshmxTAMju3dTEleFol9LsRkMpHv9nJh7271Ea6IyElqPBV85MiRAKxbt44777xTyY1IE3WqlYUDzP/rhYkMsbHzYC6HfvgcZ84hAIqzDxAal0p0cPXnEBGpa7Ve5+bNN9+sizhEpIE4sbJwVY+mHAEWzCYItltxlOXxzSfvUV5WgtlioXmncwmJTSHYZqFDvP74ERH/0SITIlLJiZWFq2Ixmwh3WDnHkc0bb86ivKwEe0gzWgy4lPDk9phMJi7rnUSUem5ExI9Oe4ViEWmaTqwsDJy0zk2ow0rn8l0UHNzB4WMlhCe1oXmn/pitAQTbLVp1WEQaBCU3InKS8EAb43smMrhdNGmZReQ6XUQHH1+FuLwohXf+fYSJEy7DEt2y0jGtOiwiDUGNFvFrSrSIn0jteL1eDh06RHJysq/M7XZjs9n8GJWInG3O+CJ+InJ2Kioq4u2332bWrFkcOnTIV67ERkQaMj2WEpEq7d69mwULFuB0OrHZbBQVFfk7JBGRGlFyIyKVeL1evvzyS7799lsA4uLimDhxYqPdT05Ezj5KbkTEp6CggA8//JD09HQAzjnnHEaMGIHVql8VItJ46DeWiPhs376d9PR07HY7l156KZ07d/Z3SCIitabkRkR8+vXrR1FREb179yYyMtLf4YiInBbNlhI5i+Xn57NgwQLcbjcAJpOJCy+8UImNiDRq6rkROUulpaWxcOFCysrKsNlsjB492t8hiYicEUpuRM4yHo+HpUuXsnr1agASExMZOHCgn6MSETlzlNyInEWOHTvG3LlzOXz4MAADBgzgggsuwGKx+DkyEZEzR8mNyFli//79vPfee7hcLgIDAxk/fjzt2rXzd1giImeckhuRs0RUVBRWq5XY2FgmTJhAeHi4v0MSEakTSm5EmrCSkhKCgoIACA0N5YYbbiAiIkKPoUSkSdNUcJEmavPmzcyYMYNt27b5yqKjo5XYiEiTp54bkSamvLycJUuWsG7dOgA2bdpEp06d/ByViEj9UXIj0oTk5uYyd+5csrOzMZlMDB48mCFDhvg7LBGReqXkRqSJ2LRpE59++inl5eWEhIRw2WWX0apVK3+HJSJS75TciDQgrgoPeU43aZlF5BS7iAmx0yE+lMhgG3Zr9WNlMjMzWbBgAQAtW7ZkwoQJhISE1FfYIiINipIbkQaioNTNki3ZLFh/EKfb4ysPtlkY3yuJkV1iCQ+0Vdk2Pj6eAQMGYLfbGTRoEGaz5gqIyNlLyY1IA+Cq8LBkSzbvrD5w0jGn2+MrH98zEZvVjGEYbNq0iVatWhEWFgbARRddVK8xi4g0VPrzTqQByHO6WbD+4CnrLFh/kKNOFy6XiwULFrBw4ULmzZuH1+utpyhFRBoHvyc3L774IqmpqTgcDvr168eaNWtOWT8/P5/bbruN+Ph47HY77dq1Y/HixfUUrUjdSMssqvQoqipOt4eVP+7hlVde4ccff8RsNtOuXTtMJlM9RSki0jj49bHU+++/z7Rp05g5cyb9+vXjhRdeYMSIEezYsYPmzZufVN/tdnPhhRfSvHlz5s2bR2JiIgcOHKBZs2b1H7zIGZRT7DrlccMwKMjYwdxtO+gQG0xYWBiXX345LVq0qKcIRUQaD78mN9OnT2fq1KnccMMNAMycOZNFixbxxhtv8MADD5xU/4033iAvL4+VK1cSEBAAQGpqan2GLFInYkLs1R7zlLvJ3vIdRZn7aNU6inbt2jFu3DjftgoiIlKZ3x5Lud1u1q1bx/Dhw/8XjNnM8OHDWbVqVZVtPv74Y/r3789tt91GbGwsXbp04ZlnnsHjqb473+VyUVhYWOkl0tB0iA8l2Fb1VG+T2Yy7OB97gIUJl47iqquuUmIjInIKfktucnNz8Xg8xMbGViqPjY0lKyuryjZ79+5l3rx5eDweFi9ezCOPPMJzzz3H008/Xe3nPPvss4SHh/teycnJZ/Q6RM6EyGAb43sl+d4bhoFhGACYLVbiewzld7dMZeT5QzTGRkTkF/h9QHFteL1emjdvziuvvELv3r2ZNGkSDz30EDNnzqy2zYMPPkhBQYHvlZGRUY8Ri9SM3WphZJdYrj03BYepgswNX5K390cAgu0Wpl7Ug6vP74HN2qj+yYqI+IXfxtyc2J04Ozu7Unl2djZxcXFVtomPjycgIKDSrsYdO3YkKysLt9uNzXbyAmd2ux27vfrxDCINRXigjb7NYUfRWoKCi3G7nVw3YBQ928QRFWxXYiMiUkN++21ps9no3bs3y5Yt85V5vV6WLVtG//79q2wzcOBAdu/eXWldj507dxIfH19lYiPSWBiGwapVq3jn7Vl4XU56tU3iuYfvYlTvlsSHByqxERGpBb/+xpw2bRqvvvoqb731Ftu3b+e3v/0tTqfTN3tq8uTJPPjgg776v/3tb8nLy+POO+9k586dLFq0iGeeeYbbbrvNX5cg8quVlpYyZ84cPvvsMzweD506deKWW24hISHB36GJiDRKfp0KPmnSJHJycnj00UfJysqiR48eLFmyxDfIOD09vdIeOcnJyXz22WfcfffddOvWjcTERO68807uv/9+f12CyK/i8Xh47bXXOHr0KFarlREjRtCnTx8NGhYR+RVMxokpGWeJwsJCwsPDKSgo8O3JI+JPa9euZfXq1UycOLHa8WYiIme72nx/a+NMkXpWUlKC0+kkJiYGgD59+tCjRw/fwpQiIvLrKLkROcNcFR7ynG7SMovIKXYRE2KnQ3wokcE2sg4dZN68eVitVm655RYcDgcmk0mJjYjIGaTkRuQMKih1s2RLNgvWH6y0EWZQgJmOpsO4Mn7EbjUTHR1NSUkJDofDj9GKiDRNSm5EzhBXhYclW7J5Z/WBSuUVrhJ2rlnBhtzDdEsKZ9LIQYwdc4mWLxARqSNKbkTOkDynmwXrD1YqKzl6mMyNX1PhKsVssVIU24Pzhl+sxEZEpA4puRE5Q9Iyiyo9igI4tm8rFa5S7KERxPcYii00grTMIuLDA/0UpYhI06fkRuQMySl2nVQW120QeXt+JKpdL8yW4//ccp0n1xMRkTNHa7qLnCExIXacOYfI2b7GV2axOYjp2NeX2ABEB2uvMxGRuqSeG5EzwOv1krPzB45sWIq7wosjojmhcakn1Qu2WegQH1r/AYqInEWU3IjUwKnWrnGVOPnwww/Zs28fHeJCSTfHERyTVOV5LuudRJR6bkRE6pSSG5FfUN3aNcE2C+dGl1OY9i3ecjfBgYHcc+tlHPBGnVzXbmFCryQu6hyrHb5FROqYkhuRU6hu7RqA9O3rWb9jHd2Swjm/V3uunHQFkZGR9KrwMrhdNGmZReQ6XUQHH+/liQq2K7EREakHSm5ETqGqtWtOcIRFYTKZyHEkM+aKa4iMPD6WxmY1Ex8eqOneIiJ+oj8jRU7h52vXVLhKff8dHJNEynnjCGvXl905pVU1FxERP1ByI3IKJ9auMbwejmz7nv0rPsRdUuQ7bg+NALR2jYhIQ6LHUiKnEBNix11SRObGryjLzwXAmZOBLaVTpXpau0ZEpOFQciNyCuaCg2St/piyMheWADtx3QYREtuiUh2tXSMi0rAouRGpQkVFBZ9//jkrV6+mbbSDXc5w4nsMJSAw5KS6WrtGRKRhUXIjUoXvv/+eNWvWYDWbuW7cRZREdeSjTZlau0ZEpBFQciNShX79+rFv3z769etH27ZtcVd4GdoxVmvXiIg0AibDMAx/B1GfCgsLCQ8Pp6CggLCwMH+HIw1EeXk5a9eu5dxzz8VsVrIiItLQ1Ob7Wz030uScah8ou9VyUv3c3Fzmzp1LdnY2ZWVlnH/++X6IWkREzhQlN9KknGofqPG9khjZJZbwQJuvfNOmTSxatAi3201ISAipqal+iFpERM4kJTfSZJxqHyin2+MrH98zEbwV/Oc//2HDhg0AtGzZkgkTJhAScvJsKBERaVyU3EiTcap9oE5YsP4gnSMNvl7yCTk5OZhMJoYOHcqgQYM01kZEpIlQciNNxs/3gaqK0+1hZ1YR+fn5hIaGMmHCBD2KEhFpYpTcSJNxYh+oqhheL6b/9sx4HGFMmjSJ+Ph4goOD6ys8ERGpJ+qHlyYjJqTqVYLLCo9y4NuFlOZlA8f3gWrTpo0SGxGRJkrJjTQZHeJDCbb9b6q3YRjkp6eRsepTXMX55KStISjArH2gRESaOCU30mREBtsY3ysJAE+5m8yNy8neshKvx0NwTBKJfS5kQp9k7QMlItLEacyNNBl2q4WRXWI5lpvNK7M+pLiwAJPJRHT7PiR16M7lvZO1D5SIyFlAyY00Ka6ifLLWLGZYyyBKiaDroBF0aN1S+0CJiJxFlNxIkxITE0PHDu3xer2MGzeOwMBAf4ckIiL1TMmNNHqHDx8mMjISh8OByWTisssuw2q1YjKZ/B2aiIj4gfropdEyDINVq1bx+uuv88knn3Big/uAgAAlNiIiZzH13EijVFpaysKFC9mxYwdwPNHxeDxYrfqRFhE52+mbQBqdjIwM5s2bR0FBARaLhZEjR9KnTx/11oiICKDkRhoRwzBYuXIly5Ytw+v1EhkZycSJE4mPj/d3aCIi0oAouZFGo6ysjNWrV+P1eunatSuXXHIJdrsW5BMRkcqU3EijERgYyOWXX05ubi69evXSYygREamSkhtpsAzD4JtvvqFZs2Z069YNgJSUFFJSUvwcmYiINGRKbqRBKi4uZsGCBezZs4eAgABSU1MJCwvzd1giItIIKLmRBmffvn18+OGHFBcXExAQwKhRowgN1U7eIiJSM0pupMHwer2sWLGCr7/+GsMwaN68ORMnTiQmJsbfoYmISCOi5EYaBK/XyzvvvMPevXsB6NWrFxdffDEBAQF+jkxERBqbBrH9wosvvkhqaioOh4N+/fqxZs2aauvOmjULk8lU6eVwOOoxWqkLZrOZhIQEbDYbl112GZdeeqkSGxEROS1+77l5//33mTZtGjNnzqRfv3688MILjBgxgh07dtC8efMq24SFhfmW3Qc0JbiR8nq9lJaWEhwcDMCwYcPo1asXkZGRfo5MREQaM7/33EyfPp2pU6dyww030KlTJ2bOnElQUBBvvPFGtW1MJhNxcXG+V2xsbD1GLGdCYWEhs2bN4t1338Xj8QBgsViU2IiIyK/m1+TG7Xazbt06hg8f7iszm80MHz6cVatWVduuuLiYlJQUkpOTGTt2LFu3bq22rsvlorCwsNJL/GvXrl3MnDmT9PR0cnNzOXLkiL9DEhGRJsSvyU1ubi4ej+eknpfY2FiysrKqbNO+fXveeOMNPvroI9555x28Xi8DBgzg4MGDVdZ/9tlnCQ8P972Sk5PP+HVIzXg8HpYuXcrs2bMpKSkhPj6eW265RXtDiYjIGeX3MTe11b9/f/r37+97P2DAADp27MjLL7/MU089dVL9Bx98kGnTpvneFxYWKsHxg/z8fObNm+dLQvv168eFF16I1drofgRFRKSB8+s3S3R0NBaLhezs7Erl2dnZxMXF1egcAQEB9OzZk927d1d53G63a3PFBuDjjz/m4MGDOBwOxo4dS8eOHf0dkoiINFF+fSxls9no3bs3y5Yt85V5vV6WLVtWqXfmVDweD5s3b9ajjQbukksuoVWrVtxyyy1KbEREpE75/ZnAtGnTmDJlCn369KFv37688MILOJ1ObrjhBgAmT55MYmIizz77LABPPvkk5557Lm3atCE/P5+//vWvHDhwgJtuusmflyE/c+zYMfbt20evXr0AiIyMZPLkyX6OSkREzgZ+T24mTZpETk4Ojz76KFlZWfTo0YMlS5b4Bhmnp6djNv+vg+nYsWNMnTqVrKwsIiIi6N27NytXrqRTp07+ugT5mW3btvHxxx/jcrlo1qwZrVq18ndIIiJyFjEZhmH4O4j6VFhYSHh4OAUFBdpl+gyrqKjg888/960wnZyczIQJE2jWrJl/AxMRkUavNt/ffu+5kaYhLy+PuXPnkpmZCcDAgQM5//zzsVgsfo5MRETONkpu5FfbunWr7zFUUFAQ48ePp23btv4OS0REzlJKbuRXc7vduFwuUlJSmDBhgh73iYiIXym5kdPi9Xp9A7179OiBzWajY8eOlQZ/i4iI+IO+iaTWNm3axL/+9S9KSkqA4xuZdu7cWYmNiIg0CPo2khpzu9189NFHLFiwgJycHL7//nt/hyQiInISPZaSGjly5Ahz584lJycHk8nEkCFDGDx4sL/DEhEROYmSGzklwzDYuHEjixcvpry8nJCQECZMmEDLli39HZqIiEiVlNzIKa1du5bFixcD0Lp1a8aPH09ISIifoxIREamekpuznKvCQ57TTVpmETnFLmJC7HSIDyUy2IbdaqFbt26sXr2anj17ct5552EymfwdsoiIyCkpuTmLFZS6WbIlmwXrD+J0e4Djj6EozOLai/pxcdc4wgMd/O53v8Nq1Y+KiIg0DvrGOku5Kjws2ZLNO6sP+Mo85W6yt3xHUeY+XiwoxGS6iPE9E7EpsRERkUZEU8HPUnlONwvWH/S9LyvIJX3lxxRl7sNkMmF4Kliw/iBHnS4/RikiIlJ7+pP8LJWWWYTT7cEwDPLTt5OzfQ2G10tAYDDxPYYSGBGL0+0hLbOI+PBAf4crIiJSY0puzlI5xS485S6yN39HUdZ+AEJiWxDXdRAWm91XL1c9NyIi0sgouTlLxYTYcRUdozj7ACazmZj259AstdNJs6Gig+3VnEFERKRhUnJzluoQH0pMXCLuTudiD48msFnMSXWCbRY6xIf6IToREZHTpwHFZ5HS0lI+/PBDcnNziQy2Mb5XEs1SOlaZ2ABc1juJKPXciIhII6Oem7NERkYG8+bNo6CggLy8PG666SZGdokFqLTODUCw3cKEXklc1DkWm1X5r4iINC5Kbpo4wzBYuXIly5Ytw+v1EhkZySWXXILJZCI80Mb4nokMbhdNWmYRuU4X0cHHVyiOCrYrsRERkUZJyU0TVlJSwoIFC9i1axcAXbp0YcyYMdjt/3vUZLOaiQ8P1HRvERFpMpTcNFF5eXnMmjWLwsJCrFYrF198Mb169dLeUCIi0uQpuWmiwsPDCQ8Px2azMXHiRGJjY/0dkoiISL1QctOEOJ1OHA4HFosFi8XCFVdcgd1ux2az+Ts0ERGReqMRo03Evn37+Ne//sWyZct8ZaGhoUpsRETkrKPkppHzer0sX76ct99+m+LiYnbv3k15ebm/wxIREfEbPZZqxIqKipg/fz779u0DoGfPnowaNYqAgAA/RyYiIuI/Sm4aqT179jB//nycTic2m43Ro0fTvXt3f4clIiLid0puGqGysjLmzp1LWVkZsbGxTJw4kejoaH+HJSIi0iAouWmEHA4Hl1xyCfv27WPkyJF6DCUiIvITSm4aiV27dmG1WmnZsiVwfLXhLl26+DkqERGRhkfJTQPn8Xj48ssv+e677wgJCeHWW28lJCTE32GJiIg0WEpuGrCCggLmzZtHRkYGAJ06dcLhcPg5KhERkYZNyU0DtWPHDhYuXEhpaSkOh4NLL72UTp06+TssERGRBk/JTQPj9XpZunQpq1atAiAxMZHLL7+ciIgIP0cmIiLSOCi5aWBMJhNOpxOAc889lwsvvBCLxeLnqERERBoPJTcNhNfrxWw2YzKZGD16NF27dqVt27b+DktERKTR0d5SflZRUcHixYt5//33MQwDALvdrsRGRETkNKnnxo/y8vKYO3cumZmZAKSnp5OSkuLnqERERBo3JTd+smXLFj755BNcLhdBQUGMGzdOiY2IiMgZoOSmnpWXl/PZZ5/xww8/ANCiRQsuv/xywsLC/ByZiIhI06Dkpp7NmzePHTt2YDKZOO+88xg2bBhms4Y+iYiInClKburZoEGDyMzMZOzYsbRu3drf4YiIiDQ5JuPEFJ2zRGFhIeHh4RQUFNTLo6Dy8nIOHTpEamqqr6yiogKrVXmliIhITdXm+1vPQ+pQTk4Or776Ku+88w7Z2dm+ciU2IiIidadBJDcvvvgiqampOBwO+vXrx5o1a2rUbs6cOZhMJsaNG1e3AdaSYRhs2LCBV155hSNHjuBwOHC5XP4OS0RE5Kzg9+Tm/fffZ9q0aTz22GOsX7+e7t27M2LECI4cOXLKdvv37+eee+5h0KBB9RRpzbjdbhYuXMhHH31EeXk5rVu35tZbb6VFixb+Dk1EROSs4PfkZvr06UydOpUbbriBTp06MXPmTIKCgnjjjTeqbePxeLjmmmt44oknaNWqVT1Ge2rZ2dm88sorbNq0CZPJxPnnn8+1115LSEiIv0MTERE5a/g1uXG73axbt47hw4f7ysxmM8OHD/ftil2VJ598kubNm/Ob3/zmFz/D5XJRWFhY6VVX0tLSyM3NJTQ0lOuvv57BgwdjMpnq7PNERETkZH4d2Zqbm4vH4yE2NrZSeWxsLGlpaVW2+fbbb3n99dfZuHFjjT7j2Wef5Yknnvi1odbIoEGD8Hg89OvXj+Dg4Hr5TBEREanM74+laqOoqIjrrruOV199lejo6Bq1efDBBykoKPC9MjIy6iw+s9nM+eefr8RGRETEj/zacxMdHY3FYqk0TRqOj12Ji4s7qf6ePXvYv38/Y8aM8ZV5vV7g+PTqHTt2nLQwnt1ux26310H0IiIi0hD5tefGZrPRu3dvli1b5ivzer0sW7aM/v37n1S/Q4cObN68mY0bN/pel156KcOGDWPjxo0kJyfXZ/giIiLSAPl9Nblp06YxZcoU+vTpQ9++fXnhhRdwOp3ccMMNAEyePJnExESeffZZHA4HXbp0qdS+WbNmACeVi4iIyNnJ78nNpEmTyMnJ4dFHHyUrK4sePXqwZMkS3yDj9PR0bSwpIiIiNaa9pURERKTB095SIiIictZSciMiIiJNipIbERERaVKU3IiIiEiTouRGREREmhQlNyIiItKkKLkRERGRJkXJjYiIiDQpSm5ERESkSfH79gv17cSCzIWFhX6ORERERGrqxPd2TTZWOOuSm6KiIgDtIC4iItIIFRUVER4efso6Z93eUl6vl8OHDxMaGorJZDqj5y4sLCQ5OZmMjAztW/ULdK9qTveq5nSvak73qnZ0v2quru6VYRgUFRWRkJDwixtqn3U9N2azmaSkpDr9jLCwMP3w15DuVc3pXtWc7lXN6V7Vju5XzdXFvfqlHpsTNKBYREREmhQlNyIiItKkKLk5g+x2O4899hh2u93foTR4ulc1p3tVc7pXNad7VTu6XzXXEO7VWTegWERERJo29dyIiIhIk6LkRkRERJoUJTciIiLSpCi5ERERkSZFyU0tvfjii6SmpuJwOOjXrx9r1qypUbs5c+ZgMpkYN25c3QbYgNTmXs2aNQuTyVTp5XA46jFa/6rtz1V+fj633XYb8fHx2O122rVrx+LFi+spWv+qzb0aOnToST9XJpOJ0aNH12PE/lPbn6sXXniB9u3bExgYSHJyMnfffTdlZWX1FK1/1eZelZeX8+STT9K6dWscDgfdu3dnyZIl9Rit/6xYsYIxY8aQkJCAyWRi4cKFv9hm+fLl9OrVC7vdTps2bZg1a1adx4khNTZnzhzDZrMZb7zxhrF161Zj6tSpRrNmzYzs7OxTttu3b5+RmJhoDBo0yBg7dmz9BOtntb1Xb775phEWFmZkZmb6XllZWfUctX/U9l65XC6jT58+xqhRo4xvv/3W2Ldvn7F8+XJj48aN9Rx5/avtvTp69Giln6ktW7YYFovFePPNN+s3cD+o7b2aPXu2YbfbjdmzZxv79u0zPvvsMyM+Pt64++676zny+lfbe3XfffcZCQkJxqJFi4w9e/YYL730kuFwOIz169fXc+T1b/HixcZDDz1kzJ8/3wCMBQsWnLL+3r17jaCgIGPatGnGtm3bjH/84x+GxWIxlixZUqdxKrmphb59+xq33Xab773H4zESEhKMZ599tto2FRUVxoABA4zXXnvNmDJlylmT3NT2Xr355ptGeHh4PUXXsNT2Xv3rX/8yWrVqZbjd7voKscE4nX+DP/X8888boaGhRnFxcV2F2GDU9l7ddtttxvnnn1+pbNq0acbAgQPrNM6GoLb3Kj4+3vjnP/9Zqeyyyy4zrrnmmjqNs6GpSXJz3333GZ07d65UNmnSJGPEiBF1GJlh6LFUDbndbtatW8fw4cN9ZWazmeHDh7Nq1apq2z355JM0b96c3/zmN/URZoNwuvequLiYlJQUkpOTGTt2LFu3bq2PcP3qdO7Vxx9/TP/+/bntttuIjY2lS5cuPPPMM3g8nvoK2y9O9+fqp15//XWuvPJKgoOD6yrMBuF07tWAAQNYt26d73HM3r17Wbx4MaNGjaqXmP3ldO6Vy+U66bF5YGAg3377bZ3G2hitWrWq0r0FGDFiRI3/zZ4uJTc1lJubi8fjITY2tlJ5bGwsWVlZVbb59ttvef3113n11VfrI8QG43TuVfv27XnjjTf46KOPeOedd/B6vQwYMICDBw/WR8h+czr3au/evcybNw+Px8PixYt55JFHeO6553j66afrI2S/OZ179VNr1qxhy5Yt3HTTTXUVYoNxOvfq6quv5sknn+S8884jICCA1q1bM3ToUP74xz/WR8h+czr3asSIEUyfPp1du3bh9XpZunQp8+fPJzMzsz5CblSysrKqvLeFhYWUlpbW2ecquakjRUVFXHfddbz66qtER0f7O5wGr3///kyePJkePXowZMgQ5s+fT0xMDC+//LK/Q2twvF4vzZs355VXXqF3795MmjSJhx56iJkzZ/o7tAbt9ddfp2vXrvTt29ffoTRIy5cv55lnnuGll15i/fr1zJ8/n0WLFvHUU0/5O7QGZ8aMGbRt25YOHTpgs9m4/fbbueGGGzCb9ZXaUFj9HUBjER0djcViITs7u1J5dnY2cXFxJ9Xfs2cP+/fvZ8yYMb4yr9cLgNVqZceOHbRu3bpug/aT2t6rqgQEBNCzZ092795dFyE2GKdzr+Lj4wkICMBisfjKOnbsSFZWFm63G5vNVqcx+8uv+blyOp3MmTOHJ598si5DbDBO51498sgjXHfddb6era5du+J0Orn55pt56KGHmuwX9+ncq5iYGBYuXEhZWRlHjx4lISGBBx54gFatWtVHyI1KXFxclfc2LCyMwMDAOvvcpvnTWgdsNhu9e/dm2bJlvjKv18uyZcvo37//SfU7dOjA5s2b2bhxo+916aWXMmzYMDZu3EhycnJ9hl+vanuvquLxeNi8eTPx8fF1FWaDcDr3auDAgezevduXLAPs3LmT+Pj4JpvYwK/7uZo7dy4ul4trr722rsNsEE7nXpWUlJyUwJxIoI0mvAXhr/m5cjgcJCYmUlFRwYcffsjYsWPrOtxGp3///pXuLcDSpUtr/F1w2up0uHITM2fOHMNutxuzZs0ytm3bZtx8881Gs2bNfFOWr7vuOuOBBx6otv3ZNFuqtvfqiSeeMD777DNjz549xrp164wrr7zScDgcxtatW/11CfWmtvcqPT3dCA0NNW6//XZjx44dxqeffmo0b97cePrpp/11CfXmdP8NnnfeecakSZPqO1y/qu29euyxx4zQ0FDjvffeM/bu3Wt8/vnnRuvWrY0rrrjCX5dQb2p7r1avXm18+OGHxp49e4wVK1YY559/vtGyZUvj2LFjfrqC+lNUVGRs2LDB2LBhgwEY06dPNzZs2GAcOHDAMAzDeOCBB4zrrrvOV//EVPB7773X2L59u/Hiiy9qKnhD9I9//MNo0aKFYbPZjL59+xqrV6/2HRsyZIgxZcqUatueTcmNYdTuXt11112+urGxscaoUaPOijUjTqjtz9XKlSuNfv36GXa73WjVqpXxf//3f0ZFRUU9R+0ftb1XaWlpBmB8/vnn9Ryp/9XmXpWXlxuPP/640bp1a8PhcBjJycnG7373u7PiC9swanevli9fbnTs2NGw2+1GVFSUcd111xmHDh3yQ9T176uvvjKAk14n7s+UKVOMIUOGnNSmR48ehs1mM1q1alUv60yZDKMJ9zeKiIjIWUdjbkRERKRJUXIjIiIiTYqSGxEREWlSlNyIiIhIk6LkRkRERJoUJTciIiLSpCi5ERERkSZFyY2I1KmhQ4dy1113VXu8pKSECRMmEBYWhslkIj8/n9TUVF544YV6i1FEmhYlNyLiV2+99RbffPMNK1euJDMzk/Dw8Dr5nKoSprKyMq6//nq6du2K1Wpl3LhxVbZ1uVw89NBDpKSkYLfbSU1N5Y033qiTOEXk19Ou4CLiV3v27KFjx4506dKl3j/b4/EQGBjI73//ez788MNq611xxRVkZ2fz+uuv06ZNGzIzMyttXCoiDYt6bkSkzlVUVHD77bcTHh5OdHQ0jzzyCIZhMHToUJ577jlWrFiByWRi6NChVbZPT09n7NixhISEEBYW5ks2TtizZw9jx44lNjaWkJAQzjnnHL744gvf8aFDh3LgwAHuvvtuTCYTJpMJgODgYP71r38xdepU4uLiqvzsJUuW8PXXX7N48WKGDx9Oamoq/fv3Z+DAgWfuBonIGaXkRkTq3FtvvYXVamXNmjXMmDGD6dOn89prrzF//nymTp1K//79yczMZP78+Se19Xq9jB07lry8PL7++muWLl3K3r17mTRpkq9OcXExo0aNYtmyZWzYsIGRI0cyZswY0tPTAZg/fz5JSUk8+eSTZGZmkpmZWePYP/74Y/r06cNf/vIXEhMTadeuHffccw+lpaW//saISJ3QYykRqXPJyck8//zzmEwm2rdvz+bNm3n++eeZOnUqQUFB2Gy2antOli1bxubNm9m3bx/JyckAvP3223Tu3Jm1a9dyzjnn0L17d7p37+5r89RTT7FgwQI+/vhjbr/9diIjI7FYLISGhlb7OdXZu3cv3377LQ6HgwULFpCbm8vvfvc7jh49yptvvnn6N0VE6ox6bkSkzp177rm+R0EA/fv3Z9euXXg8nl9su337dpKTk32JDUCnTp1o1qwZ27dvB4733Nxzzz107NiRZs2aERISwvbt2309N7+G1+vFZDIxe/Zs+vbty6hRo5g+fTpvvfWWem9EGij13IhIo3fPPfewdOlS/va3v9GmTRsCAwO5/PLLcbvdv/rc8fHxJCYmVprF1bFjRwzD4ODBg7Rt2/ZXf4aInFnquRGROvf9999Xer969Wratm2LxWL5xbYdO3YkIyODjIwMX9m2bdvIz8+nU6dOAHz33Xdcf/31jB8/nq5duxIXF8f+/fsrncdms9Wop+jnBg4cyOHDhykuLvaV7dy5E7PZTFJSUq3PJyJ1T8mNiNS59PR0pk2bxo4dO3jvvff4xz/+wZ133lmjtsOHD6dr165cc801rF+/njVr1jB58mSGDBlCnz59AGjbti3z589n48aNbNq0iauvvvqkqdqpqamsWLGCQ4cOkZub6yvftm0bGzduJC8vj4KCAjZu3MjGjRt9x6+++mqioqK44YYb2LZtGytWrODee+/lxhtvJDAw8NffHBE54/RYSkTq3OTJkyktLaVv375YLBbuvPNObr755hq1NZlMfPTRR9xxxx0MHjwYs9nMyJEj+cc//uGrM336dG688UYGDBhAdHQ0999/P4WFhZXO8+STT3LLLbfQunVrXC4XhmEAMGrUKA4cOOCr17NnTwDf8ZCQEJYuXcodd9xBnz59iIqK4oorruDpp5/+VfdEROqOyTjxL1hERESkCdBjKREREWlSlNyIiIhIk6LkRkRERJoUJTciIiLSpCi5ERERkSZFyY2IiIg0KUpuREREpElRciMiIiJNipIbERERaVKU3IiIiEiTouRGREREmhQlNyIiItKk/D/4+Hj5EQ1m5wAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sns.scatterplot(x=df[df['dtype'] == 'bfloat16']['AP@0.5'].values,\n",
+    "                y=df[df['dtype'] == 'float32']['AP@0.5'].values, \n",
+    "                alpha=0.8, s=60)\n",
+    "plt.plot([0.4, 1], [0.4, 1], 'k--', alpha=0.5)\n",
+    "\n",
+    "plt.xlabel('bfloat16')\n",
+    "plt.ylabel('float32')\n",
+    "plt.title('AP@0.5')\n",
+    "\n",
+    "mean_16 = df[df[\"dtype\"] == \"bfloat16\"][\"AP@0.5\"].mean()\n",
+    "sem_16 = df[df[\"dtype\"] == \"bfloat16\"][\"AP@0.5\"].sem()\n",
+    "mean_fp32 = df[df[\"dtype\"] == \"float32\"][\"AP@0.5\"].mean()\n",
+    "sem_fp32 = df[df[\"dtype\"] == \"float32\"][\"AP@0.5\"].sem()\n",
+    "\n",
+    "b16_text = f\"bfloat16: {mean_16:.2f} ± {sem_16:.2f}\"\n",
+    "fp32_text = f\"float32: {mean_fp32:.2f} ± {sem_fp32:.2f}\"\n",
+    "\n",
+    "#put text in the top left corner inside plot\n",
+    "plt.text(0.5, 0.9, fp32_text, )\n",
+    "plt.text(0.5, 0.85, b16_text, )\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a132963",
+   "metadata": {},
+   "source": [
+    "## Net runtimes: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "3b4876c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_32 = \"\"\"0.294391393661499\n",
+    "0.10566282272338867\n",
+    "0.10566210746765137\n",
+    "0.1054537296295166\n",
+    "0.1054391860961914\n",
+    "0.1054220199584961\n",
+    "0.10538077354431152\n",
+    "0.10544037818908691\n",
+    "0.1053924560546875\n",
+    "0.10545110702514648\n",
+    "0.10546135902404785\n",
+    "0.10551738739013672\n",
+    "0.14010334014892578\n",
+    "0.03056049346923828\n",
+    "0.13769793510437012\n",
+    "0.01892995834350586\n",
+    "0.13856029510498047\n",
+    "0.01896953582763672\n",
+    "0.0724632740020752\n",
+    "0.07106661796569824\n",
+    "0.07092642784118652\n",
+    "0.10555696487426758\n",
+    "0.10549330711364746\n",
+    "0.13778305053710938\n",
+    "0.018965721130371094\n",
+    "0.10743331909179688\n",
+    "0.10565423965454102\n",
+    "0.10552358627319336\n",
+    "0.13784480094909668\n",
+    "0.02016282081604004\n",
+    "0.13783907890319824\n",
+    "0.020309925079345703\n",
+    "0.07099795341491699\n",
+    "0.10557174682617188\n",
+    "0.10559439659118652\n",
+    "0.07105278968811035\n",
+    "0.10557770729064941\n",
+    "0.07100772857666016\n",
+    "0.07098531723022461\n",
+    "0.07098126411437988\n",
+    "0.10552239418029785\n",
+    "0.10556793212890625\n",
+    "0.13777732849121094\n",
+    "0.01897907257080078\n",
+    "0.07097315788269043\n",
+    "0.10598492622375488\n",
+    "0.07102131843566895\n",
+    "0.10643315315246582\n",
+    "0.10553717613220215\n",
+    "0.13783693313598633\n",
+    "0.07087469100952148\n",
+    "0.137861967086792\n",
+    "0.01903247833251953\n",
+    "0.07105255126953125\n",
+    "0.1378159523010254\n",
+    "0.01899552345275879\n",
+    "0.10564446449279785\n",
+    "0.07107090950012207\n",
+    "0.1055288314819336\n",
+    "0.10568070411682129\n",
+    "0.13799118995666504\n",
+    "0.019019603729248047\n",
+    "0.13792991638183594\n",
+    "0.019294261932373047\n",
+    "0.1056520938873291\n",
+    "0.07103753089904785\n",
+    "0.0709378719329834\n",
+    "0.10561275482177734\n",
+    "0.10563540458679199\n",
+    "0.1058347225189209\n",
+    "0.10560488700866699\n",
+    "0.10566568374633789\n",
+    "0.13782858848571777\n",
+    "0.01899266242980957\n",
+    "0.10626649856567383\n",
+    "0.10564661026000977\n",
+    "0.1378488540649414\n",
+    "0.01894855499267578\n",
+    "0.1056060791015625\n",
+    "0.10567069053649902\n",
+    "0.1056678295135498\n",
+    "0.10565543174743652\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "6f7cc415",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number of images: 82\n"
+     ]
+    }
+   ],
+   "source": [
+    "times_32_net = [float(i.strip()) for i in s_32.split('\\n') if not i.isspace() and i]\n",
+    "print(f'number of images: {len(times_32_net)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "2daf7881",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s_16 = \"\"\"0.11516189575195312\n",
+    "0.058031558990478516\n",
+    "0.05804800987243652\n",
+    "0.05808424949645996\n",
+    "0.05808281898498535\n",
+    "0.058046817779541016\n",
+    "0.05802583694458008\n",
+    "0.05847907066345215\n",
+    "0.05806088447570801\n",
+    "0.0584867000579834\n",
+    "0.05828237533569336\n",
+    "0.05893754959106445\n",
+    "0.07747244834899902\n",
+    "0.045305490493774414\n",
+    "0.07477998733520508\n",
+    "0.013552665710449219\n",
+    "0.07479357719421387\n",
+    "0.013551950454711914\n",
+    "0.043792009353637695\n",
+    "0.04104137420654297\n",
+    "0.041014909744262695\n",
+    "0.058069705963134766\n",
+    "0.0580294132232666\n",
+    "0.07482671737670898\n",
+    "0.013544797897338867\n",
+    "0.05800151824951172\n",
+    "0.05847024917602539\n",
+    "0.05807852745056152\n",
+    "0.07517027854919434\n",
+    "0.013546228408813477\n",
+    "0.07479357719421387\n",
+    "0.01348733901977539\n",
+    "0.041010379791259766\n",
+    "0.05801200866699219\n",
+    "0.058434486389160156\n",
+    "0.04100942611694336\n",
+    "0.058017730712890625\n",
+    "0.0410466194152832\n",
+    "0.04103398323059082\n",
+    "0.04092764854431152\n",
+    "0.05802440643310547\n",
+    "0.05807328224182129\n",
+    "0.07480764389038086\n",
+    "0.013559579849243164\n",
+    "0.04101085662841797\n",
+    "0.05935239791870117\n",
+    "0.04103398323059082\n",
+    "0.05810737609863281\n",
+    "0.05816531181335449\n",
+    "0.07482767105102539\n",
+    "0.04098010063171387\n",
+    "0.07501530647277832\n",
+    "0.01353764533996582\n",
+    "0.04108142852783203\n",
+    "0.07491874694824219\n",
+    "0.013569116592407227\n",
+    "0.058103084564208984\n",
+    "0.04150509834289551\n",
+    "0.05811190605163574\n",
+    "0.05801248550415039\n",
+    "0.07481527328491211\n",
+    "0.013541936874389648\n",
+    "0.07481718063354492\n",
+    "0.013478994369506836\n",
+    "0.058016300201416016\n",
+    "0.04112553596496582\n",
+    "0.04111933708190918\n",
+    "0.058096885681152344\n",
+    "0.05807924270629883\n",
+    "0.05885148048400879\n",
+    "0.05804085731506348\n",
+    "0.05811619758605957\n",
+    "0.07520294189453125\n",
+    "0.013704299926757812\n",
+    "0.0581209659576416\n",
+    "0.0581517219543457\n",
+    "0.07493185997009277\n",
+    "0.013637304306030273\n",
+    "0.058087825775146484\n",
+    "0.05855107307434082\n",
+    "0.05815911293029785\n",
+    "0.058122873306274414\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "b0b53281",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "number of images: 82\n"
+     ]
+    }
+   ],
+   "source": [
+    "times_16_net = [float(i.strip()) for i in s_16.split('\\n') if not i.isspace() and i]\n",
+    "print(f'number of images: {len(times_16_net)}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "7f3b9cfc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "b16 : 0.05199 ± 0.00220\n",
+      "fp32 : 0.09361 ± 0.00475\n"
+     ]
+    }
+   ],
+   "source": [
+    "times_16_net = np.array(times_16_net)\n",
+    "times_32_net = np.array(times_32_net)\n",
+    "print(f'b16 : {times_16_net.mean():.5f} ± {times_16_net.std() / (len(times_16_net))**.5:.5f}')\n",
+    "print(f'fp32 : {times_32_net.mean():.5f} ± {times_32_net.std() / (len(times_32_net))**.5:.5f}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5d6b139",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
CPSAM's transformer weights are unnecessarily too precise at 32bit, and 16 bit is sufficient for prediction. Switching to 16bit comes with multiple benefits, not the least of which is to free up RAM for loading more images for evaluation, reducing OOM issues. 

This PR: 

- Sets default to `bfloat16`, although this can be changed during `CellposeModel` object instantiation using the `use_bfloat16` flag. 
- Reduces model size from 1.2GB to 580MB
- Reduces runtime by ~20%
- Retains all segmentation accuracy

Testing:
- [X] Notebook verification for API
- [x] GUI tesing
- [x] CLI testing