### PR TITLE
Claude/cellpose mlx support

### DIFF
--- a/cellpose/__main__.py
+++ b/cellpose/__main__.py
@@ -198,7 +198,9 @@ def _evaluate_cellposemodel_cli(args, logger, imf, device, pretrained_model, nor
             ">>>> running cellpose on %d images using all channels" % nimg)
 
     # handle built-in model exceptions
-    model = models.CellposeModel(device=device, pretrained_model=pretrained_model,)
+    use_mlx = getattr(args, 'use_mlx', False)
+    model = models.CellposeModel(device=device, pretrained_model=pretrained_model,
+                                  use_mlx=use_mlx)
 
     tqdm_out = utils.TqdmToLogger(logger, level=logging.INFO)
 

--- a/cellpose/cli.py
+++ b/cellpose/cli.py
@@ -30,6 +30,9 @@ def get_arg_parser():
     hardware_args.add_argument(
         "--gpu_device", required=False, default="0", type=str,
         help="which gpu device to use, use an integer for torch, or mps for M1")
+    hardware_args.add_argument(
+        "--use_mlx", action="store_true",
+        help="use MLX backend for Apple Silicon acceleration (requires macOS + Apple Silicon + mlx package)")
     
     # settings for locating and formatting images
     input_img_args = parser.add_argument_group("Input Image Arguments")

--- a/cellpose/cli.py
+++ b/cellpose/cli.py
@@ -31,8 +31,10 @@ def get_arg_parser():
         "--gpu_device", required=False, default="0", type=str,
         help="which gpu device to use, use an integer for torch, or mps for M1")
     hardware_args.add_argument(
-        "--use_mlx", action="store_true",
-        help="use MLX backend for Apple Silicon acceleration (requires macOS + Apple Silicon + mlx package)")
+        "--use_mlx", nargs="?", const=True, default=False,
+        help="use MLX backend for Apple Silicon acceleration. "
+             "Pass without value to enable, or pass 'auto' to auto-detect "
+             "(requires macOS + Apple Silicon + mlx package)")
     
     # settings for locating and formatting images
     input_img_args = parser.add_argument_group("Input Image Arguments")

--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -10,12 +10,18 @@ import torch
 
 TORCH_ENABLED = True
 
+try:
+    import mlx.core as mx
+    MLX_AVAILABLE = True
+except ImportError:
+    MLX_AVAILABLE = False
+
 core_logger = logging.getLogger(__name__)
 tqdm_out = utils.TqdmToLogger(core_logger, level=logging.INFO)
 
 
 def use_gpu(gpu_number=0, use_torch=True):
-    """ 
+    """
     Check if GPU is available for use.
 
     Args:
@@ -32,6 +38,23 @@ def use_gpu(gpu_number=0, use_torch=True):
         return _use_gpu_torch(gpu_number)
     else:
         raise ValueError("cellpose only runs with PyTorch now")
+
+
+def use_mlx():
+    """Check if MLX is available and running on Apple Silicon.
+
+    Returns:
+        bool: True if MLX is available.
+    """
+    if not MLX_AVAILABLE:
+        return False
+    try:
+        _ = mx.zeros((1, 1))
+        mx.eval(_)
+        core_logger.info("** MLX available on Apple Silicon. **")
+        return True
+    except Exception:
+        return False
 
 
 def _use_gpu_torch(gpu_number=0):
@@ -109,6 +132,22 @@ def assign_device(use_torch=True, gpu=False, device=0):
     return device, gpu
 
 
+def _forward_mlx(net, x):
+    """Converts images to MLX arrays, runs the network model, and returns numpy arrays.
+
+    Args:
+        net: The MLX TransformerMLX model.
+        x (numpy.ndarray): The input images of shape (N, C, H, W).
+
+    Returns:
+        Tuple[numpy.ndarray, numpy.ndarray]: The output predictions and style features.
+    """
+    X = mx.array(x)
+    y, style = net(X)
+    mx.eval(y, style)
+    return np.array(y, copy=False), np.array(style, copy=False)
+
+
 def _to_device(x, device, dtype=torch.float32):
     """
     Converts the input tensor or numpy array to the specified device.
@@ -163,10 +202,10 @@ def _forward(net, x):
 
 
 def run_net(net, imgi, batch_size=8, augment=False, tile_overlap=0.1, bsize=224,
-            rsz=None):
-    """ 
+            rsz=None, use_mlx_backend=False):
+    """
     Run network on stack of images.
-    
+
     (faster if augment is False)
 
     Args:
@@ -177,39 +216,42 @@ def run_net(net, imgi, batch_size=8, augment=False, tile_overlap=0.1, bsize=224,
         augment (bool, optional): Tiles image with overlapping tiles and flips overlapped regions to augment. Defaults to False.
         tile_overlap (float, optional): Fraction of overlap of tiles when computing flows. Defaults to 0.1.
         bsize (int, optional): Size of tiles to use in pixels [bsize x bsize]. Defaults to 224.
+        use_mlx_backend (bool, optional): Use MLX backend for inference. Defaults to False.
 
     Returns:
         Tuple[numpy.ndarray, numpy.ndarray]: outputs of network y and style. If tiled `y` is averaged in tile overlaps. Size of [Ly x Lx x 3] or [Lz x Ly x Lx x 3].
-            y[...,0] is Y flow; y[...,1] is X flow; y[...,2] is cell probability. 
+            y[...,0] is Y flow; y[...,1] is X flow; y[...,2] is cell probability.
             style is a 1D array of size 256 summarizing the style of the image, if tiled `style` is averaged over tiles.
     """
+    forward_fn = _forward_mlx if use_mlx_backend else _forward
+
     # run network
-    Lz, Ly0, Lx0, nchan = imgi.shape 
+    Lz, Ly0, Lx0, nchan = imgi.shape
     if rsz is not None:
         if not isinstance(rsz, list) and not isinstance(rsz, np.ndarray):
             rsz = [rsz, rsz]
         Lyr, Lxr = int(Ly0 * rsz[0]), int(Lx0 * rsz[1])
     else:
         Lyr, Lxr = Ly0, Lx0
-    
+
     ly, lx = bsize, bsize
     ypad1, ypad2, xpad1, xpad2 = transforms.get_pad_yx(Lyr, Lxr, min_size=(bsize, bsize))
     Ly, Lx = Lyr + ypad1 + ypad2, Lxr + xpad1 + xpad2
     pads = np.array([[0, 0], [ypad1, ypad2], [xpad1, xpad2]])
-    
+
     if augment:
         ny = max(2, int(np.ceil(2. * Ly / bsize)))
         nx = max(2, int(np.ceil(2. * Lx / bsize)))
     else:
         ny = 1 if Ly <= bsize else int(np.ceil((1. + 2 * tile_overlap) * Ly / bsize))
         nx = 1 if Lx <= bsize else int(np.ceil((1. + 2 * tile_overlap) * Lx / bsize))
-    
-    
+
+
     # run multiple slices at the same time
     ntiles = ny * nx
     nimgs = max(1, batch_size // ntiles) # number of imgs to run in the same batch
     niter = int(np.ceil(Lz / nimgs))
-    ziterator = (trange(niter, file=tqdm_out, mininterval=30) 
+    ziterator = (trange(niter, file=tqdm_out, mininterval=30)
                     if niter > 10 or Lz > 1 else range(niter))
     for k in ziterator:
         inds = np.arange(k * nimgs, min(Lz, (k + 1) * nimgs))
@@ -221,13 +263,13 @@ def run_net(net, imgi, batch_size=8, augment=False, tile_overlap=0.1, bsize=224,
             IMG, ysub, xsub, Lyt, Lxt = transforms.make_tiles(
                 imgb, bsize=bsize, augment=augment,
                 tile_overlap=tile_overlap)
-            IMGa[i * ntiles : (i+1) * ntiles] = np.reshape(IMG, 
+            IMGa[i * ntiles : (i+1) * ntiles] = np.reshape(IMG,
                                             (ny * nx, nchan, ly, lx))
-        
+
         # run network
         for j in range(0, IMGa.shape[0], batch_size):
             bslc = slice(j, min(j + batch_size, IMGa.shape[0]))
-            ya0, stylea0 = _forward(net, IMGa[bslc])
+            ya0, stylea0 = forward_fn(net, IMGa[bslc])
             if j == 0:
                 nout = ya0.shape[1]
                 ya = np.zeros((IMGa.shape[0], nout, ly, lx), "float32")
@@ -252,13 +294,13 @@ def run_net(net, imgi, batch_size=8, augment=False, tile_overlap=0.1, bsize=224,
             # styles[b] = stylei
     # slices from padding
     yf = yf[:, :, ypad1 : Ly-ypad2, xpad1 : Lx-xpad2]
-    yf = yf.transpose(0,2,3,1)   
+    yf = yf.transpose(0,2,3,1)
     return yf, np.array(styles)
 
 
 def run_3D(net, imgs, batch_size=8, augment=False,
            tile_overlap=0.1, bsize=224, net_ortho=None,
-           progress=None):
+           progress=None, use_mlx_backend=False):
     """ 
     Run network on image z-stack.
     
@@ -293,9 +335,9 @@ def run_3D(net, imgs, batch_size=8, augment=False,
         core_logger.info("running %s: %d planes of size (%d, %d)" %
                          (sstr[p], shape[pm[p][0]], shape[pm[p][1]], shape[pm[p][2]]))
         y, style = run_net(net,
-                           xsl, batch_size=batch_size, augment=augment, 
-                           bsize=bsize, tile_overlap=tile_overlap, 
-                           rsz=None)
+                           xsl, batch_size=batch_size, augment=augment,
+                           bsize=bsize, tile_overlap=tile_overlap,
+                           rsz=None, use_mlx_backend=use_mlx_backend)
         yf[..., -1] += y[..., -1].transpose(ipm[p])
         for j in range(2):
             yf[..., cp[p][j]] += y[..., cpy[p][j]].transpose(ipm[p])

--- a/cellpose/mlx_net.py
+++ b/cellpose/mlx_net.py
@@ -1,0 +1,336 @@
+"""
+Copyright © 2025 Howard Hughes Medical Institute, Authored by Carsen Stringer, Michael Rariden and Marius Pachitariu.
+
+MLX implementation of the Cellpose-SAM (CP-SAM) Transformer model for Apple Silicon.
+This module re-implements the ViT-based encoder and cellpose readout head using MLX,
+enabling native Apple Silicon GPU acceleration without PyTorch/MPS overhead.
+"""
+
+import math
+import numpy as np
+
+try:
+    import mlx.core as mx
+    import mlx.nn as nn
+    MLX_AVAILABLE = True
+except ImportError:
+    MLX_AVAILABLE = False
+    # Create a dummy base class so the module can be imported without MLX
+    class _DummyModule:
+        pass
+
+
+def check_mlx():
+    if not MLX_AVAILABLE:
+        raise ImportError(
+            "MLX is not installed. Install it with: pip install mlx\n"
+            "MLX requires macOS 13.5+ on Apple Silicon (M1/M2/M3/M4)."
+        )
+
+
+_BaseModule = nn.Module if MLX_AVAILABLE else _DummyModule
+
+
+class MLPBlock(_BaseModule):
+    """MLP block used in each transformer layer."""
+
+    def __init__(self, embedding_dim: int, mlp_dim: int):
+        super().__init__()
+        self.lin1 = nn.Linear(embedding_dim, mlp_dim)
+        self.lin2 = nn.Linear(mlp_dim, embedding_dim)
+
+    def __call__(self, x):
+        return self.lin2(nn.gelu(self.lin1(x)))
+
+
+class LayerNorm2d(_BaseModule):
+    """Layer normalization for 2D feature maps (N, C, H, W)."""
+
+    def __init__(self, num_channels: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.ones((num_channels,))
+        self.bias = mx.zeros((num_channels,))
+        self.eps = eps
+
+    def __call__(self, x):
+        # x: (N, C, H, W)
+        u = mx.mean(x, axis=1, keepdims=True)
+        s = mx.mean((x - u) ** 2, axis=1, keepdims=True)
+        x = (x - u) / mx.sqrt(s + self.eps)
+        x = self.weight[None, :, None, None] * x + self.bias[None, :, None, None]
+        return x
+
+
+class Attention(_BaseModule):
+    """Multi-head attention block with relative position embeddings."""
+
+    def __init__(self, dim: int, num_heads: int = 8, qkv_bias: bool = True,
+                 use_rel_pos: bool = True, input_size: int = 32):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = head_dim ** -0.5
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.proj = nn.Linear(dim, dim)
+
+        self.use_rel_pos = use_rel_pos
+        if use_rel_pos:
+            self.rel_pos_h = mx.zeros((2 * input_size - 1, head_dim))
+            self.rel_pos_w = mx.zeros((2 * input_size - 1, head_dim))
+
+    def __call__(self, x):
+        B, H, W, _ = x.shape
+        # qkv: (B, H*W, 3, num_heads, head_dim)
+        qkv = self.qkv(x).reshape(B, H * W, 3, self.num_heads, -1)
+        # transpose to (3, B, num_heads, H*W, head_dim)
+        qkv = qkv.transpose(2, 0, 3, 1, 4)
+        # reshape to (3, B*num_heads, H*W, head_dim)
+        q, k, v = [qkv[i].reshape(B * self.num_heads, H * W, -1) for i in range(3)]
+
+        attn = (q * self.scale) @ k.transpose(0, 2, 1)
+
+        if self.use_rel_pos:
+            attn = _add_decomposed_rel_pos(attn, q, self.rel_pos_h, self.rel_pos_w,
+                                           (H, W), (H, W))
+
+        attn = mx.softmax(attn, axis=-1)
+
+        x = (attn @ v).reshape(B, self.num_heads, H, W, -1)
+        x = x.transpose(0, 2, 3, 1, 4).reshape(B, H, W, -1)
+        x = self.proj(x)
+        return x
+
+
+def _get_rel_pos(q_size, k_size, rel_pos):
+    """Get relative positional embeddings according to the relative positions of query and key."""
+    max_rel_dist = int(2 * max(q_size, k_size) - 1)
+    if rel_pos.shape[0] != max_rel_dist:
+        # Interpolate rel pos (equivalent to F.interpolate linear)
+        rel_pos_resized = np.array(rel_pos)
+        from scipy.interpolate import interp1d
+        x_old = np.linspace(0, 1, rel_pos_resized.shape[0])
+        x_new = np.linspace(0, 1, max_rel_dist)
+        f = interp1d(x_old, rel_pos_resized, axis=0, kind='linear')
+        rel_pos_resized = mx.array(f(x_new).astype(np.float32))
+    else:
+        rel_pos_resized = rel_pos
+
+    q_coords = np.arange(q_size)[:, None] * max(k_size / q_size, 1.0)
+    k_coords = np.arange(k_size)[None, :] * max(q_size / k_size, 1.0)
+    relative_coords = (q_coords - k_coords) + (k_size - 1) * max(q_size / k_size, 1.0)
+    indices = relative_coords.astype(np.int64)
+
+    return rel_pos_resized[mx.array(indices)]
+
+
+def _add_decomposed_rel_pos(attn, q, rel_pos_h, rel_pos_w, q_size, k_size):
+    """Add decomposed relative positional embeddings to attention."""
+    q_h, q_w = q_size
+    k_h, k_w = k_size
+    Rh = _get_rel_pos(q_h, k_h, rel_pos_h)
+    Rw = _get_rel_pos(q_w, k_w, rel_pos_w)
+
+    B, _, dim = q.shape
+    r_q = q.reshape(B, q_h, q_w, dim)
+    # einsum "bhwc,hkc->bhwk"
+    rel_h = (r_q[:, :, :, None, :] * Rh[None, :, None, :, :]).sum(axis=-1)
+    # einsum "bhwc,wkc->bhwk"
+    rel_w = (r_q[:, :, :, None, :] * Rw[None, None, :, :, :]).sum(axis=-1)
+
+    attn = attn.reshape(B, q_h, q_w, k_h, k_w) + rel_h + rel_w
+    attn = attn.reshape(B, q_h * q_w, k_h * k_w)
+    return attn
+
+
+class Block(_BaseModule):
+    """Transformer block with global attention."""
+
+    def __init__(self, dim: int, num_heads: int, mlp_ratio: float = 4.0,
+                 qkv_bias: bool = True, norm_eps: float = 1e-6,
+                 use_rel_pos: bool = True, input_size: int = 32):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(dim, eps=norm_eps)
+        self.attn = Attention(dim, num_heads=num_heads, qkv_bias=qkv_bias,
+                              use_rel_pos=use_rel_pos, input_size=input_size)
+        self.norm2 = nn.LayerNorm(dim, eps=norm_eps)
+        self.mlp = MLPBlock(embedding_dim=dim, mlp_dim=int(dim * mlp_ratio))
+        self.window_size = 0  # always global attention in cellpose
+
+    def __call__(self, x):
+        shortcut = x
+        x = self.norm1(x)
+        x = self.attn(x)
+        x = shortcut + x
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class PatchEmbed(_BaseModule):
+    """Image to Patch Embedding using convolution."""
+
+    def __init__(self, in_chans: int = 3, embed_dim: int = 1024, ps: int = 8):
+        super().__init__()
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=ps, stride=ps, bias=True)
+
+    def __call__(self, x):
+        # x: (N, C, H, W) in channels-first format
+        # MLX Conv2d expects (N, H, W, C), so transpose
+        x = x.transpose(0, 2, 3, 1)  # (N, H, W, C)
+        x = self.proj(x)  # (N, H', W', embed_dim) - already channels-last
+        return x
+
+
+class Neck(_BaseModule):
+    """Neck module: two Conv2d + LayerNorm2d layers."""
+
+    def __init__(self, embed_dim: int = 1024, out_chans: int = 256):
+        super().__init__()
+        self.conv1 = nn.Conv2d(embed_dim, out_chans, kernel_size=1, bias=False)
+        self.ln1 = LayerNorm2d(out_chans)
+        self.conv2 = nn.Conv2d(out_chans, out_chans, kernel_size=3, padding=1, bias=False)
+        self.ln2 = LayerNorm2d(out_chans)
+
+    def __call__(self, x):
+        # x: (N, C, H, W) channels-first
+        # MLX Conv2d expects (N, H, W, C)
+        x = x.transpose(0, 2, 3, 1)  # (N, H, W, C)
+        x = self.conv1(x)
+        x = x.transpose(0, 3, 1, 2)  # back to (N, C, H, W) for LayerNorm2d
+        x = self.ln1(x)
+        x = x.transpose(0, 2, 3, 1)  # (N, H, W, C) for conv2
+        x = self.conv2(x)
+        x = x.transpose(0, 3, 1, 2)  # (N, C, H, W) for LayerNorm2d
+        x = self.ln2(x)
+        return x
+
+
+class TransformerMLX(_BaseModule):
+    """
+    MLX implementation of the Cellpose-SAM Transformer model.
+
+    This mirrors the PyTorch Transformer class in vit_sam.py but uses MLX operations.
+    Only used for inference (not training).
+    """
+
+    def __init__(self, backbone="vit_l", ps=8, nout=3, bsize=256):
+        super().__init__()
+
+        # ViT-Large config (default for cellpose)
+        configs = {
+            "vit_l": {"embed_dim": 1024, "depth": 24, "num_heads": 16},
+            "vit_h": {"embed_dim": 1280, "depth": 32, "num_heads": 16},
+            "vit_b": {"embed_dim": 768, "depth": 12, "num_heads": 12},
+        }
+        config = configs[backbone]
+        embed_dim = config["embed_dim"]
+        depth = config["depth"]
+        num_heads = config["num_heads"]
+
+        self.ps = ps
+        self.nout = nout
+        self.bsize = bsize
+
+        # Patch embedding
+        self.patch_embed = PatchEmbed(in_chans=3, embed_dim=embed_dim, ps=ps)
+
+        # Positional embedding
+        pos_embed_size = bsize // ps
+        self.pos_embed = mx.zeros((1, pos_embed_size, pos_embed_size, embed_dim))
+
+        # Transformer blocks (input_size = pos_embed_size for rel_pos)
+        self.blocks = [
+            Block(dim=embed_dim, num_heads=num_heads, mlp_ratio=4.0,
+                  qkv_bias=True, norm_eps=1e-6, use_rel_pos=True,
+                  input_size=pos_embed_size)
+            for _ in range(depth)
+        ]
+
+        # Neck
+        self.neck = Neck(embed_dim=embed_dim, out_chans=256)
+
+        # Readout head
+        self.out_conv = nn.Conv2d(256, nout * ps ** 2, kernel_size=1, bias=True)
+
+        # W2: fixed reshape matrix (not trainable) for transpose convolution equivalent
+        self.W2 = mx.array(
+            np.eye(nout * ps ** 2).reshape(nout * ps ** 2, nout, ps, ps).astype(np.float32)
+        )
+
+        # Diameter parameters (loaded from checkpoint)
+        self.diam_labels = mx.array([30.0])
+        self.diam_mean = mx.array([30.0])
+
+    def __call__(self, x):
+        """
+        Forward pass.
+
+        Args:
+            x: Input image tensor of shape (N, C, H, W) in channels-first format.
+
+        Returns:
+            Tuple of (output, style):
+                output: (N, nout, H, W) flow predictions
+                style: (N, 256) zeros for backward compatibility
+        """
+        # Patch embedding: (N, C, H, W) -> (N, H', W', embed_dim)
+        x = self.patch_embed(x)
+
+        # Add positional embeddings
+        if self.pos_embed is not None:
+            x = x + self.pos_embed
+
+        # Transformer blocks
+        for blk in self.blocks:
+            x = blk(x)
+
+        # Neck: (N, H', W', embed_dim) -> permute to (N, embed_dim, H', W') -> neck -> (N, 256, H', W')
+        x = x.transpose(0, 3, 1, 2)  # (N, embed_dim, H', W')
+        x = self.neck(x)
+
+        # Readout: (N, 256, H', W') -> (N, nout*ps^2, H', W')
+        # MLX Conv2d expects (N, H, W, C)
+        x1 = x.transpose(0, 2, 3, 1)  # (N, H', W', 256)
+        x1 = self.out_conv(x1)  # (N, H', W', nout*ps^2)
+        x1 = x1.transpose(0, 3, 1, 2)  # (N, nout*ps^2, H', W')
+
+        # Transpose convolution equivalent (pixel shuffle)
+        x1 = self._conv_transpose(x1)
+
+        # Style vector (zeros for compatibility)
+        style = mx.zeros((x.shape[0], 256))
+
+        return x1, style
+
+    def _conv_transpose(self, x):
+        """
+        Equivalent to F.conv_transpose2d(x, W2, stride=ps, padding=0).
+        Implemented as pixel shuffle since W2 is an identity reshape matrix.
+
+        Args:
+            x: (N, nout*ps^2, H', W')
+
+        Returns:
+            (N, nout, H'*ps, W'*ps)
+        """
+        N, C, H, W = x.shape
+        ps = self.ps
+        nout = self.nout
+        # Reshape: (N, nout, ps, ps, H, W)
+        x = x.reshape(N, nout, ps, ps, H, W)
+        # Permute to (N, nout, H, ps, W, ps)
+        x = x.transpose(0, 1, 4, 2, 5, 3)
+        # Reshape to final: (N, nout, H*ps, W*ps)
+        x = x.reshape(N, nout, H * ps, W * ps)
+        return x
+
+    def load_weights_from_pytorch(self, state_dict):
+        """
+        Load weights from a PyTorch state dict, converting to MLX format.
+
+        Args:
+            state_dict: Dictionary of PyTorch weight tensors (as numpy arrays).
+        """
+        from .mlx_utils import convert_pytorch_to_mlx_weights
+        mlx_weights = convert_pytorch_to_mlx_weights(state_dict, self)
+        self.update(mlx_weights)
+        mx.eval(self.parameters())

--- a/cellpose/mlx_net.py
+++ b/cellpose/mlx_net.py
@@ -101,6 +101,27 @@ class Attention(_BaseModule):
         return x
 
 
+def _precompute_rel_pos_for_size(spatial_size, rel_pos):
+    """Interpolate relative position embeddings to match the target spatial size.
+
+    Args:
+        spatial_size: Target spatial dimension (H or W of feature map).
+        rel_pos: Current rel_pos embeddings, shape (L, head_dim).
+
+    Returns:
+        Interpolated rel_pos of shape (2*spatial_size-1, head_dim).
+    """
+    target_len = 2 * spatial_size - 1
+    if rel_pos.shape[0] == target_len:
+        return rel_pos
+    from scipy.interpolate import interp1d
+    rel_pos_np = np.array(rel_pos)
+    x_old = np.linspace(0, 1, rel_pos_np.shape[0])
+    x_new = np.linspace(0, 1, target_len)
+    f = interp1d(x_old, rel_pos_np, axis=0, kind='linear')
+    return mx.array(f(x_new).astype(np.float32))
+
+
 def _get_rel_pos(q_size, k_size, rel_pos):
     """Get relative positional embeddings according to the relative positions of query and key."""
     max_rel_dist = int(2 * max(q_size, k_size) - 1)
@@ -124,7 +145,13 @@ def _get_rel_pos(q_size, k_size, rel_pos):
 
 
 def _add_decomposed_rel_pos(attn, q, rel_pos_h, rel_pos_w, q_size, k_size):
-    """Add decomposed relative positional embeddings to attention."""
+    """Add decomposed relative positional embeddings to attention.
+
+    Mirrors SAM's add_decomposed_rel_pos exactly:
+        rel_h = einsum("bhwc,hkc->bhwk", r_q, Rh)  -> (B, q_h, q_w, k_h)
+        rel_w = einsum("bhwc,wkc->bhwk", r_q, Rw)  -> (B, q_h, q_w, k_w)
+        attn += rel_h[:,:,:,:,None] + rel_w[:,:,:,None,:]
+    """
     q_h, q_w = q_size
     k_h, k_w = k_size
     Rh = _get_rel_pos(q_h, k_h, rel_pos_h)
@@ -132,12 +159,19 @@ def _add_decomposed_rel_pos(attn, q, rel_pos_h, rel_pos_w, q_size, k_size):
 
     B, _, dim = q.shape
     r_q = q.reshape(B, q_h, q_w, dim)
-    # einsum "bhwc,hkc->bhwk"
+
+    # einsum "bhwc,hkc->bhwk": contract over c, index h shared
+    # r_q: (B, q_h, q_w, dim), Rh: (q_h, k_h, dim)
     rel_h = (r_q[:, :, :, None, :] * Rh[None, :, None, :, :]).sum(axis=-1)
-    # einsum "bhwc,wkc->bhwk"
+    # einsum "bhwc,wkc->bhwk": contract over c, index w shared
+    # r_q: (B, q_h, q_w, dim), Rw: (q_w, k_w, dim)
     rel_w = (r_q[:, :, :, None, :] * Rw[None, None, :, :, :]).sum(axis=-1)
 
-    attn = attn.reshape(B, q_h, q_w, k_h, k_w) + rel_h + rel_w
+    # rel_h: (B, q_h, q_w, k_h) -> unsqueeze last dim for broadcasting over k_w
+    # rel_w: (B, q_h, q_w, k_w) -> unsqueeze at -2 for broadcasting over k_h
+    attn = (attn.reshape(B, q_h, q_w, k_h, k_w)
+            + mx.expand_dims(rel_h, axis=-1)
+            + mx.expand_dims(rel_w, axis=-2))
     attn = attn.reshape(B, q_h * q_w, k_h * k_w)
     return attn
 
@@ -333,4 +367,21 @@ class TransformerMLX(_BaseModule):
         from .mlx_utils import convert_pytorch_to_mlx_weights
         mlx_weights = convert_pytorch_to_mlx_weights(state_dict, self)
         self.update(mlx_weights)
+        mx.eval(self.parameters())
+        self._precompute_rel_pos()
+
+    def _precompute_rel_pos(self):
+        """Pre-compute interpolated relative position embeddings.
+
+        The SAM checkpoint stores rel_pos at size (2*64-1, head_dim)=(127, head_dim),
+        but cellpose uses spatial size bsize//ps=32, needing (2*32-1)=(63, head_dim).
+        Pre-computing avoids repeated scipy interpolation during inference.
+        """
+        spatial_size = self.bsize // self.ps
+        for blk in self.blocks:
+            if blk.attn.use_rel_pos:
+                blk.attn.rel_pos_h = _precompute_rel_pos_for_size(
+                    spatial_size, blk.attn.rel_pos_h)
+                blk.attn.rel_pos_w = _precompute_rel_pos_for_size(
+                    spatial_size, blk.attn.rel_pos_w)
         mx.eval(self.parameters())

--- a/cellpose/mlx_utils.py
+++ b/cellpose/mlx_utils.py
@@ -1,0 +1,221 @@
+"""
+Copyright © 2025 Howard Hughes Medical Institute, Authored by Carsen Stringer, Michael Rariden and Marius Pachitariu.
+
+Utilities for converting PyTorch Cellpose-SAM weights to MLX format.
+"""
+
+import logging
+import numpy as np
+
+mlx_logger = logging.getLogger(__name__)
+
+try:
+    import mlx.core as mx
+    MLX_AVAILABLE = True
+except ImportError:
+    MLX_AVAILABLE = False
+
+
+def _torch_state_dict_to_numpy(path):
+    """Load a PyTorch state dict and convert all tensors to numpy arrays.
+
+    Args:
+        path: Path to the PyTorch model file.
+
+    Returns:
+        dict: State dict with numpy arrays.
+    """
+    import torch
+    state_dict = torch.load(path, map_location="cpu", weights_only=True)
+
+    # Handle DataParallel/DistributedDataParallel wrapper
+    keys = list(state_dict.keys())
+    if keys and keys[0].startswith("module."):
+        state_dict = {k[7:]: v for k, v in state_dict.items()}
+
+    # Validate CP4 model
+    if "W2" not in state_dict:
+        raise ValueError(
+            "This model does not appear to be a CP4 model. "
+            "CP3 models are not compatible with CP4."
+        )
+
+    numpy_dict = {}
+    for k, v in state_dict.items():
+        numpy_dict[k] = v.float().numpy()
+    return numpy_dict
+
+
+def convert_pytorch_to_mlx_weights(state_dict, model):
+    """Convert a PyTorch state dict (numpy arrays) to MLX model weight format.
+
+    The key challenge is mapping PyTorch's nested module naming to MLX's
+    tree-structured weight dictionary, and transposing Conv2d weights from
+    PyTorch (O, I, H, W) to MLX (O, H, W, I) format.
+
+    Args:
+        state_dict: Dict of {pytorch_key: numpy_array}.
+        model: The MLX TransformerMLX model instance.
+
+    Returns:
+        dict: Nested dictionary suitable for model.update().
+    """
+    weights = {}
+
+    for pt_key, value in state_dict.items():
+        mlx_path = _map_key(pt_key)
+        if mlx_path is None:
+            continue  # skip unmapped keys
+
+        # Convert conv2d weights: PyTorch (O, I, H, W) -> MLX (O, H, W, I)
+        arr = value
+        if _is_conv_weight(pt_key, arr):
+            arr = np.transpose(arr, (0, 2, 3, 1))
+
+        _set_nested(weights, mlx_path, mx.array(arr))
+
+    return weights
+
+
+def _is_conv_weight(key, arr):
+    """Check if a weight tensor is a Conv2d weight (4D, not W2)."""
+    if arr.ndim != 4:
+        return False
+    if key == "W2":
+        return False
+    # Conv weights in the model
+    conv_patterns = [
+        "encoder.patch_embed.proj.weight",
+        "encoder.neck.0.weight",  # conv1
+        "encoder.neck.2.weight",  # conv2
+        "out.weight",             # readout conv
+    ]
+    return key in conv_patterns
+
+
+def _map_key(pt_key):
+    """Map a PyTorch state dict key to an MLX nested key path.
+
+    Returns:
+        list of str path components, or None to skip.
+    """
+    # Skip W2 - it's a fixed identity matrix, reconstructed in __init__
+    if pt_key == "W2":
+        return None
+
+    # Diameter parameters
+    if pt_key == "diam_labels":
+        return ["diam_labels"]
+    if pt_key == "diam_mean":
+        return ["diam_mean"]
+
+    # Patch embedding
+    if pt_key == "encoder.patch_embed.proj.weight":
+        return ["patch_embed", "proj", "weight"]
+    if pt_key == "encoder.patch_embed.proj.bias":
+        return ["patch_embed", "proj", "bias"]
+
+    # Positional embedding
+    if pt_key == "encoder.pos_embed":
+        return ["pos_embed"]
+
+    # Transformer blocks: encoder.blocks.{i}.{submodule}
+    if pt_key.startswith("encoder.blocks."):
+        rest = pt_key[len("encoder.blocks."):]
+        parts = rest.split(".", 1)
+        block_idx = parts[0]
+        sub_key = parts[1]
+        return ["blocks", block_idx] + _map_block_key(sub_key)
+
+    # Neck
+    # encoder.neck.0 = conv1, encoder.neck.1 = ln1, encoder.neck.2 = conv2, encoder.neck.3 = ln2
+    if pt_key.startswith("encoder.neck."):
+        rest = pt_key[len("encoder.neck."):]
+        parts = rest.split(".", 1)
+        neck_idx = int(parts[0])
+        param = parts[1]
+        neck_map = {0: "conv1", 1: "ln1", 2: "conv2", 3: "ln2"}
+        return ["neck", neck_map[neck_idx], param]
+
+    # Readout convolution
+    if pt_key == "out.weight":
+        return ["out_conv", "weight"]
+    if pt_key == "out.bias":
+        return ["out_conv", "bias"]
+
+    mlx_logger.warning(f"Unmapped PyTorch key: {pt_key}")
+    return None
+
+
+def _map_block_key(sub_key):
+    """Map block sub-keys from PyTorch to MLX format.
+
+    PyTorch: norm1.weight, attn.qkv.weight, attn.proj.weight, norm2.weight, mlp.lin1.weight, etc.
+    MLX: same structure, just different nesting.
+    """
+    # norm1, norm2
+    if sub_key.startswith("norm1."):
+        param = sub_key[len("norm1."):]
+        return ["norm1", param]
+    if sub_key.startswith("norm2."):
+        param = sub_key[len("norm2."):]
+        return ["norm2", param]
+
+    # attention: attn.qkv.weight, attn.qkv.bias, attn.proj.weight, attn.proj.bias
+    if sub_key.startswith("attn."):
+        attn_rest = sub_key[len("attn."):]
+        parts = attn_rest.split(".")
+        return ["attn"] + parts
+
+    # MLP: mlp.lin1.weight, mlp.lin1.bias, mlp.lin2.weight, mlp.lin2.bias
+    if sub_key.startswith("mlp."):
+        mlp_rest = sub_key[len("mlp."):]
+        parts = mlp_rest.split(".")
+        return ["mlp"] + parts
+
+    mlx_logger.warning(f"Unmapped block sub-key: {sub_key}")
+    return [sub_key]
+
+
+def _set_nested(d, path, value):
+    """Set a value in a nested dictionary using a list of keys."""
+    for key in path[:-1]:
+        if key not in d:
+            d[key] = {}
+        d = d[key]
+    d[path[-1]] = value
+
+
+def save_mlx_weights(state_dict_path, output_path):
+    """Convert a PyTorch checkpoint to MLX safetensors format.
+
+    Args:
+        state_dict_path: Path to PyTorch model file.
+        output_path: Path to save MLX weights (.safetensors or .npz).
+    """
+    from .mlx_net import TransformerMLX
+    numpy_dict = _torch_state_dict_to_numpy(state_dict_path)
+    model = TransformerMLX()
+    mlx_weights = convert_pytorch_to_mlx_weights(numpy_dict, model)
+
+    # Flatten nested dict for saving
+    flat = {}
+    _flatten_dict(mlx_weights, [], flat)
+
+    if output_path.endswith(".npz"):
+        np_dict = {k: np.array(v) for k, v in flat.items()}
+        np.savez(output_path, **np_dict)
+    else:
+        mx.savez(output_path, **flat)
+
+    mlx_logger.info(f"MLX weights saved to {output_path}")
+
+
+def _flatten_dict(d, prefix, out):
+    """Flatten a nested dict to dot-separated keys."""
+    for k, v in d.items():
+        key = ".".join(prefix + [k])
+        if isinstance(v, dict):
+            _flatten_dict(v, prefix + [k], out)
+        else:
+            out[key] = v

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -108,7 +108,10 @@ class CellposeModel():
             diam_mean (float, optional): Mean "diameter", 30. is built-in value for "cyto" model; 17. is built-in value for "nuclei" model; if saved in custom model file (cellpose>=2.0) then it will be loaded automatically and overwrite this value.
             device (torch device, optional): Device used for model running / training (torch.device("cuda") or torch.device("cpu")), overrides gpu input, recommended if you want to use a specific GPU (e.g. torch.device("cuda:1")).
             use_bfloat16 (bool, optional): Use 16bit float precision instead of 32bit for model weights. Default to 16bit (True).
-            use_mlx (bool, optional): Use MLX backend for Apple Silicon acceleration. Requires macOS with Apple Silicon and MLX installed. Defaults to False.
+            use_mlx (bool or str, optional): Use MLX backend for Apple Silicon acceleration.
+                If True, use MLX backend. If "auto", auto-detect and use MLX on Apple Silicon
+                when CUDA is not available. Requires macOS with Apple Silicon and MLX installed.
+                Defaults to False.
         """
         if diam_mean is not None:
             models_logger.warning(
@@ -121,13 +124,25 @@ class CellposeModel():
         if nchan is not None:
             models_logger.warning("nchan argument is deprecated in v4.0.1+. Ignoring this argument")
 
-        # Check if MLX backend is requested
-        self.use_mlx = use_mlx and MLX_AVAILABLE
-        if use_mlx and not MLX_AVAILABLE:
-            models_logger.warning(
-                "MLX backend requested but MLX is not available. "
-                "Install with: pip install mlx. Falling back to PyTorch."
-            )
+        # Check if MLX backend is requested or auto-detected
+        if use_mlx == "auto":
+            # Auto-detect: use MLX on Apple Silicon when CUDA is not available
+            if MLX_AVAILABLE and not torch.cuda.is_available():
+                self.use_mlx = True
+                models_logger.info(
+                    "MLX auto-detected on Apple Silicon (no CUDA available). "
+                    "Using MLX backend."
+                )
+            else:
+                self.use_mlx = False
+        elif use_mlx:
+            self.use_mlx = MLX_AVAILABLE
+            if not MLX_AVAILABLE:
+                models_logger.warning(
+                    "MLX backend requested but MLX is not available. "
+                    "Install with: pip install mlx. Falling back to PyTorch."
+                )
+        else:
             self.use_mlx = False
 
         if self.use_mlx:
@@ -351,9 +366,10 @@ class CellposeModel():
             if len(flow3D_smooth) == 3 and any(v > 0 for v in flow3D_smooth):
                 models_logger.info(f"smoothing flows with ZYX sigma={flow3D_smooth}")
                 dP = gaussian_filter(dP, [0, *flow3D_smooth])
-            else: 
+            else:
                 models_logger.warning(f"Could not do flow smoothing with {flow3D_smooth} either because its len was not 3 or no items were > 0, skipping flow3D_smoothing")
-            torch.cuda.empty_cache()
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
             gc.collect()
 
         if compute_masks:

--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -19,6 +19,13 @@ from . import transforms, dynamics, utils, plot
 from .vit_sam import Transformer
 from .core import assign_device, run_net, run_3D
 
+try:
+    import mlx.core as mx
+    from .mlx_net import TransformerMLX, MLX_AVAILABLE
+    from .mlx_utils import _torch_state_dict_to_numpy
+except ImportError:
+    MLX_AVAILABLE = False
+
 _CPSAM_MODEL_URL = "https://huggingface.co/mouseland/cellpose-sam/resolve/main/cpsam"
 _MODEL_DIR_ENV = os.environ.get("CELLPOSE_LOCAL_MODELS_PATH")
 _MODEL_DIR_DEFAULT = Path.home().joinpath(".cellpose", "models")
@@ -89,7 +96,8 @@ class CellposeModel():
     """
 
     def __init__(self, gpu=False, pretrained_model="cpsam", model_type=None,
-                 diam_mean=None, device=None, nchan=None, use_bfloat16=True):
+                 diam_mean=None, device=None, nchan=None, use_bfloat16=True,
+                 use_mlx=False):
         """
         Initialize the CellposeModel.
 
@@ -100,6 +108,7 @@ class CellposeModel():
             diam_mean (float, optional): Mean "diameter", 30. is built-in value for "cyto" model; 17. is built-in value for "nuclei" model; if saved in custom model file (cellpose>=2.0) then it will be loaded automatically and overwrite this value.
             device (torch device, optional): Device used for model running / training (torch.device("cuda") or torch.device("cpu")), overrides gpu input, recommended if you want to use a specific GPU (e.g. torch.device("cuda:1")).
             use_bfloat16 (bool, optional): Use 16bit float precision instead of 32bit for model weights. Default to 16bit (True).
+            use_mlx (bool, optional): Use MLX backend for Apple Silicon acceleration. Requires macOS with Apple Silicon and MLX installed. Defaults to False.
         """
         if diam_mean is not None:
             models_logger.warning(
@@ -112,19 +121,33 @@ class CellposeModel():
         if nchan is not None:
             models_logger.warning("nchan argument is deprecated in v4.0.1+. Ignoring this argument")
 
-        ### assign model device
-        self.device = assign_device(gpu=gpu)[0] if device is None else device
-        if torch.cuda.is_available():
-            device_gpu = self.device.type == "cuda"
-        elif torch.backends.mps.is_available():
-            device_gpu = self.device.type == "mps"
+        # Check if MLX backend is requested
+        self.use_mlx = use_mlx and MLX_AVAILABLE
+        if use_mlx and not MLX_AVAILABLE:
+            models_logger.warning(
+                "MLX backend requested but MLX is not available. "
+                "Install with: pip install mlx. Falling back to PyTorch."
+            )
+            self.use_mlx = False
+
+        if self.use_mlx:
+            models_logger.info(">>>> using MLX backend (Apple Silicon)")
+            self.device = torch.device("cpu")  # dynamics still uses torch on CPU
+            self.gpu = False
         else:
-            device_gpu = False
-        self.gpu = device_gpu
+            ### assign model device
+            self.device = assign_device(gpu=gpu)[0] if device is None else device
+            if torch.cuda.is_available():
+                device_gpu = self.device.type == "cuda"
+            elif torch.backends.mps.is_available():
+                device_gpu = self.device.type == "mps"
+            else:
+                device_gpu = False
+            self.gpu = device_gpu
 
         if pretrained_model is None:
             raise ValueError("Must specify a pretrained model, training from scratch is not implemented")
-        
+
         ### create neural network
         if pretrained_model and not os.path.exists(pretrained_model):
             # check if pretrained model is in the models directory
@@ -140,17 +163,28 @@ class CellposeModel():
                 )
 
         self.pretrained_model = pretrained_model
-        dtype = torch.bfloat16 if use_bfloat16 else torch.float32
-        self.net = Transformer(dtype=dtype).to(self.device)
 
-        if os.path.exists(self.pretrained_model):
-            models_logger.info(f">>>> loading model {self.pretrained_model}")
-            self.net.load_model(self.pretrained_model, device=self.device)
+        if self.use_mlx:
+            self.net = TransformerMLX()
+            if not os.path.exists(self.pretrained_model):
+                if os.path.split(self.pretrained_model)[-1] != 'cpsam':
+                    raise FileNotFoundError('model file not recognized')
+                cache_CPSAM_model_path()
+            models_logger.info(f">>>> loading model {self.pretrained_model} (MLX)")
+            numpy_dict = _torch_state_dict_to_numpy(self.pretrained_model)
+            self.net.load_weights_from_pytorch(numpy_dict)
         else:
-            if os.path.split(self.pretrained_model)[-1] != 'cpsam':
-                raise FileNotFoundError('model file not recognized')
-            cache_CPSAM_model_path()
-            self.net.load_model(self.pretrained_model, device=self.device)
+            dtype = torch.bfloat16 if use_bfloat16 else torch.float32
+            self.net = Transformer(dtype=dtype).to(self.device)
+
+            if os.path.exists(self.pretrained_model):
+                models_logger.info(f">>>> loading model {self.pretrained_model}")
+                self.net.load_model(self.pretrained_model, device=self.device)
+            else:
+                if os.path.split(self.pretrained_model)[-1] != 'cpsam':
+                    raise FileNotFoundError('model file not recognized')
+                cache_CPSAM_model_path()
+                self.net.load_model(self.pretrained_model, device=self.device)
         
         
     def eval(self, x, batch_size=8, resample=True, channels=None, channel_axis=None,
@@ -365,12 +399,13 @@ class CellposeModel():
                     x = transforms.resize_image(x, Ly=int(Ly*rescale),
                                                 Lx=int(Lx*rescale))
                 x = transforms.resize_image(x.transpose(1,0,2,3),
-                                        Ly=int(Lz*anisotropy*rescale), 
+                                        Ly=int(Lz*anisotropy*rescale),
                                         Lx=int(Lx*rescale)).transpose(1,0,2,3)
             yf, styles = run_3D(self.net, x,
-                                batch_size=batch_size, augment=augment,  
-                                tile_overlap=tile_overlap, 
-                                bsize=bsize
+                                batch_size=batch_size, augment=augment,
+                                tile_overlap=tile_overlap,
+                                bsize=bsize,
+                                use_mlx_backend=self.use_mlx
                                 )
             if resample:
                 if rescale != 1.0 or Lz != yf.shape[0]:
@@ -383,9 +418,10 @@ class CellposeModel():
             dP = yf[..., :-1].transpose((3, 0, 1, 2))
         else:
             yf, styles = run_net(self.net, x, bsize=bsize, augment=augment,
-                                batch_size=batch_size,  
-                                tile_overlap=tile_overlap, 
-                                rsz=rescale if rescale !=1.0 else None)
+                                batch_size=batch_size,
+                                tile_overlap=tile_overlap,
+                                rsz=rescale if rescale !=1.0 else None,
+                                use_mlx_backend=self.use_mlx)
             if resample:
                 if rescale != 1.0:
                     yf = transforms.resize_image(yf, shape[1], shape[2])

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,10 @@ bioimageio_deps = [
     'bioimageio.core',
 ]
 
+mlx_deps = [
+    'mlx>=0.10.0',
+]
+
 try:
     import torch
     a = torch.ones(2, 3)
@@ -94,6 +98,7 @@ setup(
         'gui': gui_deps,
         'distributed': distributed_deps,
         'bioimageio': bioimageio_deps,
+        'mlx': mlx_deps,
         'all': gui_deps + distributed_deps + image_deps + bioimageio_deps,
     }, include_package_data=True, classifiers=(
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This pull request introduces support for the MLX backend to accelerate Cellpose inference on Apple Silicon (M1/M2/M3/M4) Macs. It adds a new MLX-based implementation of the Cellpose-SAM Transformer model, CLI options to enable MLX, and integrates MLX inference into the core pipeline, ensuring users can leverage native GPU acceleration on macOS with Apple Silicon.

**MLX backend integration:**

* Added a new module `cellpose/mlx_net.py` implementing the Cellpose-SAM Transformer model using MLX, including all necessary transformer, attention, and convolutional blocks for inference on Apple Silicon.
* In `cellpose/core.py`, added MLX availability detection, a `use_mlx()` utility, and a `_forward_mlx` function for running inference with MLX models. The main `run_net` and `run_3D` functions now accept a `use_mlx_backend` parameter to switch between PyTorch and MLX backends. [[1]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022R13-R18) [[2]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022R43-R59) [[3]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022R135-R150) [[4]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022L166-R205) [[5]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022R219-R227) [[6]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022L230-R272) [[7]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022L261-R303) [[8]](diffhunk://#diff-36b410cafe8a5e5865f1e8ff58df6c745aafbba63673a3e6bb7bc10eeacb4022L298-R340)

**Command-line interface updates:**

* Added a `--use_mlx` CLI argument in `cellpose/cli.py` to enable or auto-detect the MLX backend for Apple Silicon acceleration.

**Core pipeline and model updates:**

* Updated the main entry point in `cellpose/__main__.py` to pass the `use_mlx` argument to the model, enabling MLX inference when requested by the user.

These changes enable native, efficient Cellpose inference on Apple Silicon Macs using the MLX backend.