### PR TITLE
Fix 3d reading cli

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -208,7 +208,7 @@ def _evaluate_cellposemodel_cli(args, logger, imf, device, pretrained_model, nor
     for image_name in tqdm(image_names, file=tqdm_out):
         if args.do_3D or args.stitch_threshold > 0.:
             logger.info('loading image as 3D zstack')
-            image = io.imread_3D(image_name)
+            image = io.imread(image_name) # Rely on transforms.convert_image() to move channels inside of .eval()
             if channel_axis is None:
                 channel_axis = 3
             if z_axis is None:

--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -208,7 +208,12 @@ def _evaluate_cellposemodel_cli(args, logger, imf, device, pretrained_model, nor
     for image_name in tqdm(image_names, file=tqdm_out):
         if args.do_3D or args.stitch_threshold > 0.:
             logger.info('loading image as 3D zstack')
-            image = io.imread(image_name) # Rely on transforms.convert_image() to move channels inside of .eval()
+
+            # guess at channels/z axis if one is not provided
+            if channel_axis or z_axis is None:
+                image = io.imread_3D(image_name)
+            else:
+                image = io.imread(image_name) # Rely on transforms.convert_image() to move channels inside of .eval()
             if channel_axis is None:
                 channel_axis = 3
             if z_axis is None:


### PR DESCRIPTION
CLI 3d image reading would correctly read the image in the first time in `__main__` but would pass the `channel_axis` and `z_axis` to the `.eval()` function and then the image would get reshaped again sometimes, depending on the channel_axis. Needed to change the image reading function in `__main__` to just read the raw image and let the conversion function in `.eval` do its thing. 

All tests passing on ubuntu. 