### PR TITLE
make merging cells faster

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1208,10 +1208,17 @@ class MainW(QMainWindow):
                 vr1, vc1 = np.nonzero(self.outpix[z] == self.selected)
                 cell0 = set(zip(ar0, ac0))
                 outline1 = set(zip(vr1, vc1))
-                touching = cell0.intersection(outline1)
+                #touching = cell0.intersection(outline1)
+                pixels0 = set(zip(ar0, ac0))
+                touching = any(
+                    (r0, c0) in pixels0
+                    for r1, c1 in zip(ar1, ac1)
+                    for r0 in range(r1 - 2, r1 + 3)
+                    for c0 in range(c1 - 2, c1 + 3)
+                )
                 self.outpix[z, vr0, vc0] = 0
                 self.outpix[z, vr1, vc1] = 0
-                if len(touching) > 0:
+                if touching:
                     mask = np.zeros((np.ptp(ar) + 4, np.ptp(ac) + 4), np.uint8)
                     mask[ar - ar.min() + 2, ac - ac.min() + 2] = 1
                     contours = cv2.findContours(mask, cv2.RETR_EXTERNAL,

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1202,15 +1202,16 @@ class MainW(QMainWindow):
             for z in range(self.NZ):
                 ar0, ac0 = np.nonzero(self.cellpix[z] == self.prev_selected)
                 ar1, ac1 = np.nonzero(self.cellpix[z] == self.selected)
-                touching = np.logical_and((ar0[:, np.newaxis] - ar1) < 3,
-                                          (ac0[:, np.newaxis] - ac1) < 3).sum()
                 ar = np.hstack((ar0, ar1))
                 ac = np.hstack((ac0, ac1))
                 vr0, vc0 = np.nonzero(self.outpix[z] == self.prev_selected)
                 vr1, vc1 = np.nonzero(self.outpix[z] == self.selected)
+                cell0 = set(zip(ar0, ac0))
+                outline1 = set(zip(vr1, vc1))
+                touching = cell0.intersection(outline1)
                 self.outpix[z, vr0, vc0] = 0
                 self.outpix[z, vr1, vc1] = 0
-                if touching > 0:
+                if len(touching) > 0:
                     mask = np.zeros((np.ptp(ar) + 4, np.ptp(ac) + 4), np.uint8)
                     mask[ar - ar.min() + 2, ac - ac.min() + 2] = 1
                     contours = cv2.findContours(mask, cv2.RETR_EXTERNAL,


### PR DESCRIPTION
The previous check for wether cells were touching:
```
touching = np.logical_and((ar0[:, np.newaxis] - ar1) < 3,
                          (ac0[:, np.newaxis] - ac1) < 3).sum()
```
This was wrong because of missing np.abs() calls and also slow, because it computes two large matrices.
Maybe related to #1148