### PR TITLE
Fix model removal from GUI

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -41,7 +41,7 @@ def _add_model(parent, filename=None, load_model=True):
 
     for ind, model_string in enumerate(parent.model_strings[:-1]):
         if model_string == fname:
-            _remove_model(parent, ind=ind + 1, verbose=False)
+            _remove_model(parent, ind=ind + 1)
 
     parent.ModelChooseC.setCurrentIndex(len(parent.model_strings))
     if load_model:

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -48,7 +48,7 @@ def _add_model(parent, filename=None, load_model=True):
         parent.model_choose(custom=True)
 
 
-def _remove_model(parent, ind=None, verbose=True):
+def _remove_model(parent, ind=None):
     if ind is None:
         ind = parent.ModelChooseC.currentIndex()
     if ind > 0:

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -56,6 +56,7 @@ def _remove_model(parent, ind=None):
         parent.ModelChooseC.removeItem(ind)
         # remove model from txt path
         remove_model(modelstr)
+        parent.model_strings.remove(modelstr)
         if len(parent.model_strings) > 0:
             parent.ModelChooseC.setCurrentIndex(len(parent.model_strings))
         else:

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -52,11 +52,9 @@ def _remove_model(parent, ind=None, verbose=True):
     if ind is None:
         ind = parent.ModelChooseC.currentIndex()
     if ind > 0:
-        ind -= 1
-        parent.ModelChooseC.removeItem(ind + 1)
-        del parent.model_strings[ind]
-        # remove model from txt path
         modelstr = parent.ModelChooseC.currentText()
+        parent.ModelChooseC.removeItem(ind)
+        # remove model from txt path
         remove_model(modelstr)
         if len(parent.model_strings) > 0:
             parent.ModelChooseC.setCurrentIndex(len(parent.model_strings))

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -336,10 +336,9 @@ def remove_model(filename, delete=False):
     filename = os.path.split(filename)[-1]
     from . import models
     model_strings = models.get_user_models()
-    try:
-        model_strings.remove(filename)
-    except ValueError as err:
+    if filename not in model_strings:
         raise ValueError(f'filename not found: {filename}')
+    model_strings.remove(filename)
     if len(model_strings) > 0:
         with open(models.MODEL_LIST_PATH, "w") as textfile:
             for fname in model_strings:

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -347,10 +347,10 @@ def remove_model(filename, delete=False):
         # write empty file
         textfile = open(models.MODEL_LIST_PATH, "w")
         textfile.close()
-    print(f"{filename} removed from custom model list")
+    io_logger.info(f"{filename} removed from custom model list")
     if delete:
-        os.remove(os.fspath(models.MODEL_DIR.joinpath(fname)))
-        print("model deleted")
+        os.remove(os.fspath(models.MODEL_DIR.joinpath(filename)))
+        io_logger.info(f"{filename} model deleted from disk")
 
 
 def add_model(filename):

--- a/cellpose/io.py
+++ b/cellpose/io.py
@@ -336,6 +336,10 @@ def remove_model(filename, delete=False):
     filename = os.path.split(filename)[-1]
     from . import models
     model_strings = models.get_user_models()
+    try:
+        model_strings.remove(filename)
+    except ValueError as err:
+        raise ValueError(f'filename not found: {filename}')
     if len(model_strings) > 0:
         with open(models.MODEL_LIST_PATH, "w") as textfile:
             for fname in model_strings:


### PR DESCRIPTION
User models wouldn't delete from the GUI after restarting. The `gui_models.txt` file in `.cellpose/models/` wasn't correctly updating. 


Resolves #1397