### PR TITLE
more verbose tox/pytest tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,5 +36,4 @@ deps =
 # ignoring contrib tests for now
 commands = 
     #linux: apt-get update && apt-get install libgl1
-    pytest -v --color=yes --cov=cellpose --cov-report=xml --ignore=tests/contrib
-    
+    pytest -vv -rA --color=yes --cov=cellpose --cov-report=xml --ignore=tests/contrib --durations=0


### PR DESCRIPTION
print runtimes for each test to help GH worker debugging 