### PR TITLE
Fix: `io.omread_3D` used when `channel_axis` > 0

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -210,7 +210,7 @@ def _evaluate_cellposemodel_cli(args, logger, imf, device, pretrained_model, nor
             logger.info('loading image as 3D zstack')
 
             # guess at channels/z axis if one is not provided
-            if channel_axis or z_axis is None:
+            if channel_axis is None or z_axis is None:
                 image = io.imread_3D(image_name)
             else:
                 image = io.imread(image_name) # Rely on transforms.convert_image() to move channels inside of .eval()


### PR DESCRIPTION
In CLI mode, when using 4D images, the image is always opened with `io.imread_3D` when `channel_axis` has a truthy value. The result is an unwanted swap between the last axis and the channel axis.

With a ZCYX axis order, the CLI command will be run with `--do_3D`, `--channel_axis 1` and `--z_axis 0`.
Because `channel_axis` is truthy, the image will be opened with `io.imread_3D` causing a swap of the last axis and the channel axis. As a result, the opened image is changed to a ZXYC order, but the `channel_axis` variable is not updated. The later call to `.eval()` is therefore using the wrong channel axis (`1`, pointing to `X`), causing error in segmentation.