### PR TITLE
Proof-of-concept: Cellpose distributed on Slurm cluster with AMD GPUs

### DIFF
--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -214,6 +214,112 @@ class myLocalCluster(distributed.LocalCluster):
         self.client.close()
         super().__exit__(exc_type, exc_value, traceback)
 
+class SlurmCluster(dask_jobqueue.SLURMCluster):
+    """
+    This is a thin wrapper extending dask_jobqueue.SLURMCluster,
+    which in turn extends dask.distributed.SpecCluster. This wrapper
+    sets configs before the cluster or workers are initialized. This is
+    an adaptive cluster and will scale the number of workers, between user
+    specified limits, based on the number of pending tasks.
+
+    For a full list of arguments see
+    https://jobqueue.dask.org/en/latest/generated/dask_jobqueue.SLURMCluster.html
+
+    Most users will only need to specify:
+    ncpus (the number of cpu cores per worker)
+    min_workers
+    max_workers
+    """
+
+    def __init__(
+        self,
+        ncpus,
+        min_workers,
+        max_workers,
+        config={},
+        config_name=DEFAULT_CONFIG_FILENAME,
+        persist_config=False,
+        scratch_dir = f"/scratch/{getpass.getuser()}/",
+        **kwargs
+    ):
+
+        # store all args in case needed later
+        self.locals_store = {**locals()}
+
+        # config
+        self.config_name = config_name
+        self.persist_config = persist_config
+        config_defaults = {
+            'temporary-directory':scratch_dir,
+            'distributed.comm.timeouts.connect':'180s',
+            'distributed.comm.timeouts.tcp':'360s',
+        }
+        config = {**config_defaults, **config}
+        _modify_dask_config(config, config_name)
+
+        # threading is best in low level libraries
+        job_script_prologue = [
+            f"export MKL_NUM_THREADS={2*ncpus}",
+            f"export NUM_MKL_THREADS={2*ncpus}",
+            f"export OPENBLAS_NUM_THREADS={2*ncpus}",
+            f"export OPENMP_NUM_THREADS={2*ncpus}",
+            f"export OMP_NUM_THREADS={2*ncpus}",
+        ]
+
+        # set scratch and log directories
+        if "local_directory" not in kwargs:
+            kwargs["local_directory"] = scratch_dir
+        if "log_directory" not in kwargs:
+            log_dir = f"{os.getcwd()}/dask_worker_logs_{os.getpid()}/"
+            pathlib.Path(log_dir).mkdir(parents=False, exist_ok=True)
+            kwargs["log_directory"] = log_dir
+
+        # construct
+        super().__init__(
+            processes=1,
+            cores=ncpus,
+            memory=str(15*ncpus)+'GB',
+            job_script_prologue=job_script_prologue,
+            **kwargs,
+        )
+        self.client = distributed.Client(self)
+        print("Cluster dashboard link: ", self.dashboard_link)
+
+        # set adaptive cluster bounds
+        self.adapt_cluster(min_workers, max_workers)
+
+
+    def __enter__(self): return self
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.persist_config:
+            _remove_config_file(self.config_name)
+        self.client.close()
+        super().__exit__(exc_type, exc_value, traceback)
+
+
+    def adapt_cluster(self, min_workers, max_workers):
+        _ = self.adapt(
+            minimum_jobs=min_workers,
+            maximum_jobs=max_workers,
+            interval='10s',
+            wait_count=6,
+        )
+
+
+    def change_worker_attributes(
+        self,
+        min_workers,
+        max_workers,
+        **kwargs,
+    ):
+        """WARNING: this function is dangerous if you don't know what
+           you're doing. Don't call this unless you know exactly what
+           this does."""
+        self.scale(0)
+        for k, v in kwargs.items():
+            self.new_spec['options'][k] = v
+        self.adapt_cluster(min_workers, max_workers)
+
 
 class janeliaLSFCluster(dask_jobqueue.LSFCluster):
     """
@@ -349,9 +455,6 @@ def cluster(func):
         "Either cluster or cluster_kwargs must be defined"
         if not 'cluster' in kwargs:
             cluster_constructor = myLocalCluster
-            F = lambda x: x in kwargs['cluster_kwargs']
-            if F('ncpus') and F('min_workers') and F('max_workers'):
-                cluster_constructor = janeliaLSFCluster
             with cluster_constructor(**kwargs['cluster_kwargs']) as cluster:
                 kwargs['cluster'] = cluster
                 return func(*args, **kwargs)
@@ -757,6 +860,7 @@ def distributed_eval(
             worker_logs_directory=str(worker_logs_dir),
         )
         results = cluster.client.gather(futures)
+        print('Scale cluster down')
         if isinstance(cluster, dask_jobqueue.core.JobQueueCluster): 
             cluster.scale(0)
 
@@ -768,27 +872,33 @@ def distributed_eval(
         new_labeling_path = temporary_directory + '/new_labeling.npy'
         np.save(new_labeling_path, new_labeling)
 
+        print('Change worker attributes')
         # stitching step is cheap, we should release gpus and use small workers
         if isinstance(cluster, dask_jobqueue.core.JobQueueCluster): 
             cluster.change_worker_attributes(
                 min_workers=cluster.locals_store['min_workers'],
                 max_workers=cluster.locals_store['max_workers'],
-                ncpus=1,
+                cores=1,
                 memory="15GB",
-                mem=int(15e9),
+                #mem=int(15e9),
                 queue=None,
                 job_extra_directives=[],
             )
     
+        print('Use dask array to relabel segmentations')
         segmentation_da = dask.array.from_zarr(temp_zarr)
+        print('Map dask to blocks')
         relabeled = dask.array.map_blocks(
             lambda block: np.load(new_labeling_path)[block],
             segmentation_da,
             dtype=np.uint32,
             chunks=segmentation_da.chunks,
         )
+        print("Write output")
         dask.array.to_zarr(relabeled, write_path, overwrite=True)
+        print("Merge bboxes")
         merged_boxes = merge_all_boxes(boxes, new_labeling[box_ids])
+        print("Merge done")
         return zarr.open(write_path, mode='r'), merged_boxes
 
 

--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -529,20 +529,27 @@ def remove_overlaps(array, crop, overlap, blocksize):
     """overlaps only there to provide context for boundary voxels
        and can be removed after segmentation is complete
        reslice array to remove the overlaps"""
-    crop_trimmed = list(crop)
+    
+    crop = list(s for s in crop if not isinstance(s, int))
+    assert len(crop) == array.ndim
+    crop_trimmed = crop
+
     for axis in range(array.ndim):
+
         if crop[axis].start != 0:
             slc = [slice(None),]*array.ndim
             slc[axis] = slice(overlap, None)
-            array = array[tuple(slc)]
+            array = array[tuple(slc)] # Why trimming array axis by axis?
             a, b = crop[axis].start, crop[axis].stop
             crop_trimmed[axis] = slice(a + overlap, b)
+
         if array.shape[axis] > blocksize[axis]:
             slc = [slice(None),]*array.ndim
             slc[axis] = slice(None, blocksize[axis])
             array = array[tuple(slc)]
             a = crop_trimmed[axis].start
             crop_trimmed[axis] = slice(a, a + blocksize[axis])
+
     return array, crop_trimmed
 
 
@@ -559,6 +566,7 @@ def bounding_boxes_in_global_coordinates(segmentation, crop):
 
 def get_nblocks(shape, blocksize):
     """Given a shape and blocksize determine the number of blocks per axis"""
+    shape = shape[len(shape) - len(blocksize):]
     return np.ceil(np.array(shape) / blocksize).astype(int)
 
 
@@ -802,14 +810,14 @@ def get_block_crops(shape, blocksize, overlap, mask):
         stop = start + blocksize + 2 * overlap
         start = np.maximum(0, start)
         stop = np.minimum(shape, stop)
-        crop = tuple(slice(x, y) for x, y in zip(start, stop))
+        crop = tuple(0 for _ in range(len(shape) - len(blocksize))) + tuple(slice(x, y) for x, y in zip(start, stop))
 
         foreground = True
         if mask is not None:
             start = mask_blocksize * index
             stop = start + mask_blocksize
             stop = np.minimum(mask.shape, stop)
-            mask_crop = tuple(slice(x, y) for x, y in zip(start, stop))
+            mask_crop = tuple(0 for _ in range(len(shape) - len(blocksize))) + tuple(slice(x, y) for x, y in zip(start, stop))
             if not np.any(mask[mask_crop]): foreground = False
         if foreground:
             indices.append(index)

--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -240,6 +240,7 @@ class SlurmCluster(dask_jobqueue.SLURMCluster):
         config_name=DEFAULT_CONFIG_FILENAME,
         persist_config=False,
         scratch_dir = f"/scratch/{getpass.getuser()}/",
+        job_script_prologue = [],
         **kwargs
     ):
 
@@ -264,7 +265,7 @@ class SlurmCluster(dask_jobqueue.SLURMCluster):
             f"export OPENBLAS_NUM_THREADS={2*ncpus}",
             f"export OPENMP_NUM_THREADS={2*ncpus}",
             f"export OMP_NUM_THREADS={2*ncpus}",
-        ]
+        ] + job_script_prologue
 
         # set scratch and log directories
         if "local_directory" not in kwargs:

--- a/cellpose/contrib/test_slurm.py
+++ b/cellpose/contrib/test_slurm.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+import imageio
+import zarr
+import numpy
+from tifffile import imwrite
+from cellpose.contrib.distributed_segmentation import numpy_array_to_zarr
+
+input_tif_path = Path('volumedata.tif')
+input_zarr_path = Path('volumedata.zarr')
+output_tif_path = Path('output.tif')
+
+scratch_dir = Path.home() / 'link_scratch'
+output_zarr_path = scratch_dir / 'output.zarr'
+
+
+if not input_zarr_path.exists():
+    print('Test zarr data not found')
+    if not input_tif_path.is_file():
+        print('Download test data')
+        # Just get image data from somewhere. Note that cellpose is probably the best choice for segmenting it
+        data_numpy = imageio.imread('https://documents.epfl.ch/groups/c/cv/cvlab-unit/www/data/%20ElectronMicroscopy_Hippocampus/volumedata.tif')
+        imageio.imwrite(input_tif_path, data_numpy)
+    else:
+        print('Load test data from disk')
+        data_numpy = imageio.imread(input_tif_path)
+
+    print('Convert data to zarr')
+    data_zarr = numpy_array_to_zarr(input_zarr_path, data_numpy, chunks=(256, 256, 256))
+    del data_numpy
+else:
+    data_zarr = zarr.open(input_zarr_path)
+
+
+# Test a single block first
+from cellpose.contrib.distributed_segmentation import process_block
+
+# parameterize cellpose however you like
+model_kwargs = {'gpu':True}
+eval_kwargs = {
+    'z_axis':0,
+    'do_3D':True,
+}
+
+if small_test := False:
+    # define a crop as the distributed function would
+    starts = (128, 128, 128)
+    blocksize = (256, 256, 256)
+    overlap = 60
+    crop = tuple(slice(s-overlap, s+b+overlap) for s, b in zip(starts, blocksize))
+
+    # call the segmentation
+    segments, boxes, box_ids = process_block(
+        block_index=(0, 0, 0),  # when test_mode=True this is just a dummy value
+        crop=crop,
+        input_zarr=data_zarr,
+        model_kwargs=model_kwargs,
+        eval_kwargs=eval_kwargs,
+        blocksize=blocksize,
+        overlap=overlap,
+        output_zarr=None,
+        test_mode=True,
+    )
+
+    imwrite(output_tif_path, segments, compression ='zlib')
+
+else:
+    from cellpose.contrib.distributed_segmentation import distributed_eval, SlurmCluster
+
+    # define cluster parameters
+    cluster_kwargs = {
+        'ncpus':2,                # cpus per worker
+        'min_workers':1,          # cluster adapts number of workers based on number of blocks
+        'max_workers':16,
+        'queue': 'apu',
+        'interface': 'ib0',
+        'scratch_dir': str(scratch_dir),
+        'walltime': '1:00:00', # TODO: find realistic wall time
+        'job_extra_directives':['--constraint apu', '--gres gpu:1'],
+        'worker_extra_args': ["--lifetime", "55m", "--lifetime-stagger", "4m"],
+        'job_script_prologue' : [
+            "module load condainer",
+            f"cd {str(Path.home())}/src/cellpose/env",
+            "source activate",
+            f"cd {str(Path.home())}/src/cellpose",
+        ],
+    }
+
+    slurm_cluster = SlurmCluster(
+        **cluster_kwargs
+    )
+
+    # run segmentation
+    # outputs:
+    #     segments: zarr array containing labels
+    #     boxes: list of bounding boxes around all labels (very useful for navigating big data)
+    segments, boxes = distributed_eval(
+        input_zarr=data_zarr,
+        blocksize=(256, 256, 256),
+        write_path=str(output_zarr_path),
+        model_kwargs=model_kwargs,
+        eval_kwargs=eval_kwargs,
+        cluster = slurm_cluster,
+    )
+

--- a/environment-rocm.yml
+++ b/environment-rocm.yml
@@ -1,0 +1,31 @@
+name: cellpose
+dependencies:
+  - python==3.9.23
+  - pip
+  - pip:
+    - --index-url https://download.pytorch.org/whl/rocm6.4
+    - --extra-index-url https://pypi.org/simple
+    - qtpy
+#    - PyQt5.sip
+    - numpy>=1.20.0
+    - scipy
+    - torch>=1.6
+    - opencv-python-headless
+    - pyqtgraph>=0.11.0rc0
+    - natsort
+    - google-cloud-storage
+    - tqdm
+    - tifffile
+    - fastremap
+    - cellpose
+    - roifile
+    - pyqt5
+    - dask
+    - distributed
+    - dask-image
+    - pyyaml
+    - zarr
+    - dask_jobqueue
+    - bokeh
+    - fill-voids
+  


### PR DESCRIPTION
Hi,

for a project of mine I needed to scale cellpose on a SLURM cluster. To make the topic a little more interesting, the cluster I have at hand only has AMD GPUs. The documentation on [distributed cellpose](https://cellpose.readthedocs.io/en/latest/distributed.html) gave hints on how to run on LSF clusters. I also want to mention that there is already some [documentation](https://cellpose.readthedocs.io/en/latest/installation.html#amd-gpu-rocm-installation) on how to run cellpose on AMD GPUs.

The first contribution of this PR is a working conda environment (`environment-rocm.yaml`) file which works for inference on AMD GPUs. I am happy to update the install documentation accordingly. 

The second contribution is a medium-sized test case for a slurm cluster (`cellpose/contrib/test_slurm.py`). The example data is not special by any means, if someone has a hint on a nice (~1024 x 1024 x 1024 px ) dataset which is worth highlighting in the cellpose distributed documentation I am open for suggestions. My hope is that the test can be serve as reference for checking cellposes distributed on different clusters before users try to run cellpose with their own data.

Lastly, I modified `cellpose/contrib/distributed_segmentation.py` so that it now works for my circumstances. Note that there two things left to be done:

1. the code still needs some clean-up after my initial tests with cropping/ transposing
2. the PR will in its current form break the functionality of the `janeliaLSFCluster` class due to missing abstraction in `distributed_eval` with respect to the `mem`, `cores`, and `ncpus` .

I am happy to polish the code and documentation the next days. Since I am not really a dask expert I am very curious about feedback about my dask usage.

Best wishes,
Eric

fixes #1111 