### PR TITLE
Gray saturation fix: drop blank channels from mean

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1374,6 +1374,10 @@ class MainW(QMainWindow):
                     self.img.setLevels(self.saturation[0][self.currentZ])
             elif self.color == 4:
                 if self.nchan > 1:
+                    # exclude channels with no data:
+                    ranges = np.ptp(image, tuple(range(image.ndim-1)))
+                    range_mask = ranges > 1e-5
+                    image = image[..., range_mask]
                     image = image.mean(axis=-1)
                 self.img.setImage(image, autoLevels=False, lut=None)
                 self.img.setLevels(self.saturation[0][self.currentZ])

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -486,6 +486,10 @@ class MainW_3d(MainW):
                                 self.saturation[0][self.currentZ])
                     elif self.color == 4:
                         if image.ndim > 2:
+                            # exclude blank channels: 
+                            ranges = np.ptp(image, tuple(range(image.ndim-1)))
+                            range_mask = ranges > 1e-5
+                            image = image[..., range_mask]
                             image = image.astype("float32").mean(axis=2).astype("uint8")
                         self.imgOrtho[j].setImage(image, autoLevels=False, lut=None)
                         self.imgOrtho[j].setLevels(self.saturation[0][self.currentZ])


### PR DESCRIPTION
Grayscale image is calculated across blank image channels in GUI, causing saturation to display incorrectly. See #1422 

The fix was to drop the blank channels from the mean calculation. 

Tested with 2D/3D single and 2-channel images. Appears to be working well. 

Before (incorrect):
<img width="1177" height="920" alt="CP4_incorrect" src="https://github.com/user-attachments/assets/b82591eb-6225-4482-a16c-aaf896b9cee6" />

After (with fix): 
<img width="1177" height="920" alt="CP4_correct" src="https://github.com/user-attachments/assets/23024c85-c0b5-4b77-b0be-7aa72171f736" />

 

Resolves #1422