### PR TITLE
Fix npy channel

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1018,7 +1018,7 @@ class MainW(QMainWindow):
         self.remove_roi_obj = None
 
     @property
-    def color(self):
+    def color(self) -> str:
         """Current color display mode as a lowercase string.
 
         Reflects the current selection of the RGBDropDown widget. Possible

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -329,7 +329,13 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
             parent.ismanual = dat["ismanual"]
 
     if "current_channel" in dat:
-        parent.color = (dat["current_channel"] + 2) % 5
+        color = dat['current_channel']
+
+        # color updated to strings, force int channels to rgb for backwards compatibility
+        if isinstance(color, int):
+            parent.color = 'rgb'
+        elif isinstance(color, str):
+            parent.color = color
 
     if "flows" in dat:
         parent.flows = dat["flows"]
@@ -559,7 +565,7 @@ def _save_sets(parent):
                 parent.cellcolors[1:],
             "masks":
                 parent.cellpix,
-            "current_channel": (parent.color - 2) % 5,
+            "current_channel": parent.color,
             "filename":
                 parent.filename,
             "flows":

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -329,14 +329,11 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
             parent.ismanual = dat["ismanual"]
 
     if "current_channel" in dat:
+        # saved as int, loading int is built into .color property
         color = dat['current_channel']
-
-        # old .npy files stored channel as int; default to 'rgb'
-        if isinstance(color, int):
-            parent.logger.warning('ignoring `current_channel` key in .npy because it is int')
-            parent.color = 'rgb'
-        elif isinstance(color, str):
-            parent.color = color
+        if isinstance(color, tuple):
+            color = color[0]
+        parent.color = color
 
     if "flows" in dat:
         parent.flows = dat["flows"]
@@ -559,6 +556,8 @@ def _save_sets(parent):
     flow_threshold = parent.segmentation_settings.flow_threshold
     cellprob_threshold = parent.segmentation_settings.cellprob_threshold
 
+    # use ints instead of strings for backwards compatibility with old _seg.npy files
+    color_int = list(parent.RGBDropDown.name_map.keys()).index(parent.color)
     if parent.NZ > 1:
         dat = {
             "outlines":
@@ -567,7 +566,7 @@ def _save_sets(parent):
                 parent.cellcolors[1:],
             "masks":
                 parent.cellpix,
-            "current_channel": parent.color,
+            "current_channel": color_int,
             "filename":
                 parent.filename,
             "flows":

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -331,8 +331,9 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
     if "current_channel" in dat:
         color = dat['current_channel']
 
-        # color updated to strings, force int channels to rgb for backwards compatibility
+        # old .npy files stored channel as int; default to 'rgb'
         if isinstance(color, int):
+            parent.logger.warning('ignoring `current_channel` key in .npy because it is int')
             parent.color = 'rgb'
         elif isinstance(color, str):
             parent.color = color

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -362,6 +362,7 @@ def _load_seg(parent, filename=None, image=None, image_file=None, load_3D=False)
 
     parent.enable_buttons()
     parent.update_layer()
+    parent.update_plot()
     del dat
     gc.collect()
 


### PR DESCRIPTION
Changing the `MainW.color` from `int` to `str` caused loading/saving .npy files to fail when loading `'current_channel'`. Added backwards-compatible check that allows old .npy files to be opened with new cellpose versions. In that case, the behavior is to set default `'current_channel'` to RGB. 

Also ensured GUI loads image with `update_plot()` when loading .npy file. 

- [ ] GUI testing protocol
- [ ] GH tests
- [x] Mac/ubuntu tests