### PR TITLE
Update return tuple in 'eval' function documentation

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -202,7 +202,7 @@ class CellposeModel():
             progress (QProgressBar, optional): pyqt progress bar. Defaults to None.
 
         Returns:
-            A tuple containing (masks, flows, styles, diams): 
+            A tuple containing (masks, flows, styles): 
             masks (list of 2D arrays or single 3D array): Labelled image, where 0=no masks; 1,2,...=mask labels;
             flows (list of lists 2D arrays or list of 3D arrays): 
                 flows[k][0] = XY flow in HSV 0-255; 


### PR DESCRIPTION
Parameter `diams` is not any more returned by function `eval`.

Removed `diams` from the return tuple in the function documentation.
