### PR TITLE
fix: remove black stripe artefacts when axis != -1 in

### DIFF
--- a/cellpose/transforms.py
+++ b/cellpose/transforms.py
@@ -765,10 +765,6 @@ def normalize_img(img, normalize=True, norm3D=True, invert=False, lowhigh=None,
             transforms_logger.critical(error_message)
             raise ValueError(error_message)
 
-    # Move channel axis back to the original position
-    if axis != -1 and axis != img_norm.ndim - 1:
-        img_norm = np.moveaxis(img_norm, -1, axis)
-
     # The transformer can get confused if a channel is all 1's instead of all 0's:
     for i, chan_did_normalize in enumerate(cgood):
         if not chan_did_normalize:
@@ -776,6 +772,10 @@ def normalize_img(img, normalize=True, norm3D=True, invert=False, lowhigh=None,
                 img_norm[:, :, i] = 0
             if img_norm.ndim == 4:
                 img_norm[:, :, :, i] = 0
+
+    # Move channel axis back to the original position
+    if axis != -1 and axis != img_norm.ndim - 1:
+        img_norm = np.moveaxis(img_norm, -1, axis)
 
     return img_norm
 


### PR DESCRIPTION
The clean-up loop that sets un-normalised channels to 0 expected the channel dimension to be last.  However, since `np.moveaxis(..., -1, axis)` was done prior to this, instead of setting the channel to zero, it would set a row/column (depending on the axis) to zero instead, resulting in a black bar across the image. 