### PR TITLE
fix: autoload _cp_masks and escape glob metacharacters in paths

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -124,11 +124,18 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
                       load_3D=load_3D)
             return
         elif parent.autoloadMasks.isChecked():
-            mask_file = os.path.splitext(filename)[0] + "_masks" + os.path.splitext(
-                filename)[-1]
-            mask_file = os.path.splitext(filename)[
-                0] + "_masks.tif" if not os.path.isfile(mask_file) else mask_file
-            load_mask = True if os.path.isfile(mask_file) else False
+            base = os.path.splitext(filename)[0]
+            ext = os.path.splitext(filename)[-1]
+            candidates = list(dict.fromkeys([
+                base + "_cp_masks.png",
+                base + "_cp_masks.tif",
+                base + "_cp_masks" + ext,
+                base + "_masks" + ext,
+                base + "_masks.tif",
+                base + "_masks.png",
+            ]))
+            mask_file = next((f for f in candidates if os.path.isfile(f)), None)
+            load_mask = mask_file is not None
     try:
         print(f"GUI_INFO: loading image: {filename}")
         if not load_3D:

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -410,17 +410,18 @@ def get_image_files(folder, mask_filter, imf=None, look_one_level_down=False):
 
     folders = []
     if look_one_level_down:
-        folders = natsorted(glob.glob(os.path.join(folder, "*/")))
+        folders = natsorted(glob.glob(os.path.join(glob.escape(folder), "*/")))
     folders.append(folder)
     exts = [".png", ".jpg", ".jpeg", ".tif", ".tiff", ".flex", ".dax", ".nd2", ".nrrd"]
     l0 = 0
     al = 0
     for folder in folders:
-        all_files = glob.glob(folder + "/*")
+        escaped = glob.escape(folder)
+        all_files = glob.glob(escaped + "/*")
         al += len(all_files)
         for ext in exts:
-            image_names.extend(glob.glob(folder + f"/*{imf}{ext}"))
-            image_names.extend(glob.glob(folder + f"/*{imf}{ext.upper()}"))
+            image_names.extend(glob.glob(escaped + f"/*{imf}{ext}"))
+            image_names.extend(glob.glob(escaped + f"/*{imf}{ext.upper()}"))
         l0 += len(image_names)
 
     # return error if no files found


### PR DESCRIPTION
## Summary
- **Mask auto-load fix:** The GUI's `autoloadMasks` checkbox only searched for `_masks.{ext}` and `_masks.tif`, but cellpose itself saves masks as `_cp_masks.png` / `_cp_masks.tif`. Added `_cp_masks` patterns to the search candidates so saved masks are found on reload.
- **Glob escape fix:** `get_image_files()` passes folder paths directly to `glob.glob()`, which interprets `[`, `]`, `?`, and `*` as pattern metacharacters. Directories containing these characters (e.g. `data[condition1]`) silently return zero matches, raising `ValueError: ERROR: no files in --dir folder`. Now uses `glob.escape()` on the folder portion before appending wildcards.

## Test plan
- [ ] Open GUI, load a `.tif` image that has a corresponding `_cp_masks.png` → mask auto-loads
- [ ] Open GUI, load image from a directory with `[brackets]` in the path → A/D navigation works
- [ ] Verify `_masks.tif` and `_masks.png` patterns still auto-load (backward compat)