### PR TITLE
Remove `.views` & `.color` states, fix gradZ 3D GUI display

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1425,7 +1425,7 @@ class MainW(QMainWindow):
         flowp_map = {
             'gradXY' : 0,
             'cellprob' : 1,
-            'gradZ' : 4,
+            'gradZ' : 2,
         }
         rgb_list = ['red', 'green', 'blue']
 

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -31,15 +31,6 @@ except:
 
 Horizontal = QtCore.Qt.Orientation.Horizontal
 
-from contextlib import contextmanager
-
-@contextmanager
-def suppress_signals(widget):
-    widget.blockSignals(True)
-    try:
-        yield
-    finally:
-        widget.blockSignals(False)
 
 class Slider(QRangeSlider):
 
@@ -1008,9 +999,9 @@ class MainW(QMainWindow):
         self.ismanual = np.zeros(0, "bool")
 
         # -- set menus to default -- #
-        with suppress_signals(self.RGBDropDown):
+        with QtCore.QSignalBlocker(self.RGBDropDown):
             self.color = 'RGB'
-        with suppress_signals(self.ViewDropDown):
+        with QtCore.QSignalBlocker(self.ViewDropDown):
             self.view = 'image'
         self.delete_restore()
 
@@ -1517,7 +1508,7 @@ class MainW(QMainWindow):
         for r in range(3):
         # setValue on the slider triggers update_plot() so it needs to be suppressed
             slider = self.sliders[r]
-            with suppress_signals(slider):
+            with QtCore.QSignalBlocker(slider):
                 slider.setValue([
                     self.saturation[r][self.currentZ][0],
                     self.saturation[r][self.currentZ][1]

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -811,8 +811,6 @@ class MainW(QMainWindow):
             self.sliders[n].setEnabled(True)
 
         self.toggle_mask_ops()
-
-        self.update_plot()
         self.setWindowTitle(self.filename)
 
     def disable_buttons_removeROIs(self):

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1454,7 +1454,7 @@ class MainW(QMainWindow):
         flowp_map = {
             'gradXY' : 0,
             'cellprob' : 1,
-            'gradZ' : 2,
+            'gradZ' : 4,
         }
         rgb_list = ['red', 'green', 'blue']
 
@@ -2082,15 +2082,15 @@ class MainW(QMainWindow):
                 print("GUI_INFO: resizing flows to original image size")
                 for flows0 in flows_new:
                     if Ly0 != Ly:
-                        flow0 = resize_image(flow0, Ly=Ly, Lx=Lx,
-                                            no_channels=flow0.ndim==3, 
+                        flows0 = resize_image(flows0, Ly=Ly, Lx=Lx,
+                                            no_channels=flows0.ndim==3, 
                                             interpolation=cv2.INTER_NEAREST)
                     if Lz0 != Lz:
-                        flow0 = np.swapaxes(resize_image(np.swapaxes(flow0, 0, 1),
+                        flows0 = np.swapaxes(resize_image(np.swapaxes(flows0, 0, 1),
                                             Ly=Lz, Lx=Lx,
-                                            no_channels=flow0.ndim==3, 
+                                            no_channels=flows0.ndim==3, 
                                             interpolation=cv2.INTER_NEAREST), 0, 1)
-                    self.flows.append(flow0)
+                    self.flows.append(flows0)
 
             # add first axis
             if self.NZ == 1:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -688,8 +688,10 @@ class MainW(QMainWindow):
                         self.get_next_image()
                     elif event.key() == QtCore.Qt.Key_PageDown:
                         self.go_next_previous_view()
+                        updated = True
                     elif event.key() == QtCore.Qt.Key_PageUp:
                         self.go_next_previous_view(-1)
+                        updated = True
 
                 # can change background or stroke size if cell not finished
                 if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -328,7 +328,7 @@ class MainW(QMainWindow):
         self.l0.addWidget(self.satBox, b, 0, 1, 9)
 
         widget_row = 0
-        self.view = 0  # 0=image, 1=flowsXY, 2=flowsZ, 3=cellprob
+        # self.view = 0  # 0=image, 1=flowsXY, 2=flowsZ, 3=cellprob
         self.color = 0  # 0=RGB, 1=gray, 2=R, 3=G, 4=B
         self.RGBDropDown = QComboBox()
         self.RGBDropDown.addItems(
@@ -350,6 +350,7 @@ class MainW(QMainWindow):
         self.ViewDropDown.setFont(self.medfont)
         self.ViewDropDown.model().item(3).setEnabled(False)
         self.ViewDropDown.currentIndexChanged.connect(self.update_plot)
+        self.view = 0 # must reference the property after the dropdown is created
         self.satBoxG.addWidget(self.ViewDropDown, widget_row, 0, 2, 3)
 
         label = QLabel("[pageup / pagedown]")
@@ -686,11 +687,9 @@ class MainW(QMainWindow):
                     ) == QtCore.Qt.Key_D:
                         self.get_next_image()
                     elif event.key() == QtCore.Qt.Key_PageDown:
-                        self.view = (self.view + 1) % (nviews)
-                        self.ViewDropDown.setCurrentIndex(self.view)
+                        self.go_next_previous_view()
                     elif event.key() == QtCore.Qt.Key_PageUp:
-                        self.view = (self.view - 1) % (nviews)
-                        self.ViewDropDown.setCurrentIndex(self.view)
+                        self.go_next_previous_view(-1)
 
                 # can change background or stroke size if cell not finished
                 if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:
@@ -982,7 +981,6 @@ class MainW(QMainWindow):
         # -- set menus to default -- #
         self.color = 0
         self.RGBDropDown.setCurrentIndex(self.color)
-        self.view = 0
         self.ViewDropDown.setCurrentIndex(0)
         self.ViewDropDown.model().item(self.ViewDropDown.count() - 1).setEnabled(False)
         self.delete_restore()
@@ -997,6 +995,36 @@ class MainW(QMainWindow):
         self.removing_cells_list = []
         self.removing_region = False
         self.remove_roi_obj = None
+
+    @property
+    def view(self):
+        """Current view mode as a string (e.g. 'image', 'gradXY', 'cellprob', 'restored')."""
+        return self.ViewDropDown.currentText()
+
+    @view.setter
+    def view(self, value: int|str):
+        """Set the active view in the ViewDropDown.
+
+        Parameters
+        ----------
+        value : int or str
+            If int, sets the dropdown to that index. If str, matches against
+            available items ('image', 'gradXY', 'cellprob', 'restored') and
+            selects the matching entry.
+
+        Raises
+        ------
+        ValueError
+            If value is neither an int nor a str.
+        """
+        if isinstance(value, int):
+            self.ViewDropDown.setCurrentIndex(value)
+        elif isinstance(value, str):
+            items = [self.ViewDropDown.itemText(i) for i in range(self.ViewDropDown.count())]
+            if value in items: 
+                self.ViewDropDown.setCurrentIndex(items.index(value))
+        else: 
+            raise ValueError('Incompatible view drop down setting')
 
     def delete_restore(self):
         """ delete restored imgs but don't reset settings """
@@ -1342,17 +1370,27 @@ class MainW(QMainWindow):
 
     def color_choose(self):
         self.color = self.RGBDropDown.currentIndex()
-        self.view = 0
-        self.ViewDropDown.setCurrentIndex(self.view)
+        self.view = 'image'
         self.update_plot()
 
     def update_plot(self):
         self.view = self.ViewDropDown.currentIndex()
         self.Ly, self.Lx, _ = self.stack[self.currentZ].shape
 
-        if self.view == 0 or self.view == self.ViewDropDown.count() - 1:
-            image = self.stack[
-                self.currentZ] if self.view == 0 else self.stack_filtered[self.currentZ]
+        is_image_view = self.view == 'image'
+        is_restored_view = self.view == 'restored'
+
+        flowp_map = {
+            'gradXY' : 0,
+            'cellprob' : 1,
+            'gradZ' : 4,
+        }
+
+        if is_image_view or is_restored_view:
+            if is_image_view:
+                image = self.stack[self.currentZ]
+            else: 
+                self.stack_filtered[self.currentZ]
             if self.color == 0:
                 self.img.setImage(image, autoLevels=False, lut=None)
                 if self.nchan > 1:
@@ -1388,12 +1426,9 @@ class MainW(QMainWindow):
                 self.img.setLevels(self.saturation[0][self.currentZ])
         else:
             image = np.zeros((self.Ly, self.Lx), np.uint8)
-            if len(self.flows) >= self.view - 1 and len(self.flows[self.view - 1]) > 0:
-                image = self.flows[self.view - 1][self.currentZ]
-            if self.view > 1:
-                self.img.setImage(image, autoLevels=False, lut=self.bwr)
-            else:
-                self.img.setImage(image, autoLevels=False, lut=None)
+            if len(self.flows[flowp_map[self.view]]) > 0:
+                image = self.flows[flowp_map[self.view]][self.currentZ]
+            self.img.setImage(image, autoLevels=False, lut=self.bwr)
             self.img.setLevels([0.0, 255.0])
 
         for r in range(3):
@@ -1946,10 +1981,11 @@ class MainW(QMainWindow):
             flows_new.append(flows[0].copy())  # RGB flow
             flows_new.append((np.clip(normalize99(flows[2].copy()), 0, 1) *
                               255).astype("uint8"))  # cellprob
-            flows_new.append(flows[1].copy()) # XY flows
+            flows_new.append(flows[1].copy()) # XY(Z) flows
             flows_new.append(flows[2].copy()) # original cellprob
 
             if self.load_3D:
+                # append Z flows (or zeros in stitching case): Z flows are flows[4]
                 if stitch_threshold == 0.:
                     flows_new.append((flows[1][0] / 10 * 127 + 127).astype("uint8"))
                 else:
@@ -1972,8 +2008,7 @@ class MainW(QMainWindow):
                 Lz, Ly, Lx = self.NZ, self.Ly, self.Lx
                 Lz0, Ly0, Lx0 = flows_new[0].shape[:3]
                 print("GUI_INFO: resizing flows to original image size")
-                for j in range(len(flows_new)):
-                    flow0 = flows_new[j]
+                for flows0 in flows_new:
                     if Ly0 != Ly:
                         flow0 = resize_image(flow0, Ly=Ly, Lx=Lx,
                                             no_channels=flow0.ndim==3, 
@@ -2009,3 +2044,28 @@ class MainW(QMainWindow):
                 self.recompute_masks = False
         except Exception as e:
             print("ERROR: %s" % e)
+
+
+    def go_next_previous_view(self, increment=1):
+        """ Go to the next view using `increment` """
+
+        # skip disabled views
+        num_items = self.ViewDropDown.count()
+        enabled = []
+        for i in range(num_items):
+            enabled.append(self.ViewDropDown.model().item(i).isEnabled())
+
+        if not any(enabled):
+            self.logger.error('No available views are enabled. Cannot adjust view.')
+            return 
+
+        idx = self.ViewDropDown.currentIndex() + increment
+
+        for _ in range(num_items):
+            idx %= num_items
+            if enabled[idx]:
+                self.ViewDropDown.setCurrentIndex(idx)
+                return
+            idx += increment
+
+        self.logger.error('Could not find an emabled view.')

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1017,13 +1017,42 @@ class MainW(QMainWindow):
 
     @property
     def color(self):
-        """ Current color mode as a string. Possible values are rgb, red, green, blue, gray, or spectral"""
+        """Current color display mode as a lowercase string.
+
+        Reflects the current selection of the RGBDropDown widget. Possible
+        values are ``'rgb'``, ``'red'``, ``'green'``, ``'blue'``, ``'gray'``,
+        and ``'spectral'``.
+
+        Returns
+        -------
+        str
+            The current color mode, always lowercase.
+        """
         # invert mapping
-        inv_name_map = {v: k for k, v in self.RGBDropDown.name_map.items()} 
+        inv_name_map = {v: k for k, v in self.RGBDropDown.name_map.items()}
         return inv_name_map[self.RGBDropDown.currentText().lower()].lower()
-    
+
     @color.setter
     def color(self, value: str|int):
+        """Set the color display mode by name or dropdown index.
+
+        Updates the RGBDropDown widget, which triggers any connected signals
+        (e.g. ``update_plot``).
+
+        Parameters
+        ----------
+        value : str or int
+            If ``str``, a case-insensitive color name (``'rgb'``, ``'red'``,
+            ``'green'``, ``'blue'``, ``'gray'``, ``'spectral'``). The name is
+            looked up via ``RGBDropDown.name_map`` before matching against the
+            dropdown items, so aliases defined in that map are also accepted.
+            If ``int``, the zero-based index of the desired dropdown item.
+
+        Raises
+        ------
+        ValueError
+            If ``value`` is neither a ``str`` nor an ``int``.
+        """
         if isinstance(value, int):
             self.RGBDropDown.setCurrentIndex(value)
         elif isinstance(value, str):
@@ -1031,7 +1060,7 @@ class MainW(QMainWindow):
             items = [self.RGBDropDown.itemText(i).lower() for i in range(self.RGBDropDown.count())]
             if value in items:
                 self.RGBDropDown.setCurrentIndex(items.index(value))
-        else: 
+        else:
             raise ValueError('Imcompatible color drop down setting')
 
     @property

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -31,6 +31,15 @@ except:
 
 Horizontal = QtCore.Qt.Orientation.Horizontal
 
+from contextlib import contextmanager
+
+@contextmanager
+def suppress_signals(widget):
+    widget.blockSignals(True)
+    try:
+        yield
+    finally:
+        widget.blockSignals(False)
 
 class Slider(QRangeSlider):
 
@@ -933,7 +942,6 @@ class MainW(QMainWindow):
             self.draw_layer()
             self.update_layer()
         if self.loaded:
-            self.update_plot()
             self.update_layer()
 
     def make_viewbox(self):
@@ -1000,8 +1008,10 @@ class MainW(QMainWindow):
         self.ismanual = np.zeros(0, "bool")
 
         # -- set menus to default -- #
-        self.color = 'RGB'
-        self.view = 'image'
+        with suppress_signals(self.RGBDropDown):
+            self.color = 'RGB'
+        with suppress_signals(self.ViewDropDown):
+            self.view = 'image'
         self.delete_restore()
 
         self.clear_all()
@@ -1505,10 +1515,13 @@ class MainW(QMainWindow):
             self.img.setLevels([0.0, 255.0])
 
         for r in range(3):
-            self.sliders[r].setValue([
-                self.saturation[r][self.currentZ][0],
-                self.saturation[r][self.currentZ][1]
-            ])
+        # setValue on the slider triggers update_plot() so it needs to be suppressed
+            slider = self.sliders[r]
+            with suppress_signals(slider):
+                slider.setValue([
+                    self.saturation[r][self.currentZ][0],
+                    self.saturation[r][self.currentZ][1]
+                ])
         self.win.show()
         self.show()
 
@@ -1864,8 +1877,6 @@ class MainW(QMainWindow):
                 self.saturation.append(self.saturation[0])
                 self.saturation.append(self.saturation[0])
 
-        # self.autobtn.setChecked(True)
-        self.update_plot()
 
 
     def get_model_path(self, custom=False):

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -328,14 +328,24 @@ class MainW(QMainWindow):
         self.l0.addWidget(self.satBox, b, 0, 1, 9)
 
         widget_row = 0
-        # self.view = 0  # 0=image, 1=flowsXY, 2=flowsZ, 3=cellprob
-        self.color = 0  # 0=RGB, 1=gray, 2=R, 3=G, 4=B
         self.RGBDropDown = QComboBox()
+
+        # This is duplication and in the future these things should be tied 
+        # together in a class: 
         self.RGBDropDown.addItems(
             ["RGB", "red=R", "green=G", "blue=B", "gray", "spectral"])
+        self.RGBDropDown.name_map = {
+            "rgb" : "rgb",
+            "red" : "red=r", 
+            "green" : "green=g", 
+            "blue" : "blue=b", 
+            "gray" : "gray", 
+            "spectral": "spectral",
+        }
         self.RGBDropDown.setFont(self.medfont)
         self.RGBDropDown.currentIndexChanged.connect(self.color_choose)
         self.satBoxG.addWidget(self.RGBDropDown, widget_row, 0, 1, 3)
+        self.color = 'RGB'  # 0=RGB, 1=gray, 2=R, 3=G, 4=B
 
         label = QLabel("<p>[&uarr; / &darr; or W/S]</p>")
         label.setFont(self.smallfont)
@@ -663,62 +673,75 @@ class MainW(QMainWindow):
             self.update_plot()
 
     def keyPressEvent(self, event):
+        event.ignore()
         if self.loaded:
             if not (event.modifiers() &
                     (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier |
                      QtCore.Qt.AltModifier) or self.in_stroke):
-                updated = False
                 if len(self.current_point_set) > 0:
                     if event.key() == QtCore.Qt.Key_Return:
                         self.add_set()
+                        event.accept()
+                        return
                 else:
-                    nviews = self.ViewDropDown.count() - 1
-                    nviews += int(
-                        self.ViewDropDown.model().item(self.ViewDropDown.count() -
-                                                       1).isEnabled())
                     if event.key() == QtCore.Qt.Key_X:
                         self.MCheckBox.toggle()
+                        event.accept()
+                        return
                     if event.key() == QtCore.Qt.Key_Z:
                         self.OCheckBox.toggle()
+                        event.accept()
+                        return
                     if event.key() == QtCore.Qt.Key_Left or event.key(
                     ) == QtCore.Qt.Key_A:
                         self.get_prev_image()
+                        event.accept()
+                        return
                     elif event.key() == QtCore.Qt.Key_Right or event.key(
                     ) == QtCore.Qt.Key_D:
                         self.get_next_image()
+                        event.accept()
+                        return
                     elif event.key() == QtCore.Qt.Key_PageDown:
-                        self.go_next_previous_view()
-                        updated = True
+                        self.go_next_previous_dropdown(self.ViewDropDown)
+                        event.accept()
+                        return
                     elif event.key() == QtCore.Qt.Key_PageUp:
-                        self.go_next_previous_view(-1)
-                        updated = True
+                        self.go_next_previous_dropdown(self.ViewDropDown, -1)
+                        event.accept()
+                        return
 
                 # can change background or stroke size if cell not finished
                 if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:
-                    self.color = (self.color - 1) % (6)
-                    self.RGBDropDown.setCurrentIndex(self.color)
+                    self.go_next_previous_dropdown(self.RGBDropDown, -1)
+                    event.accept()
+                    return
                 elif event.key() == QtCore.Qt.Key_Down or event.key(
                 ) == QtCore.Qt.Key_S:
-                    self.color = (self.color + 1) % (6)
-                    self.RGBDropDown.setCurrentIndex(self.color)
+                    self.go_next_previous_dropdown(self.RGBDropDown, 1)
+                    event.accept()
+                    return
                 elif event.key() == QtCore.Qt.Key_R:
-                    if self.color != 1:
-                        self.color = 1
+                    if self.color != 'red':
+                        self.color = 'red'
                     else:
-                        self.color = 0
-                    self.RGBDropDown.setCurrentIndex(self.color)
+                        self.color = 'rgb'
+                    event.accept()
+                    return
                 elif event.key() == QtCore.Qt.Key_G:
-                    if self.color != 2:
-                        self.color = 2
+                    if self.color != 'green':
+                        self.color = 'green'
                     else:
-                        self.color = 0
-                    self.RGBDropDown.setCurrentIndex(self.color)
+                        self.color = 'rgb'
+                    event.accept()
+                    return
                 elif event.key() == QtCore.Qt.Key_B:
-                    if self.color != 3:
-                        self.color = 3
+                    if self.color != 'blue':
+                        self.color = 'blue'
                     else:
-                        self.color = 0
-                    self.RGBDropDown.setCurrentIndex(self.color)
+                        self.color = 'rgb'
+                    event.accept()
+                    return
                 elif (event.key() == QtCore.Qt.Key_Comma or
                       event.key() == QtCore.Qt.Key_Period):
                     count = self.BrushChoose.count()
@@ -729,8 +752,6 @@ class MainW(QMainWindow):
                         gci = min(count - 1, gci + 1)
                     self.BrushChoose.setCurrentIndex(gci)
                     self.brush_choose()
-                if not updated:
-                    self.update_plot()
         if event.key() == QtCore.Qt.Key_Minus or event.key() == QtCore.Qt.Key_Equal:
             self.p0.keyPressEvent(event)
 
@@ -981,10 +1002,8 @@ class MainW(QMainWindow):
         self.ismanual = np.zeros(0, "bool")
 
         # -- set menus to default -- #
-        self.color = 0
-        self.RGBDropDown.setCurrentIndex(self.color)
-        self.ViewDropDown.setCurrentIndex(0)
-        self.ViewDropDown.model().item(self.ViewDropDown.count() - 1).setEnabled(False)
+        self.color = 'RGB'
+        self.view = 'image'
         self.delete_restore()
 
         self.clear_all()
@@ -997,6 +1016,25 @@ class MainW(QMainWindow):
         self.removing_cells_list = []
         self.removing_region = False
         self.remove_roi_obj = None
+
+    @property
+    def color(self):
+        """ Current color mode as a string. Possible values are rgb, red, green, blue, gray, or spectral"""
+        # invert mapping
+        inv_name_map = {v: k for k, v in self.RGBDropDown.name_map.items()} 
+        return inv_name_map[self.RGBDropDown.currentText().lower()].lower()
+    
+    @color.setter
+    def color(self, value: str|int):
+        if isinstance(value, int):
+            self.RGBDropDown.setCurrentIndex(value)
+        elif isinstance(value, str):
+            value = self.RGBDropDown.name_map[value.lower()]
+            items = [self.RGBDropDown.itemText(i).lower() for i in range(self.RGBDropDown.count())]
+            if value in items:
+                self.RGBDropDown.setCurrentIndex(items.index(value))
+        else: 
+            raise ValueError('Imcompatible color drop down setting')
 
     @property
     def view(self):
@@ -1027,6 +1065,11 @@ class MainW(QMainWindow):
                 self.ViewDropDown.setCurrentIndex(items.index(value))
         else: 
             raise ValueError('Incompatible view drop down setting')
+        
+    def enable_restored_view(self, enable: bool):
+        items = [self.ViewDropDown.itemText(i) for i in range(self.ViewDropDown.count())]
+        self.ViewDropDown.model().item(items.index('restored')).setEnabled(enable)
+
 
     def delete_restore(self):
         """ delete restored imgs but don't reset settings """
@@ -1041,9 +1084,9 @@ class MainW(QMainWindow):
     def clear_restore(self):
         """ delete restored imgs and reset settings """
         print("GUI_INFO: clearing restored image")
-        self.ViewDropDown.model().item(self.ViewDropDown.count() - 1).setEnabled(False)
-        if self.ViewDropDown.currentIndex() == self.ViewDropDown.count() - 1:
-            self.ViewDropDown.setCurrentIndex(0)
+        self.enable_restored_view(False)
+        if self.view == 'restored': 
+            self.view = 'image'
         self.delete_restore()
         self.restore = None
         self.ratio = 1.
@@ -1371,12 +1414,11 @@ class MainW(QMainWindow):
         items = self.win.scene().items(pos)
 
     def color_choose(self):
-        self.color = self.RGBDropDown.currentIndex()
         self.view = 'image'
         self.update_plot()
 
     def update_plot(self):
-        self.view = self.ViewDropDown.currentIndex()
+
         self.Ly, self.Lx, _ = self.stack[self.currentZ].shape
 
         is_image_view = self.view == 'image'
@@ -1387,13 +1429,14 @@ class MainW(QMainWindow):
             'cellprob' : 1,
             'gradZ' : 4,
         }
+        rgb_list = ['red', 'green', 'blue']
 
         if is_image_view or is_restored_view:
             if is_image_view:
                 image = self.stack[self.currentZ]
             else: 
-                self.stack_filtered[self.currentZ]
-            if self.color == 0:
+                image = self.stack_filtered[self.currentZ]
+            if self.color == 'rgb':
                 self.img.setImage(image, autoLevels=False, lut=None)
                 if self.nchan > 1:
                     levels = np.array([
@@ -1404,15 +1447,16 @@ class MainW(QMainWindow):
                     self.img.setLevels(levels)
                 else:
                     self.img.setLevels(self.saturation[0][self.currentZ])
-            elif self.color > 0 and self.color < 4:
+            elif self.color in rgb_list:
+                color_index = rgb_list.index(self.color)
                 if self.nchan > 1:
-                    image = image[:, :, self.color - 1]
-                self.img.setImage(image, autoLevels=False, lut=self.cmap[self.color])
+                    image = image[:, :, color_index]
+                self.img.setImage(image, autoLevels=False, lut=self.cmap[color_index+1])
                 if self.nchan > 1:
-                    self.img.setLevels(self.saturation[self.color - 1][self.currentZ])
+                    self.img.setLevels(self.saturation[color_index][self.currentZ])
                 else:
                     self.img.setLevels(self.saturation[0][self.currentZ])
-            elif self.color == 4:
+            elif self.color == 'gray':
                 if self.nchan > 1:
                     # exclude channels with no data:
                     ranges = np.ptp(image, tuple(range(image.ndim-1)))
@@ -1421,7 +1465,7 @@ class MainW(QMainWindow):
                     image = image.mean(axis=-1)
                 self.img.setImage(image, autoLevels=False, lut=None)
                 self.img.setLevels(self.saturation[0][self.currentZ])
-            elif self.color == 5:
+            elif self.color == 'spectral':
                 if self.nchan > 1:
                     image = image.mean(axis=-1)
                 self.img.setImage(image, autoLevels=False, lut=self.cmap[0])
@@ -1752,9 +1796,8 @@ class MainW(QMainWindow):
                     img_norm[..., c] /= (img_norm_max - img_norm_min)
             img_norm *= 255
             self.stack_filtered = img_norm
-            self.ViewDropDown.model().item(self.ViewDropDown.count() -
-                                           1).setEnabled(True)
-            self.ViewDropDown.setCurrentIndex(self.ViewDropDown.count() - 1)
+            self.enable_restored_view(True)
+            self.view = 'restored'
         else:
             img_norm = self.stack if self.restore is None or self.restore == "filter" else self.stack_filtered
 
@@ -2048,26 +2091,26 @@ class MainW(QMainWindow):
             print("ERROR: %s" % e)
 
 
-    def go_next_previous_view(self, increment=1):
-        """ Go to the next view using `increment` """
+    def go_next_previous_dropdown(self, dropdown, increment=1):
+        """ Go to the next dropdown element using `increment` """
 
         # skip disabled views
-        num_items = self.ViewDropDown.count()
+        num_items = dropdown.count()
         enabled = []
         for i in range(num_items):
-            enabled.append(self.ViewDropDown.model().item(i).isEnabled())
+            enabled.append(dropdown.model().item(i).isEnabled())
 
         if not any(enabled):
-            self.logger.error('No available views are enabled. Cannot adjust view.')
+            self.logger.error('No available dropdown items are enabled. Cannot adjust view.')
             return 
 
-        idx = self.ViewDropDown.currentIndex() + increment
+        idx = dropdown.currentIndex() + increment
 
         for _ in range(num_items):
             idx %= num_items
             if enabled[idx]:
-                self.ViewDropDown.setCurrentIndex(idx)
+                dropdown.setCurrentIndex(idx)
                 return
             idx += increment
 
-        self.logger.error('Could not find an emabled view.')
+        self.logger.error('Could not find an emabled dropdown item.')

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1506,7 +1506,7 @@ class MainW(QMainWindow):
             self.img.setLevels([0.0, 255.0])
 
         for r in range(3):
-        # setValue on the slider triggers update_plot() so it needs to be suppressed
+            # setValue on the slider triggers update_plot() so it needs to be suppressed
             slider = self.sliders[r]
             with QtCore.QSignalBlocker(slider):
                 slider.setValue([
@@ -1867,7 +1867,6 @@ class MainW(QMainWindow):
             if img_norm.shape[-1] == 1:
                 self.saturation.append(self.saturation[0])
                 self.saturation.append(self.saturation[0])
-
 
 
     def get_model_path(self, custom=False):

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -208,6 +208,10 @@ class MainW_3d(MainW):
         self.l0.addWidget(self.orthobtn, b, 0, 1, 2)
         self.orthobtn.toggled.connect(self.toggle_ortho)
 
+        # connect the ortho masks and outlines: 
+        self.MCheckBox.toggled.connect(self.update_ortho)
+        self.OCheckBox.toggled.connect(self.update_ortho)
+
         label = QLabel("dz:")
         label.setAlignment(QtCore.Qt.AlignRight | QtCore.Qt.AlignVCenter)
         label.setFont(self.medfont)

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -445,10 +445,14 @@ class MainW_3d(MainW):
                     zmin, zmax = z - self.dz, z + self.dz
             self.zc = z - zmin
             self.update_crosshairs()
-            if self.view == 0 or self.view == 4:
+
+            is_image_view = self.view == 'image'
+            is_restored_view = self.view == 'restored'
+
+            if is_image_view or is_restored_view:
                 for j in range(2):
                     if j == 0:
-                        if self.view == 0:
+                        if is_image_view:
                             image = self.stack[zmin:zmax, :, x].transpose(1, 0, 2).copy()
                         else:
                             image = self.stack_filtered[zmin:zmax, :,
@@ -456,7 +460,7 @@ class MainW_3d(MainW):
                     else:
                         image = self.stack[
                             zmin:zmax,
-                            y, :].copy() if self.view == 0 else self.stack_filtered[zmin:zmax,
+                            y, :].copy() if is_image_view else self.stack_filtered[zmin:zmax,
                                                                              y, :].copy()
                     if self.nchan == 1:
                         # show single channel
@@ -613,11 +617,9 @@ class MainW_3d(MainW):
                         self.scroll.setValue(self.currentZ)
                         updated = True
                     elif event.key() == QtCore.Qt.Key_PageDown:
-                        self.view = (self.view + 1) % (nviews)
-                        self.ViewDropDown.setCurrentIndex(self.view)
+                        self.go_next_previous_view()
                     elif event.key() == QtCore.Qt.Key_PageUp:
-                        self.view = (self.view - 1) % (nviews)
-                        self.ViewDropDown.setCurrentIndex(self.view)
+                        self.go_next_previous_view(-1)
 
                 # can change background or stroke size if cell not finished
                 if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -449,6 +449,8 @@ class MainW_3d(MainW):
             is_image_view = self.view == 'image'
             is_restored_view = self.view == 'restored'
 
+            rgb_list = ['red', 'green', 'blue']
+
             if is_image_view or is_restored_view:
                 for j in range(2):
                     if j == 0:
@@ -477,18 +479,19 @@ class MainW_3d(MainW):
                         else:
                             self.imgOrtho[j].setLevels(
                                 self.saturation[0][self.currentZ])
-                    elif self.color > 0 and self.color < 4:
+                    elif self.color in rgb_list:
+                        color_index = rgb_list.index(self.color)
                         if self.nchan > 1:
-                            image = image[..., self.color - 1]
+                            image = image[..., color_index]
                         self.imgOrtho[j].setImage(image, autoLevels=False,
-                                                  lut=self.cmap[self.color])
+                                                  lut=self.cmap[color_index + 1])
                         if self.nchan > 1:
                             self.imgOrtho[j].setLevels(
-                                self.saturation[self.color - 1][self.currentZ])
+                                self.saturation[color_index][self.currentZ])
                         else:
                             self.imgOrtho[j].setLevels(
                                 self.saturation[0][self.currentZ])
-                    elif self.color == 4:
+                    elif self.color == 'gray':
                         if image.ndim > 2:
                             # exclude blank channels: 
                             ranges = np.ptp(image, tuple(range(image.ndim-1)))
@@ -497,7 +500,7 @@ class MainW_3d(MainW):
                             image = image.astype("float32").mean(axis=2).astype("uint8")
                         self.imgOrtho[j].setImage(image, autoLevels=False, lut=None)
                         self.imgOrtho[j].setLevels(self.saturation[0][self.currentZ])
-                    elif self.color == 5:
+                    elif self.color == 'spectral':
                         if image.ndim > 2:
                             image = image.astype("float32").mean(axis=2).astype("uint8")
                         self.imgOrtho[j].setImage(image, autoLevels=False,

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -583,87 +583,93 @@ class MainW_3d(MainW):
         self.show()
 
     def keyPressEvent(self, event):
+        event.ignore()
         if self.loaded:
             if not (event.modifiers() &
                     (QtCore.Qt.ControlModifier | QtCore.Qt.ShiftModifier |
                      QtCore.Qt.AltModifier) or self.in_stroke):
-                updated = False
                 if len(self.current_point_set) > 0:
                     if event.key() == QtCore.Qt.Key_Return:
                         self.add_set()
+                        event.accept()
+                        return
                     if self.NZ > 1:
                         if event.key() == QtCore.Qt.Key_Left:
                             self.currentZ = max(0, self.currentZ - 1)
                             self.scroll.setValue(self.currentZ)
-                            updated = True
+                            event.accept()
+                            return
                         elif event.key() == QtCore.Qt.Key_Right:
                             self.currentZ = min(self.NZ - 1, self.currentZ + 1)
                             self.scroll.setValue(self.currentZ)
-                            updated = True
+                            event.accept()
+                            return
                 else:
-                    nviews = self.ViewDropDown.count() - 1
-                    nviews += int(
-                        self.ViewDropDown.model().item(self.ViewDropDown.count() -
-                                                       1).isEnabled())
-                    if event.key() == QtCore.Qt.Key_X:
-                        self.MCheckBox.toggle()
-                    if event.key() == QtCore.Qt.Key_Z:
-                        self.OCheckBox.toggle()
+                    # nviews = self.ViewDropDown.count() - 1
+                    # nviews += int(
+                    #     self.ViewDropDown.model().item(self.ViewDropDown.count() -
+                    #                                    1).isEnabled())
+                    # if event.key() == QtCore.Qt.Key_X:
+                    #     self.MCheckBox.toggle()
+                    # if event.key() == QtCore.Qt.Key_Z:
+                    #     self.OCheckBox.toggle()
                     if event.key() == QtCore.Qt.Key_Left or event.key(
                     ) == QtCore.Qt.Key_A:
                         self.currentZ = max(0, self.currentZ - 1)
                         self.scroll.setValue(self.currentZ)
-                        updated = True
+                        event.accept()
                     elif event.key() == QtCore.Qt.Key_Right or event.key(
                     ) == QtCore.Qt.Key_D:
                         self.currentZ = min(self.NZ - 1, self.currentZ + 1)
                         self.scroll.setValue(self.currentZ)
-                        updated = True
-                    elif event.key() == QtCore.Qt.Key_PageDown:
-                        self.go_next_previous_view()
-                    elif event.key() == QtCore.Qt.Key_PageUp:
-                        self.go_next_previous_view(-1)
+                        event.accept()
+                    # elif event.key() == QtCore.Qt.Key_PageDown:
+                    #     self.go_next_previous_view()
+                    # elif event.key() == QtCore.Qt.Key_PageUp:
+                    #     self.go_next_previous_view(-1)
 
                 # can change background or stroke size if cell not finished
-                if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:
-                    self.color = (self.color - 1) % (6)
-                    self.RGBDropDown.setCurrentIndex(self.color)
-                elif event.key() == QtCore.Qt.Key_Down or event.key(
-                ) == QtCore.Qt.Key_S:
-                    self.color = (self.color + 1) % (6)
-                    self.RGBDropDown.setCurrentIndex(self.color)
-                elif event.key() == QtCore.Qt.Key_R:
-                    if self.color != 1:
-                        self.color = 1
-                    else:
-                        self.color = 0
-                    self.RGBDropDown.setCurrentIndex(self.color)
-                elif event.key() == QtCore.Qt.Key_G:
-                    if self.color != 2:
-                        self.color = 2
-                    else:
-                        self.color = 0
-                    self.RGBDropDown.setCurrentIndex(self.color)
-                elif event.key() == QtCore.Qt.Key_B:
-                    if self.color != 3:
-                        self.color = 3
-                    else:
-                        self.color = 0
-                    self.RGBDropDown.setCurrentIndex(self.color)
-                elif (event.key() == QtCore.Qt.Key_Comma or
-                      event.key() == QtCore.Qt.Key_Period):
-                    count = self.BrushChoose.count()
-                    gci = self.BrushChoose.currentIndex()
-                    if event.key() == QtCore.Qt.Key_Comma:
-                        gci = max(0, gci - 1)
-                    else:
-                        gci = min(count - 1, gci + 1)
-                    self.BrushChoose.setCurrentIndex(gci)
-                    self.brush_choose()
-                if not updated:
-                    self.update_plot()
+                # if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:
+                #     self.color = (self.color - 1) % (6)
+                #     self.RGBDropDown.setCurrentIndex(self.color)
+                # elif event.key() == QtCore.Qt.Key_Down or event.key(
+                # ) == QtCore.Qt.Key_S:
+                #     self.color = (self.color + 1) % (6)
+                #     self.RGBDropDown.setCurrentIndex(self.color)
+                # elif event.key() == QtCore.Qt.Key_R:
+                #     if self.color != 1:
+                #         self.color = 1
+                #     else:
+                #         self.color = 0
+                #     self.RGBDropDown.setCurrentIndex(self.color)
+                # elif event.key() == QtCore.Qt.Key_G:
+                #     if self.color != 2:
+                #         self.color = 2
+                #     else:
+                #         self.color = 0
+                #     self.RGBDropDown.setCurrentIndex(self.color)
+                # elif event.key() == QtCore.Qt.Key_B:
+                #     if self.color != 3:
+                #         self.color = 3
+                #     else:
+                #         self.color = 0
+                #     self.RGBDropDown.setCurrentIndex(self.color)
+                # elif (event.key() == QtCore.Qt.Key_Comma or
+                #       event.key() == QtCore.Qt.Key_Period):
+                #     count = self.BrushChoose.count()
+                #     gci = self.BrushChoose.currentIndex()
+                #     if event.key() == QtCore.Qt.Key_Comma:
+                #         gci = max(0, gci - 1)
+                #     else:
+                #         gci = min(count - 1, gci + 1)
+                #     self.BrushChoose.setCurrentIndex(gci)
+                #     self.brush_choose()
         if event.key() == QtCore.Qt.Key_Minus or event.key() == QtCore.Qt.Key_Equal:
             self.p0.keyPressEvent(event)
+
+        # propagate unhandled events to MainW                                                                                   
+        if not event.isAccepted():
+            super().keyPressEvent(event)   
 
     def update_ztext(self):
         zpos = self.currentZ

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -605,67 +605,22 @@ class MainW_3d(MainW):
                             event.accept()
                             return
                 else:
-                    # nviews = self.ViewDropDown.count() - 1
-                    # nviews += int(
-                    #     self.ViewDropDown.model().item(self.ViewDropDown.count() -
-                    #                                    1).isEnabled())
-                    # if event.key() == QtCore.Qt.Key_X:
-                    #     self.MCheckBox.toggle()
-                    # if event.key() == QtCore.Qt.Key_Z:
-                    #     self.OCheckBox.toggle()
                     if event.key() == QtCore.Qt.Key_Left or event.key(
                     ) == QtCore.Qt.Key_A:
                         self.currentZ = max(0, self.currentZ - 1)
                         self.scroll.setValue(self.currentZ)
                         event.accept()
+                        return
                     elif event.key() == QtCore.Qt.Key_Right or event.key(
                     ) == QtCore.Qt.Key_D:
                         self.currentZ = min(self.NZ - 1, self.currentZ + 1)
                         self.scroll.setValue(self.currentZ)
                         event.accept()
-                    # elif event.key() == QtCore.Qt.Key_PageDown:
-                    #     self.go_next_previous_view()
-                    # elif event.key() == QtCore.Qt.Key_PageUp:
-                    #     self.go_next_previous_view(-1)
-
-                # can change background or stroke size if cell not finished
-                # if event.key() == QtCore.Qt.Key_Up or event.key() == QtCore.Qt.Key_W:
-                #     self.color = (self.color - 1) % (6)
-                #     self.RGBDropDown.setCurrentIndex(self.color)
-                # elif event.key() == QtCore.Qt.Key_Down or event.key(
-                # ) == QtCore.Qt.Key_S:
-                #     self.color = (self.color + 1) % (6)
-                #     self.RGBDropDown.setCurrentIndex(self.color)
-                # elif event.key() == QtCore.Qt.Key_R:
-                #     if self.color != 1:
-                #         self.color = 1
-                #     else:
-                #         self.color = 0
-                #     self.RGBDropDown.setCurrentIndex(self.color)
-                # elif event.key() == QtCore.Qt.Key_G:
-                #     if self.color != 2:
-                #         self.color = 2
-                #     else:
-                #         self.color = 0
-                #     self.RGBDropDown.setCurrentIndex(self.color)
-                # elif event.key() == QtCore.Qt.Key_B:
-                #     if self.color != 3:
-                #         self.color = 3
-                #     else:
-                #         self.color = 0
-                #     self.RGBDropDown.setCurrentIndex(self.color)
-                # elif (event.key() == QtCore.Qt.Key_Comma or
-                #       event.key() == QtCore.Qt.Key_Period):
-                #     count = self.BrushChoose.count()
-                #     gci = self.BrushChoose.currentIndex()
-                #     if event.key() == QtCore.Qt.Key_Comma:
-                #         gci = max(0, gci - 1)
-                #     else:
-                #         gci = min(count - 1, gci + 1)
-                #     self.BrushChoose.setCurrentIndex(gci)
-                #     self.brush_choose()
+                        return
         if event.key() == QtCore.Qt.Key_Minus or event.key() == QtCore.Qt.Key_Equal:
             self.p0.keyPressEvent(event)
+            event.accept()
+            return
 
         # propagate unhandled events to MainW                                                                                   
         if not event.isAccepted():

--- a/cellpose/gui/gui3d.py
+++ b/cellpose/gui/gui3d.py
@@ -467,7 +467,7 @@ class MainW_3d(MainW):
                     if self.nchan == 1:
                         # show single channel
                         image = image[..., 0]
-                    if self.color == 0:
+                    if self.color == 'rgb':
                         self.imgOrtho[j].setImage(image, autoLevels=False, lut=None)
                         if self.nchan > 1:
                             levels = np.array([

--- a/cellpose/gui/guiparts.py
+++ b/cellpose/gui/guiparts.py
@@ -171,11 +171,8 @@ class FilterButton(QPushButton):
                 return
             parent.restore = self.model_type
             parent.compute_saturation()
-        # elif self.model_type != "none":
-        #     parent.compute_denoise_model(model_type=self.model_type)
         else:
             parent.clear_restore()
-        # parent.set_restore_button()
 
 
 class ObservableVariable(QtCore.QObject):

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -121,7 +121,11 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
             else:
                 image = None
             _load_seg(parent, manual_file, image=image, image_file=filename,
-                      load_3D=load_3D)
+                        load_3D=load_3D)
+            if len(np.unique(image[..., 1:])) == 1:
+                parent.color = 'gray' # updates the plot automatically
+            else:
+                parent.update_plot()
             return
         elif parent.autoloadMasks.isChecked():
             mask_file = os.path.splitext(filename)[0] + "_masks" + os.path.splitext(
@@ -153,9 +157,10 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
 
     # check if gray and adjust viewer:
     if len(np.unique(image[..., 1:])) == 1:
-        parent.color = 'gray'
+        parent.color = 'gray' # triggers update_plot
+    else:
+        parent.update_plot()
 
-        
 def _initialize_images(parent, image, load_3D=False):
     """ format image for GUI
 

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -202,23 +202,13 @@ def _initialize_images(parent, image, load_3D=False):
         parent.Lyr, parent.Lxr = parent.Ly, parent.Lx
     parent.clear_all()
 
-    if not hasattr(parent, "stack_filtered") and parent.restore:
-        print("GUI_INFO: no 'img_restore' found, applying current settings")
-        parent.compute_restore()
-
     if parent.autobtn.isChecked():
         if parent.restore is None or parent.restore != "filter":
             print(
                 "GUI_INFO: normalization checked: computing saturation levels (and optionally filtered image)"
             )
             parent.compute_saturation()
-    # elif len(parent.saturation) != parent.NZ:
-    #     parent.saturation = []
-    #     for r in range(3):
-    #         parent.saturation.append([])
-    #         for n in range(parent.NZ):
-    #             parent.saturation[-1].append([0, 255])
-    #         parent.sliders[r].setValue([0, 255])
+
     parent.compute_scale()
     parent.track_changes = []
 

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -323,7 +323,6 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
 
     if "current_channel" in dat:
         parent.color = (dat["current_channel"] + 2) % 5
-        parent.RGBDropDown.setCurrentIndex(parent.color)
 
     if "flows" in dat:
         parent.flows = dat["flows"]

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -153,9 +153,7 @@ def _load_image(parent, filename=None, load_seg=True, load_3D=False):
 
     # check if gray and adjust viewer:
     if len(np.unique(image[..., 1:])) == 1:
-        parent.color = 4
-        parent.RGBDropDown.setCurrentIndex(4) # gray
-        parent.update_plot()
+        parent.color = 'gray'
 
         
 def _initialize_images(parent, image, load_3D=False):
@@ -389,7 +387,6 @@ def _load_masks(parent, filename=None):
     del masks
     gc.collect()
     parent.update_layer()
-    parent.update_plot()
 
 
 def _masks_to_gui(parent, masks, outlines=None, colors=None):


### PR DESCRIPTION
Moved the main gui's `.view` and `.color` attributes to a stateless property that just looks at the actual drop down state. Setting the attribute/property is backwards compatible to use indexes or strings for convenience.  

Also, using more intuitive variables for the update_plot function. 

Also, removed duplicated code from 3d GUI `keyPressEvent` that is now delegated to `MainW` class. 

Fix gradZ displaying in 3d GUI. 

- [x] GUI testing protocol 
- [x] passing CI tests 