### PR TITLE
Enable rescaling when resample=False

### DIFF
--- a/cellpose/models.py
+++ b/cellpose/models.py
@@ -372,13 +372,12 @@ class CellposeModel():
                                 tile_overlap=tile_overlap, 
                                 bsize=bsize
                                 )
-            if resample:
-                if rescale != 1.0 or Lz != yf.shape[0]:
-                    models_logger.info("resizing 3D flows and cellprobl to original image size")
-                    if rescale != 1.0:
-                        yf = transforms.resize_image(yf, Ly=Ly, Lx=Lx)
-                    if Lz != yf.shape[0]:
-                        yf = transforms.resize_image(yf.transpose(1, 0, 2, 3), Ly=Lz, Lx=Lx).transpose(1, 0, 2, 3)
+            if rescale != 1.0 or Lz != yf.shape[0]:
+                models_logger.info("resizing 3D flows and cellprobl to original image size")
+                if rescale != 1.0:
+                    yf = transforms.resize_image(yf, Ly=Ly, Lx=Lx)
+                if Lz != yf.shape[0]:
+                    yf = transforms.resize_image(yf.transpose(1, 0, 2, 3), Ly=Lz, Lx=Lx).transpose(1, 0, 2, 3)
             cellprob = yf[..., -1]
             dP = yf[..., :-1].transpose((3, 0, 1, 2))
         else:
@@ -386,9 +385,8 @@ class CellposeModel():
                                 batch_size=batch_size,  
                                 tile_overlap=tile_overlap, 
                                 rsz=rescale if rescale !=1.0 else None)
-            if resample:
-                if rescale != 1.0:
-                    yf = transforms.resize_image(yf, shape[1], shape[2])
+            if rescale != 1.0:
+                yf = transforms.resize_image(yf, shape[1], shape[2])
             cellprob = yf[..., -1]
             dP = yf[..., -3:-1].transpose((3, 0, 1, 2))
         


### PR DESCRIPTION
I think there was some [back](https://github.com/MouseLand/cellpose/commit/d1ac88ffc65f4b87e6ebea1f67ac8ab73ad6bf8a#diff-288cdea0dc8425516336e7b78c9ec33ec151fdb0f2cf01ec08217f332a1e44ffR254) and [forth](https://github.com/MouseLand/cellpose/commit/4669b57bc2a7a76200347b59b594a35e0c7b9fd1#diff-288cdea0dc8425516336e7b78c9ec33ec151fdb0f2cf01ec08217f332a1e44ffR255) about the interaction of `diameter`, `resample` and the `resize`-ing happening under the hood. This meant that masks are sometimes returned with dimensions different to the input.

```python
import cellpose
import cellpose.models
import numpy as np

img = np.random.rand(100,100)
model = cellpose.models.CellposeModel()

masks, _, _ = model.eval(img, diameter=10, resample=False)
print(masks.shape)
#> (300, 300) # <- this is the issue

# When using resample=True the dimensions are as expected
masks, _, _ = model.eval(img, diameter=10, resample=True)
print(masks.shape)
#> (100, 100)
