### PR TITLE
GUI fixes: Add escape drawing, disable right-click drag, disable double left-click

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1018,7 +1018,7 @@ class MainW(QMainWindow):
         self.remove_roi_obj = None
 
     @property
-    def color(self):
+    def color(self) -> str:
         """Current color display mode as a lowercase string.
 
         Reflects the current selection of the RGBDropDown widget. Possible

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -730,6 +730,11 @@ class MainW(QMainWindow):
                     self.brush_choose()
                 if not updated:
                     self.update_plot()
+            
+            # when in stroke, allow escaping out of drawing
+            else: 
+                if event.key() == QtCore.Qt.Key_Escape:
+                    self.layer.end_stroke(keep_stroke=False)
         if event.key() == QtCore.Qt.Key_Minus or event.key() == QtCore.Qt.Key_Equal:
             self.p0.keyPressEvent(event)
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -752,8 +752,6 @@ class MainW(QMainWindow):
                         gci = min(count - 1, gci + 1)
                     self.BrushChoose.setCurrentIndex(gci)
                     self.brush_choose()
-                if not updated:
-                    self.update_plot()
             
             # when in stroke, allow escaping out of drawing
             else: 

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -653,6 +653,11 @@ class MainW_3d(MainW):
                     self.brush_choose()
                 if not updated:
                     self.update_plot()
+
+            # when in stroke, allow escaping out of drawing
+            else: 
+                if event.key() == QtCore.Qt.Key_Escape:
+                    self.layer.end_stroke(keep_stroke=False)
         if event.key() == QtCore.Qt.Key_Minus or event.key() == QtCore.Qt.Key_Equal:
             self.p0.keyPressEvent(event)
 

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -722,8 +722,17 @@ class ImageDraw(pg.ImageItem):
             else:
                 return False
 
-    def end_stroke(self):
+    def end_stroke(self, keep_stroke=True):
         self.parent.p0.removeItem(self.scatter)
+        if not keep_stroke:
+            if not self.parent.stroke_appended:
+                self.parent.strokes.append(self.parent.current_stroke)
+                self.parent.stroke_appended = True
+            self.parent.remove_stroke(delete_points=False)
+            self.parent.current_stroke = []
+            self.parent.current_point_set = []
+            self.parent.in_stroke = False
+            return
         if not self.parent.stroke_appended:
             self.parent.strokes.append(self.parent.current_stroke)
             self.parent.stroke_appended = True

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -677,7 +677,10 @@ class ImageDraw(pg.ImageItem):
         return
 
     def mouseDragEvent(self, ev):
-        ev.accept()
+        if ev.button() == QtCore.Qt.RightButton:
+            ev.accept()
+        else:
+            ev.ignore()
         return
 
     def hoverEvent(self, ev):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -672,8 +672,12 @@ class ImageDraw(pg.ImageItem):
                         elif self.parent.masksOn and not self.parent.deleting_multiple:
                             self.parent.unselect_cell()
 
+    def mouseDoubleClickEvent(self, ev) -> None:
+        ev.accept()
+        return
+
     def mouseDragEvent(self, ev):
-        ev.ignore()
+        ev.accept()
         return
 
     def hoverEvent(self, ev):

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -708,6 +708,9 @@ class ImageDraw(pg.ImageItem):
         # first check if you ever left the start
         if len(self.parent.current_stroke) > 3:
             stroke = np.array(self.parent.current_stroke)
+            stroke = stroke[stroke[:, 0] == self.parent.currentZ]
+            if len(stroke) <= 3:
+                return False
             dist = (((stroke[1:, 1:] -
                       stroke[:1, 1:][np.newaxis, :, :])**2).sum(axis=-1))**0.5
             dist = dist.flatten()
@@ -729,8 +732,8 @@ class ImageDraw(pg.ImageItem):
                 self.parent.strokes.append(self.parent.current_stroke)
                 self.parent.stroke_appended = True
             self.parent.remove_stroke(delete_points=False)
-            self.parent.current_stroke = []
-            self.parent.current_point_set = []
+            self.parent.current_stroke = [s for s in self.parent.current_stroke
+                                          if s[0] != self.parent.currentZ]
             self.parent.in_stroke = False
             return
         if not self.parent.stroke_appended:

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -329,7 +329,13 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
             parent.ismanual = dat["ismanual"]
 
     if "current_channel" in dat:
-        parent.color = (dat["current_channel"] + 2) % 5
+        color = dat['current_channel']
+
+        # color updated to strings, force int channels to rgb for backwards compatibility
+        if isinstance(color, int):
+            parent.color = 'rgb'
+        elif isinstance(color, str):
+            parent.color = color
 
     if "flows" in dat:
         parent.flows = dat["flows"]
@@ -559,7 +565,7 @@ def _save_sets(parent):
                 parent.cellcolors[1:],
             "masks":
                 parent.cellpix,
-            "current_channel": (parent.color - 2) % 5,
+            "current_channel": parent.color,
             "filename":
                 parent.filename,
             "flows":

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -331,8 +331,9 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
     if "current_channel" in dat:
         color = dat['current_channel']
 
-        # color updated to strings, force int channels to rgb for backwards compatibility
+        # old .npy files stored channel as int; default to 'rgb'
         if isinstance(color, int):
+            parent.logger.warning('ignoring `current_channel` key in .npy because it is int')
             parent.color = 'rgb'
         elif isinstance(color, str):
             parent.color = color

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -362,6 +362,7 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
 
     parent.enable_buttons()
     parent.update_layer()
+    parent.update_plot()
     del dat
     gc.collect()
 

--- a/docs/gui.rst
+++ b/docs/gui.rst
@@ -40,28 +40,28 @@ For multi-Z 3D data, please use the 3D version of the GUI:
 Using the GUI 
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-The GUI serves two main functions:
+The GUI serves three main functions:
 
 1. Running the segmentation algorithm.
 2. Manually labelling data.
-3. (NEW) Fine-tuning a pretrained cellpose model on your own data.
+3. Fine-tuning a pretrained cellpose model on your own data.
 
 Main GUI mouse controls (works in all views):
 
 -  Pan = left-click + drag
 -  Zoom = scroll wheel (or +/= and - buttons)
--  Full view = double left-click
 -  Select mask = left-click on mask
 -  Delete mask = Ctrl (or Command on Mac) + left-click
 -  Merge masks = Alt + left-click (will merge last two)
 -  Start draw mask = right-click
--  End draw mask = right-click, or return to circle at beginning
+-  End draw mask = press esc, right-click, or return to circle at beginning
 
 Drawing masks 
 ~~~~~~~~~~~~~~~~~~~~~~
 
 Masks are started with right-click, then hover your mouse (do not hold it down), 
 and return it to the red circle to complete the mask. The mask should now be completed.
+At any point, you can escape drawing a mask with the Esc key.
 
 Overlaps in masks are NOT allowed. If you draw a mask on top of another
 mask, it is cropped so that it doesn't overlap with the old mask. Masks


### PR DESCRIPTION
- Add escape drawing by hitting escape key. 
- Disable unused right-click and drag to zoom behavior. This is not needed because other zoom controls exist and right-click to drag occasionally gets in the way of annotation. 
- Disable double left-click to reset the view. This was especially painful when looking at orthoviews in the 3D gui and quickly clicking around to see the orthoviews update. 


- [x] Update docs to describe escape draw behavior
- [x] GUI testing protocol
- [x] tests passing