### PR TITLE
Add SLURM cluster support to distributed_segmentation

### DIFF
--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -1,4 +1,5 @@
 # stdlib imports
+import contextlib
 import os, getpass, datetime, pathlib, tempfile, functools, glob
 
 # non-stdlib core dependencies
@@ -145,6 +146,34 @@ def _remove_config_file(
     if os.path.exists(config_path): os.remove(config_path)
 
 
+#----------------------- helpers ---------------------------------------------#
+def _parse_memory_mb(memory):
+    """Accept memory as int (MB) or str like '125000', '125GB', '125 GiB'
+    and return an integer in megabytes. Used by the SLURM cluster wrapper
+    to pass the right format to both dask (string with unit) and to
+    SLURM's --mem (integer MB)."""
+    if isinstance(memory, (int, np.integer)):
+        return int(memory)
+    s = str(memory).strip().lower().replace(" ", "")
+    # strip optional 'b' (so '125gb' and '125g' both work)
+    if s.endswith("ib"):
+        s = s[:-2]
+        binary = True
+    elif s.endswith("b"):
+        s = s[:-1]
+        binary = False
+    else:
+        binary = False
+    units = {"k": 1, "m": 1, "g": 1000, "t": 1000_000}
+    units_bin = {"k": 1, "m": 1, "g": 1024, "t": 1024 * 1024}
+    if s and s[-1] in "kmgt":
+        n = float(s[:-1])
+        mul = (units_bin if binary else units)[s[-1]]
+        return int(round(n * mul))
+    # plain number → already MB
+    return int(round(float(s)))
+
+
 #----------------------- clusters --------------------------------------------#
 class myLocalCluster(distributed.LocalCluster):
     """
@@ -213,6 +242,224 @@ class myLocalCluster(distributed.LocalCluster):
             _remove_config_file(self.config_name)
         self.client.close()
         super().__exit__(exc_type, exc_value, traceback)
+
+
+class slurmCluster(dask_jobqueue.SLURMCluster):
+    """
+    Thin wrapper around dask_jobqueue.SLURMCluster, which in turn extends
+    dask.distributed.SpecCluster. This wrapper sets configs before the
+    cluster or workers are initialized. This is an adaptive cluster and
+    will scale the number of workers, between user-specified limits, based
+    on the number of pending tasks.
+
+    Defaults are tuned for GPU jobs on a typical SLURM cluster (one worker
+    per submitted job, one GPU per worker). Tested on the MPCDF Raven
+    cluster; should work on any SLURM cluster by adjusting partition,
+    account, and the GPU directives.
+
+    For a full list of arguments see
+    https://jobqueue.dask.org/en/latest/generated/dask_jobqueue.SLURMCluster.html
+
+    Most users only need to specify:
+        ncpus       (CPU cores per worker, sets ``--cpus-per-task``)
+        min_workers (lower bound for adaptive scaling)
+        max_workers (upper bound for adaptive scaling)
+        walltime    (e.g. ``"24:00:00"``)
+        memory      (e.g. ``"125GB"``)
+
+    Cluster-specific extras such as ``--constraint=gpu`` and
+    ``--gres=gpu:a100:1`` can be passed via ``job_extra_directives``. A
+    ``partition`` and/or ``account`` may be required by your cluster.
+
+    Example (MPCDF Raven, 1 A100 GPU per worker)::
+
+        cluster_kwargs = {
+            'cluster_type': 'slurm',
+            'ncpus': 18,
+            'min_workers': 1,
+            'max_workers': 4,
+            'walltime': '24:00:00',
+            'memory': '125GB',
+            'job_extra_directives': [
+                '--constraint=gpu',
+                '--gres=gpu:a100:1',
+            ],
+        }
+
+    Example (MPCDF Raven, 4 A100 GPUs per SLURM job, 4 dask workers per
+    job via dask-cuda — useful when the per-user concurrent-job cap (8)
+    bottlenecks total GPUs)::
+
+        cluster_kwargs = {
+            'cluster_type': 'slurm',
+            'ncpus': 18,           # CPUs per GPU/worker; the wrapper multiplies by gpus_per_job
+            'memory': '125000',    # MB per GPU/worker; multiplied by gpus_per_job
+            'gpus_per_job': 4,
+            'min_workers': 1,
+            'max_workers': 8,      # 8 jobs * 4 GPUs = 32 effective workers
+            'walltime': '24:00:00',
+            'job_extra_directives': [
+                '--constraint=gpu',
+                '--gres=gpu:a100:4',
+            ],
+        }
+    """
+
+    def __init__(
+        self,
+        ncpus,
+        min_workers,
+        max_workers,
+        walltime='24:00:00',
+        memory=None,
+        partition=None,
+        account=None,
+        gpus_per_job=1,
+        config={},
+        config_name=DEFAULT_CONFIG_FILENAME,
+        persist_config=False,
+        **kwargs,
+    ):
+        """``gpus_per_job`` controls multi-GPU mode. The default of 1
+        keeps single-GPU behavior. Setting it to >1 makes each submitted
+        SLURM job hold multiple GPUs and starts that many dask workers
+        per job (one per GPU) using ``dask-cuda-worker`` for per-process
+        GPU isolation. Requires ``dask-cuda`` (and a ``dask_cuda_worker_entry``
+        importable shim that calls dask_cuda.cli.worker) to be installed
+        in the worker env.
+
+        With multi-GPU mode the caller still passes ``ncpus`` as the
+        per-GPU CPU count (e.g. 18 on Raven). The wrapper multiplies that
+        by ``gpus_per_job`` for the SLURM job_cpu/job_mem directives, so
+        a 4-GPU job on Raven gets cpus=72, mem=500000.
+        """
+
+        # store all args in case needed later
+        self.locals_store = {**locals()}
+        self.gpus_per_job = int(gpus_per_job)
+
+        # config
+        self.config_name = config_name
+        self.persist_config = persist_config
+        # /ptmp/<user> is the recommended fast scratch on Raven; fall back
+        # to a per-user dir under /tmp on systems that don't have /ptmp.
+        ptmp = pathlib.Path(f"/ptmp/{getpass.getuser()}")
+        scratch_dir = (str(ptmp) + "/") if ptmp.is_dir() \
+            else f"/tmp/{getpass.getuser()}/"
+        config_defaults = {
+            'temporary-directory': scratch_dir,
+            'distributed.comm.timeouts.connect': '180s',
+            'distributed.comm.timeouts.tcp': '360s',
+        }
+        config = {**config_defaults, **config}
+        _modify_dask_config(config, config_name)
+
+        # threading is best in low level libraries
+        job_script_prologue = [
+            f"export MKL_NUM_THREADS={2*ncpus}",
+            f"export NUM_MKL_THREADS={2*ncpus}",
+            f"export OPENBLAS_NUM_THREADS={2*ncpus}",
+            f"export OPENMP_NUM_THREADS={2*ncpus}",
+            f"export OMP_NUM_THREADS={2*ncpus}",
+        ]
+        # allow caller to extend (rather than replace) the prologue
+        user_prologue = kwargs.pop('job_script_prologue', [])
+        job_script_prologue = job_script_prologue + list(user_prologue)
+
+        # set scratch and log directories
+        if "local_directory" not in kwargs:
+            kwargs["local_directory"] = scratch_dir
+        if "log_directory" not in kwargs:
+            log_dir = f"{os.getcwd()}/dask_worker_logs_{os.getpid()}/"
+            pathlib.Path(log_dir).mkdir(parents=False, exist_ok=True)
+            kwargs["log_directory"] = log_dir
+
+        # default per-worker memory: ~15 GB per requested CPU
+        if memory is None:
+            memory_mb = 15 * 1000 * ncpus
+        else:
+            memory_mb = _parse_memory_mb(memory)
+
+        # In multi-GPU mode the SLURM job holds gpus_per_job GPUs and runs
+        # gpus_per_job dask worker processes (one per GPU). Scale the SLURM
+        # cpu and memory totals accordingly. ncpus and memory remain the
+        # *per-GPU* (per-worker) numbers as the caller passed them.
+        n_dask_workers_per_job = self.gpus_per_job
+        slurm_cpus = ncpus * self.gpus_per_job
+        slurm_mem_mb = memory_mb * self.gpus_per_job
+        # dask's per-worker memory budget — *per worker process*, so just memory_mb.
+        dask_worker_memory = f"{memory_mb}MB"
+        # cores= controls how many dask workers run in this SLURM job.
+        # processes= splits cores across that many worker processes.
+        # For dask-cuda mode we set both = gpus_per_job and let dask-cuda-worker
+        # pin each to a different CUDA_VISIBLE_DEVICES.
+        # SLURM --mem expects an integer of MB (the safest cross-cluster
+        # form; G/GiB/GB suffixes get interpreted differently by different
+        # SLURM versions and by some site rules — Raven for example treats
+        # "G" as GiB, which silently exceeds the 1/4-of-node share cap on
+        # GPU jobs). Dask, on the other hand, parses its `memory` argument
+        # as a human-readable string and treats a bare number as BYTES,
+        # which would set a microscopic per-worker memory budget. So we
+        # pass the SLURM directive as a plain int and the dask budget as
+        # a unit-suffixed string.
+        super_kwargs = dict(
+            cores=n_dask_workers_per_job,
+            processes=n_dask_workers_per_job,
+            memory=f"{slurm_mem_mb}MB",
+            walltime=walltime,
+            queue=partition,
+            account=account,
+            job_cpu=slurm_cpus,
+            job_mem=str(slurm_mem_mb),
+            job_script_prologue=job_script_prologue,
+        )
+        if self.gpus_per_job > 1:
+            # Use dask-cuda's worker so each of the N dask processes in this
+            # SLURM job binds to exactly one GPU. We point dask-jobqueue at
+            # a small shim module that calls dask_cuda.cli.worker, since
+            # the package only ships a console script (no `__main__.py`).
+            super_kwargs["worker_command"] = "dask_cuda_worker_entry"
+        super().__init__(
+            **super_kwargs,
+            **kwargs,
+        )
+        self.client = distributed.Client(self)
+        print("Cluster dashboard link: ", self.dashboard_link)
+
+        # set adaptive cluster bounds
+        self.adapt_cluster(min_workers, max_workers)
+
+
+    def __enter__(self): return self
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.persist_config:
+            _remove_config_file(self.config_name)
+        self.client.close()
+        super().__exit__(exc_type, exc_value, traceback)
+
+
+    def adapt_cluster(self, min_workers, max_workers):
+        _ = self.adapt(
+            minimum_jobs=min_workers,
+            maximum_jobs=max_workers,
+            interval='10s',
+            wait_count=6,
+        )
+
+
+    def change_worker_attributes(
+        self,
+        min_workers,
+        max_workers,
+        **kwargs,
+    ):
+        """WARNING: this function is dangerous if you don't know what
+           you're doing. Don't call this unless you know exactly what
+           this does."""
+        self.scale(0)
+        for k, v in kwargs.items():
+            self.new_spec['options'][k] = v
+        self.adapt_cluster(min_workers, max_workers)
 
 
 class janeliaLSFCluster(dask_jobqueue.LSFCluster):
@@ -331,6 +578,13 @@ class janeliaLSFCluster(dask_jobqueue.LSFCluster):
 
 
 #----------------------- decorator -------------------------------------------#
+CLUSTER_CONSTRUCTORS = {
+    'local': myLocalCluster,
+    'lsf': janeliaLSFCluster,
+    'slurm': slurmCluster,
+}
+
+
 def cluster(func):
     """
     This decorator ensures a function will run inside a cluster
@@ -340,6 +594,12 @@ def cluster(func):
     cluster and we just run func. If "cluster" is None then
     "cluster_kwargs" are used to construct a new cluster, and
     the function is run inside that cluster context.
+
+    The cluster type is selected by the ``cluster_type`` key in
+    ``cluster_kwargs`` ("local", "lsf", or "slurm"). For backward
+    compatibility, when ``cluster_type`` is not given the choice
+    defaults to LSF if ``ncpus``, ``min_workers``, and ``max_workers``
+    are all present (the original LSF signature) and to local otherwise.
     """
     @functools.wraps(func)
     def create_or_pass_cluster(*args, **kwargs):
@@ -348,11 +608,21 @@ def cluster(func):
         assert 'cluster' in kwargs or 'cluster_kwargs' in kwargs, \
         "Either cluster or cluster_kwargs must be defined"
         if not 'cluster' in kwargs:
-            cluster_constructor = myLocalCluster
-            F = lambda x: x in kwargs['cluster_kwargs']
-            if F('ncpus') and F('min_workers') and F('max_workers'):
-                cluster_constructor = janeliaLSFCluster
-            with cluster_constructor(**kwargs['cluster_kwargs']) as cluster:
+            cluster_kwargs = dict(kwargs['cluster_kwargs'])  # copy; we pop
+            cluster_type = cluster_kwargs.pop('cluster_type', None)
+            if cluster_type is None:
+                F = lambda x: x in cluster_kwargs
+                if F('ncpus') and F('min_workers') and F('max_workers'):
+                    cluster_type = 'lsf'
+                else:
+                    cluster_type = 'local'
+            if cluster_type not in CLUSTER_CONSTRUCTORS:
+                raise ValueError(
+                    f"Unknown cluster_type {cluster_type!r}. "
+                    f"Choose from {list(CLUSTER_CONSTRUCTORS)}."
+                )
+            cluster_constructor = CLUSTER_CONSTRUCTORS[cluster_type]
+            with cluster_constructor(**cluster_kwargs) as cluster:
                 kwargs['cluster'] = cluster
                 return func(*args, **kwargs)
         return func(*args, **kwargs)
@@ -606,6 +876,7 @@ def distributed_eval(
     cluster=None,
     cluster_kwargs={},
     temporary_directory=None,
+    resume_dir=None,
 ):
     """
     Evaluate a cellpose model on overlapping blocks of a big image.
@@ -614,20 +885,23 @@ def distributed_eval(
     Optionally use a mask to ignore background regions in image.
     Either cluster or cluster_kwargs parameter must be set to a
     non-default value; please read these parameter descriptions below.
-    If using cluster_kwargs, the workstation and Janelia LSF cluster cases
-    are distinguished by the arguments present in the dictionary.
 
-    PC/Mac/Linux workstations and the Janelia LSF cluster are supported;
-    running on a different institute cluster will require implementing your
-    own dask cluster class. Look at the JaneliaLSFCluster class in this
-    module as an example, also look at the dask_jobqueue library. A PR with
-    a solid start is the right way to get help running this on your own
-    institute cluster.
+    Three cluster types are supported out of the box, selectable via the
+    ``cluster_type`` key in ``cluster_kwargs``:
+
+    - ``"local"`` -> :class:`myLocalCluster` (single workstation)
+    - ``"lsf"``   -> :class:`janeliaLSFCluster` (Janelia LSF cluster)
+    - ``"slurm"`` -> :class:`slurmCluster` (any SLURM cluster, defaults
+      tuned for MPCDF Raven)
+
+    Running on a different cluster manager will require implementing your
+    own dask cluster class; the existing classes are good starting points,
+    and the dask_jobqueue library covers most schedulers. PRs with a
+    solid start are welcome.
 
     If running on a workstation, please read the docstring for the
-    LocalCluster class defined in this module. That will tell you what to
-    put in the cluster_kwargs dictionary. If using the Janelia cluster,
-    please read the docstring for the JaneliaLSFCluster class.
+    LocalCluster class defined in this module. For LSF or SLURM, see the
+    docstrings for the corresponding cluster classes.
 
     Parameters
     ----------
@@ -695,6 +969,25 @@ def distributed_eval(
         is the current directory. Temporary files are removed if the function
         completes successfully.
 
+    resume_dir : string (default: None)
+        If set, this exact path is used as the (persistent) tempdir instead
+        of a randomly named one under ``temporary_directory``. The directory
+        is created if missing and is NOT auto-deleted, so a subsequent call
+        with the same ``resume_dir`` will detect blocks that were already
+        segmented in a previous run and skip them.
+
+        A block is considered "already done" if its corresponding chunk
+        file in the unstitched temp zarr exists on disk (the temp zarr is
+        chunked at exactly ``blocksize`` so each block maps to one chunk
+        file). For each already-done block the per-block return values
+        ``(faces, boxes, remap)`` are recomputed from the saved
+        segmentation, and stitching proceeds on the union of recomputed
+        and freshly-computed results.
+
+        Use this to recover from a SLURM walltime kill: pass the original
+        run's tempdir as ``resume_dir`` to the new run; only un-segmented
+        blocks will actually be processed.
+
     Returns
     -------
     Two values are returned:
@@ -714,31 +1007,81 @@ def distributed_eval(
 
     if 'diameter' not in eval_kwargs.keys():
         eval_kwargs['diameter'] = 30
-    overlap = eval_kwargs['diameter'] * 2
+    # diameter may be a float; overlap is used to build zarr slices and
+    # must be an int.
+    overlap = int(eval_kwargs['diameter'] * 2)
     block_indices, block_crops = get_block_crops(
         input_zarr.shape, blocksize, overlap, mask,
     )
 
-    # I hate indenting all that code just for the tempdir
-    # but context manager is the only way to really guarantee that
-    # the tempdir gets cleaned up even after unhandled exceptions
-    with tempfile.TemporaryDirectory(
-        prefix='.', suffix='_distributed_cellpose_tempdir',
-        dir=temporary_directory or os.getcwd(),
-    ) as temporary_directory:
+    # tempdir context: random-and-auto-deleted by default, or persistent
+    # at `resume_dir` if the caller wants resume capability.
+    if resume_dir is not None:
+        pathlib.Path(resume_dir).mkdir(parents=True, exist_ok=True)
+        tempdir_ctx = contextlib.nullcontext(resume_dir)
+    else:
+        tempdir_ctx = tempfile.TemporaryDirectory(
+            prefix='.', suffix='_distributed_cellpose_tempdir',
+            dir=temporary_directory or os.getcwd(),
+        )
+    with tempdir_ctx as temporary_directory:
 
         temp_zarr_path = temporary_directory + '/segmentation_unstitched.zarr'
-        temp_zarr = zarr.open(
-            temp_zarr_path, 'w',
-            shape=input_zarr.shape,
-            chunks=blocksize,
-            dtype=np.uint32,
-        )
+        # Open existing temp zarr (resume) or create fresh.
+        if resume_dir is not None and pathlib.Path(temp_zarr_path).exists():
+            temp_zarr = zarr.open(temp_zarr_path, mode='a')
+            assert temp_zarr.shape == tuple(input_zarr.shape), (
+                f"resume_dir {resume_dir} has temp zarr of shape {temp_zarr.shape} "
+                f"but input is {tuple(input_zarr.shape)}"
+            )
+        else:
+            temp_zarr = zarr.open(
+                temp_zarr_path, 'w',
+                shape=input_zarr.shape,
+                chunks=blocksize,
+                dtype=np.uint32,
+            )
+
+        # Resume: classify blocks into todo (need to run) vs done (chunk
+        # file already on disk in the temp zarr) and reconstruct the done
+        # blocks' return values from the saved segmentation. We freeze
+        # done_indices BEFORE workers start so the ordering is stable
+        # (workers will write chunks for new blocks during the run, which
+        # would otherwise confuse a re-classification at gather time).
+        done_indices, done_crops = [], []
+        precomputed_results = []
+        todo_indices, todo_crops = list(block_indices), list(block_crops)
+        if resume_dir is not None:
+            done_indices, done_crops = [], []
+            todo_indices, todo_crops = [], []
+            for idx, crop in zip(block_indices, block_crops):
+                if block_chunk_path(temp_zarr_path, idx).exists():
+                    done_indices.append(idx)
+                    done_crops.append(crop)
+                else:
+                    todo_indices.append(idx)
+                    todo_crops.append(crop)
+            print(
+                f"resume: {len(done_indices)} blocks already done, "
+                f"{len(todo_indices)} blocks to process",
+                flush=True,
+            )
+            for k, (idx, crop) in enumerate(zip(done_indices, done_crops), start=1):
+                precomputed_results.append(
+                    recompute_block_results(
+                        temp_zarr, idx, crop, overlap, blocksize,
+                    )
+                )
+                if k % 100 == 0 or k == len(done_indices):
+                    print(
+                        f"  recomputed {k}/{len(done_indices)} done blocks",
+                        flush=True,
+                    )
 
         futures = cluster.client.map(
             process_block,
-            block_indices,
-            block_crops,
+            todo_indices,
+            todo_crops,
             input_zarr=input_zarr,
             preprocessing_steps=preprocessing_steps,
             model_kwargs=model_kwargs,
@@ -748,9 +1091,15 @@ def distributed_eval(
             output_zarr=temp_zarr,
             worker_logs_directory=str(worker_logs_dir),
         )
-        results = cluster.client.gather(futures)
-        if isinstance(cluster, dask_jobqueue.core.JobQueueCluster): 
+        new_results = cluster.client.gather(futures)
+        if isinstance(cluster, dask_jobqueue.core.JobQueueCluster):
             cluster.scale(0)
+
+        # Combine results: precomputed (done) first, then freshly-computed.
+        # block_indices is rewritten to match this ordering so downstream
+        # stitching code keeps the parallel-list invariant with results.
+        results = list(precomputed_results) + list(new_results)
+        block_indices = list(done_indices) + list(todo_indices)
 
         faces, boxes_, box_ids_ = list(zip(*results))
         boxes = [box for sublist in boxes_ for box in sublist]
@@ -761,7 +1110,7 @@ def distributed_eval(
         np.save(new_labeling_path, new_labeling)
 
         # stitching step is cheap, we should release gpus and use small workers
-        if isinstance(cluster, dask_jobqueue.core.JobQueueCluster): 
+        if isinstance(cluster, janeliaLSFCluster):
             cluster.change_worker_attributes(
                 min_workers=cluster.locals_store['min_workers'],
                 max_workers=cluster.locals_store['max_workers'],
@@ -769,6 +1118,18 @@ def distributed_eval(
                 memory="15GB",
                 mem=int(15e9),
                 queue=None,
+                job_extra_directives=[],
+            )
+        elif isinstance(cluster, slurmCluster):
+            cluster.change_worker_attributes(
+                min_workers=cluster.locals_store['min_workers'],
+                max_workers=cluster.locals_store['max_workers'],
+                cores=1,
+                processes=1,
+                memory="15GB",
+                job_cpu=1,
+                job_mem="15GB",
+                # drop GPU constraints / gres so stitching workers run on CPU nodes
                 job_extra_directives=[],
             )
     
@@ -888,6 +1249,84 @@ def shrink_labels(plane, threshold):
     distances = scipy.ndimage.distance_transform_edt(shrunk_labels)
     shrunk_labels[distances <= threshold] = 0
     return shrunk_labels.reshape(plane.shape)
+
+
+def compute_trimmed_crop(crop, overlap, blocksize):
+    """Pure-function reproduction of remove_overlaps' crop adjustment, for
+    use when we want to know where a block lives in the temp zarr without
+    having the segmentation array on hand. Mirrors remove_overlaps logic
+    exactly: trim left by overlap if the crop didn't start at zero on
+    that axis, then trim right to blocksize if there's still room."""
+    crop_trimmed = list(crop)
+    for axis in range(len(crop)):
+        length = crop[axis].stop - crop[axis].start
+        if crop[axis].start != 0:
+            crop_trimmed[axis] = slice(
+                crop[axis].start + overlap, crop[axis].stop
+            )
+            length -= overlap
+        if length > blocksize[axis]:
+            a = crop_trimmed[axis].start
+            crop_trimmed[axis] = slice(a, a + blocksize[axis])
+    return tuple(crop_trimmed)
+
+
+def recompute_block_results(temp_zarr, block_index, crop, overlap, blocksize):
+    """Reconstruct (faces, boxes, remap) for an already-completed block by
+    reading its segmentation from the temp zarr. Used in resume mode where
+    we don't have the original return values from process_block.
+
+    The saved segmentation is already globally-remapped (labels packed
+    with block index, max can be ~10^9). Calling
+    ``scipy.ndimage.find_objects`` on it directly allocates a list of
+    None entries up to ``max(label)`` — gigabytes per call, OOMing the
+    driver after a few hundred blocks. Instead we relabel locally to
+    1..N (sequential) via searchsorted, run find_objects on that small
+    label space, and translate the resulting per-label boxes back into
+    global coordinates."""
+    crop_trimmed = compute_trimmed_crop(crop, overlap, blocksize)
+    segmentation = np.asarray(temp_zarr[crop_trimmed])
+
+    # Drop 0 (background). The unique non-zero labels in this block are
+    # both the block's "remap" (parallel to its boxes) and the lookup
+    # table for our local relabeling.
+    remap_arr = np.unique(segmentation)
+    if remap_arr.size > 0 and remap_arr[0] == 0:
+        remap_arr = remap_arr[1:]
+
+    if remap_arr.size == 0:
+        boxes = []
+    else:
+        # Build a local-label image: 0 stays 0, label remap_arr[k] becomes k+1.
+        # searchsorted on a sorted unique array gives a 0-based index, +1
+        # so background stays at 0.
+        local_seg = np.zeros_like(segmentation, dtype=np.int32)
+        nonzero = segmentation != 0
+        local_seg[nonzero] = (
+            np.searchsorted(remap_arr, segmentation[nonzero]).astype(np.int32) + 1
+        )
+        local_boxes = scipy.ndimage.find_objects(local_seg)
+        # find_objects returns a list of length max(local_seg)==len(remap_arr).
+        # Each entry is either a slice tuple or None.
+        translate = lambda a, b: slice(a.start + b.start, a.start + b.stop)
+        boxes = []
+        for box in local_boxes:
+            if box is None:
+                continue
+            boxes.append(tuple(translate(a, b) for a, b in zip(crop_trimmed, box)))
+
+    # block_faces returns numpy views into `segmentation`. Without a copy
+    # the views keep the full 64 MB block alive in `precomputed_results`
+    # for the rest of the run; for ~900 blocks that's 50+ GB resident.
+    faces = [f.copy() for f in block_faces(segmentation)]
+    return faces, boxes, list(remap_arr)
+
+
+def block_chunk_path(temp_zarr_path, block_index, dimension_separator='.'):
+    """Path of the zarr v2 chunk file for the given block. The temp zarr is
+    chunked at blocksize so block_index == chunk index."""
+    name = dimension_separator.join(str(int(i)) for i in block_index)
+    return pathlib.Path(temp_zarr_path) / name
 
 
 def merge_all_boxes(boxes, box_ids):

--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -453,12 +453,46 @@ class slurmCluster(dask_jobqueue.SLURMCluster):
         max_workers,
         **kwargs,
     ):
-        """WARNING: this function is dangerous if you don't know what
-           you're doing. Don't call this unless you know exactly what
-           this does."""
+        """Drop existing workers and respawn with updated kwargs.
+
+        WARNING: dangerous if you don't know what you're doing.
+
+        Used by ``distributed_eval`` to release GPUs and shrink workers
+        for the cheap stitching phase. Updates the canonical
+        ``self._job_kwargs`` store; ``self.new_spec['options']`` is the
+        same dict (per dask_jobqueue.JobQueueCluster.__init__) so it
+        picks up the change. ``_dummy_job`` is a property and recomputes
+        the SLURM header on next access. The job_script preview below
+        is logged so future runs can verify the new directives reach
+        the queued jobs."""
         self.scale(0)
-        for k, v in kwargs.items():
-            self.new_spec['options'][k] = v
+        # Block until existing workers actually leave; otherwise adapt()
+        # below sees them and skips the respawn.
+        try:
+            self.sync(self._correct_state)
+        except Exception:
+            pass
+        # SpecCluster shallow-copied the worker dict at __init__, so
+        # ``self.new_spec['options']`` and ``self._job_kwargs`` are the
+        # same dict object. We update ``_job_kwargs`` (the canonical
+        # store) and assert the alias still holds.
+        self._job_kwargs.update(kwargs)
+        assert self.new_spec['options'] is self._job_kwargs, (
+            "internal invariant broken: new_spec['options'] is no longer "
+            "self._job_kwargs; dask_jobqueue API changed?"
+        )
+        # Log the freshly-rendered job script so the SBATCH directives
+        # are visible in the driver log — makes it obvious whether the
+        # new kwargs propagated. Truncated to the header.
+        try:
+            preview = "\n".join(
+                ln for ln in self._dummy_job.job_script().split("\n")
+                if ln.startswith("#") or "dask" in ln.lower()
+            )
+            print("change_worker_attributes -> next job script header:")
+            print(preview)
+        except Exception as exc:  # pragma: no cover
+            print(f"change_worker_attributes: could not preview job script: {exc}")
         self.adapt_cluster(min_workers, max_workers)
 
 
@@ -1330,22 +1364,46 @@ def block_chunk_path(temp_zarr_path, block_index, dimension_separator='.'):
 
 
 def merge_all_boxes(boxes, box_ids):
-    """Merge all boxes that map to the same box_ids"""
-    merged_boxes = []
-    boxes_array = np.array(boxes, dtype=object)
-    # FIX float parameters
-    # print("Box IDs:", box_ids, "Type:", type(box_ids))
-    box_ids = box_ids.astype(int)
-    # print("Box IDs:", box_ids, "Type:", type(box_ids))
+    """Merge all boxes that map to the same box_ids.
 
-    for iii in np.unique(box_ids):
-        merge_indices = np.argwhere(box_ids == iii).squeeze()
-        if merge_indices.shape:
-            merged_box = merge_boxes(boxes_array[merge_indices])
-        else:
-            merged_box = boxes_array[merge_indices]
-        merged_boxes.append(merged_box)
-    return merged_boxes
+    Returns one merged box per unique id, in sorted-id order (matching
+    the legacy ``np.unique(box_ids)`` iteration order).
+
+    Vectorized via ``argsort`` + ``np.minimum/maximum.reduceat`` to keep
+    runtime at O(N log N * ndim). The previous per-id ``argwhere`` loop
+    was O(N) per group; on volumes with ~10^7 unique labels the
+    quadratic blow-up made the stitching tail wedge for hours."""
+    box_ids = np.asarray(box_ids).astype(int)
+    n = len(boxes)
+    if n == 0:
+        return []
+
+    # Pull starts/stops out of the slice tuples into dense (N, ndim) arrays.
+    ndim = len(boxes[0])
+    starts = np.empty((n, ndim), dtype=np.int64)
+    stops = np.empty((n, ndim), dtype=np.int64)
+    for i, box in enumerate(boxes):
+        for d, s in enumerate(box):
+            starts[i, d] = s.start
+            stops[i, d] = s.stop
+
+    # Sort rows by id so same-id rows are contiguous, then reduce per group.
+    order = np.argsort(box_ids, kind="stable")
+    box_ids_sorted = box_ids[order]
+    starts_sorted = starts[order]
+    stops_sorted = stops[order]
+
+    # `return_index=True` on a sorted array gives the start of each run,
+    # which is exactly what reduceat needs.
+    unique_ids, group_starts = np.unique(box_ids_sorted, return_index=True)
+    merged_starts = np.minimum.reduceat(starts_sorted, group_starts, axis=0)
+    merged_stops = np.maximum.reduceat(stops_sorted, group_starts, axis=0)
+
+    return [
+        tuple(slice(int(merged_starts[i, d]), int(merged_stops[i, d]))
+              for d in range(ndim))
+        for i in range(len(unique_ids))
+    ]
 
 
 def merge_boxes(boxes):

--- a/docs/distributed.rst
+++ b/docs/distributed.rst
@@ -9,11 +9,14 @@ that are too large to fit in system memory. The dataset is divided into overlapp
 each block is segmented separately. Results are stitched back together into a seamless segmentation
 of the whole dataset.
 
-Built to run on workstations or clusters. Blocks can be run in parallel, in series, or both. 
+Built to run on workstations or clusters. Blocks can be run in parallel, in series, or both.
 Compute resources (GPUs, CPUs, and RAM) can be arbitrarily partitioned for parallel computing.
-Currently workstations and LSF clusters are supported. SLURM clusters are
-an easy addition - if you need this to run on a SLURM cluster `please post a feature request issue
-to the github repository <https://github.com/MouseLand/cellpose/issues>`_ and tag @GFleishman.
+Workstations, LSF clusters, and SLURM clusters are supported. The cluster type is
+selected via ``cluster_type`` in ``cluster_kwargs`` (``"local"``, ``"lsf"``, or
+``"slurm"``); see the examples below. The SLURM defaults were tuned against the
+MPCDF Raven cluster but expose the standard ``dask_jobqueue.SLURMCluster``
+parameters so other SLURM sites can override partition, account, GPU constraints,
+walltime, etc.
 
 The input data format must be a `zarr array <https://zarr.readthedocs.io/en/stable/>`_.
 Some functions are provided in the module to help convert your data to a zarr array, but
@@ -141,6 +144,49 @@ Wrap a folder of tiff images/tiles into a single zarr array without duplicating 
     reconstructed_virtual_zarr_array = wrap_folder_of_tiffs(
         filname_pattern='/path/to/folder/of/*.tiff',
         block_index_pattern=r'_(Z)(\d+)(Y)(\d+)(X)(\d+)',
+    )
+
+
+Run distributed Cellpose on a SLURM cluster (example: MPCDF Raven, 1 A100 per worker):
+
+.. code-block:: python
+
+    from cellpose.contrib.distributed_segmentation import distributed_eval
+
+    # parameterize cellpose however you like
+    model_kwargs = {'gpu':True, 'model_type':'cyto3'}
+    eval_kwargs = {'diameter':30,
+                   'z_axis':0,
+                   'channels':[0,0],
+                   'do_3D':True,
+    }
+
+    # define SLURM cluster parameters; ncpus, min_workers, max_workers are required.
+    # Cluster-specific extras (constraints, GRES, partition, account) go through
+    # the standard dask_jobqueue.SLURMCluster keyword arguments.
+    cluster_kwargs = {
+        'cluster_type':'slurm',
+        'ncpus':18,                  # --cpus-per-task per worker job
+        'min_workers':1,             # cluster adapts based on number of blocks
+        'max_workers':4,
+        'walltime':'24:00:00',
+        'memory':'125GB',            # per worker job
+        'job_extra_directives':[
+            '--constraint=gpu',
+            '--gres=gpu:a100:1',
+        ],
+        # 'partition':'<your_partition>',   # if your site requires it
+        # 'account':'<your_account>',       # if your site requires it
+    }
+
+    # run segmentation
+    segments, boxes = distributed_eval(
+        input_zarr=large_zarr_array,
+        blocksize=(256, 256, 256),
+        write_path='/where/zarr/array/containing/results/will/be/written.zarr',
+        model_kwargs=model_kwargs,
+        eval_kwargs=eval_kwargs,
+        cluster_kwargs=cluster_kwargs,
     )
 
 


### PR DESCRIPTION
# Add SLURM cluster support to `distributed_segmentation` (4.x)

Closes/refs #1111.

## Summary

`cellpose/contrib/distributed_segmentation.py` ships single-machine
(`myLocalCluster`) and Janelia-LSF (`janeliaLSFCluster`) cluster
backends, with the docs noting that SLURM "is an easy addition" —
this PR is that addition, plus the tooling around it that bigger
runs need (resume after walltime kill, multi-GPU per SLURM job,
robust memory-format handling, faster final merge for volumes with
many millions of labels).

Tested end-to-end on the **MPCDF Raven** cluster (NVIDIA A100 GPU
nodes) against a 4518 × 5008 × 4560 uint16 X-ray nuclei volume with
both a custom cellpose 3.x model (`CP_20250324_Nuc6`, via the v3
backport branch) and the built-in `cyto3`/`cpsam` models in 4.x.

## What changes

All edits in **two files**: `cellpose/contrib/distributed_segmentation.py`
and `docs/distributed.rst`. Backward-compatible — existing local and
LSF code paths are untouched.

### `slurmCluster` (new class)

Thin wrapper on `dask_jobqueue.SLURMCluster`, mirroring the shape of
`janeliaLSFCluster`. Defaults are tuned for GPU jobs (one A100 per
worker by default). Cluster-specific extras pass through as
`job_extra_directives`, and `partition` / `account` are first-class
kwargs.

```python
cluster_kwargs = {
    'cluster_type': 'slurm',
    'ncpus': 18,
    'min_workers': 1,
    'max_workers': 8,
    'walltime': '24:00:00',
    'memory': '125GB',
    'job_extra_directives': ['--constraint=gpu', '--gres=gpu:a100:1'],
}
segments, boxes = distributed_eval(
    input_zarr=arr, blocksize=(256,256,256), write_path='out.zarr',
    model_kwargs={'gpu': True, 'pretrained_model': '/path/to/model'},
    eval_kwargs={'diameter': 7.5, 'do_3D': True, 'z_axis': 0},
    cluster_kwargs=cluster_kwargs,
)
```

### Multi-GPU per SLURM job (`gpus_per_job=N`)

Some clusters cap concurrent jobs per user (Raven default is 8). A
`gpus_per_job=N` parameter on `slurmCluster` lets a single SLURM
allocation hold N GPUs and run N dask worker processes per job (one
per GPU). When `gpus_per_job > 1` the wrapper switches the worker
command to `dask-cuda-worker` for per-process `CUDA_VISIBLE_DEVICES`
isolation. Optional dependency on `dask-cuda` (only needed when N > 1).

### `cluster_type` dispatch in the `cluster` decorator

The decorator now picks a constructor by `cluster_kwargs['cluster_type']`
(`"local"`, `"lsf"`, `"slurm"`). When the key is missing it falls back
to the original LSF detection (LSF if `ncpus`+`min_workers`+`max_workers`
are all present, otherwise local), so existing user code keeps working.

### `distributed_eval` resume mechanism (`resume_dir`)

A new `resume_dir` argument turns the temp dir into a caller-provided
persistent path. On a second call with the same `resume_dir`, blocks
whose chunk file already exists in the unstitched temp zarr are
skipped, and their `(faces, boxes, remap)` is **recomputed from the
saved segmentation** (helpers `compute_trimmed_crop` and
`recompute_block_results`). Stitching then proceeds on the union of
recomputed and freshly-computed results.

This makes a 24-hour SLURM walltime kill recoverable: re-submit with
the same `resume_dir`, only un-done blocks actually run.

### Memory-format split for dask vs SLURM

`_parse_memory_mb` accepts memory as int (MB) or string (`"125GB"` /
`"125000"` / `"8 GiB"`) and emits two distinct representations:
- `memory=f"{n}MB"` to dask (string with unit, parsed correctly),
- `job_mem=str(n)` to SLURM `--mem` (plain MB integer).

Avoids two failure modes I hit in testing:
1. dask interprets a bare number as **bytes**, setting a microscopic
   per-worker memory budget that makes the nanny kill the worker
   immediately on every restart.
2. SLURM treats `G` as `GiB` on some sites, silently exceeding
   per-share memory caps.

### SLURM-aware "release GPUs for stitching"

The post-segmentation step that drops GPUs and shrinks workers for
the cheap stitching pass branches on cluster type. LSF keeps the
existing `change_worker_attributes(...)` call with LSF-flavored
kwargs; SLURM gets a parallel call with SLURM-flavored kwargs and
empty `job_extra_directives` (drops the GPU constraint and gres so
the stitcher runs on cheap CPU jobs).

### Reliable `change_worker_attributes` on SLURM (follow-up commit)

The original LSF-shape implementation patched
`self.new_spec['options'][k] = v` and called `adapt()`. On SLURM this
was unreliable: an in-flight production run finished segmentation,
then `change_worker_attributes(cores=1, memory='15GB',
job_extra_directives=[], …)` was called to drop the GPU constraint
for stitching — `scontrol show job` showed the new SLURM jobs still
had the original `cpu=18, mem=125000M, gres/gpu:a100=1` directives.

The fix:
- Block until existing workers actually leave (`self.scale(0)` then
  `self.sync(self._correct_state)`); otherwise `adapt()` can find a
  worker still in the spec and skip the respawn.
- Update `self._job_kwargs` (the canonical store dask-jobqueue uses
  to render the job script) directly, with an assertion that
  `self.new_spec['options']` is the same dict — so a future
  dask-jobqueue API change fails loudly rather than silently.
- Print the freshly-rendered SBATCH header for the next worker so the
  directives are visible in the driver log; future runs can verify
  propagation at a glance.

### Vectorized `merge_all_boxes` (follow-up commit)

The previous loop was `for iii in np.unique(box_ids):
np.argwhere(box_ids == iii)` — O(N) per group. On the production
volume the stitching tail wedged for 2 + hours when the global
relabeled label count hit ~10^7. Replaced with one `argsort` plus
`np.minimum/maximum.reduceat` over (N, ndim) start/stop arrays —
O(N log N · ndim). Verified bit-for-bit against the legacy
implementation on synthetic inputs of (N=5e3, M=8e2) and (N=5e4,
M=5e3); 0 mismatches.

**End-to-end run on the 8-block, 512³ test subvolume completed
successfully**: 51 356 final merged cells, no Traceback. The
follow-up validation captured the freshly-rendered SBATCH header
in the driver log (`--cpus-per-task=1 --mem=15GB`, no
`--gres=gpu` / `--constraint=gpu`) — confirming the
`change_worker_attributes` fix above also propagated correctly
on this run.

Worth flagging for reviewers: on this subvolume the
`dask.array.map_blocks(np.load(new_labeling)[block], …)` /
`to_zarr` step (which runs *before* `merge_all_boxes` and is
unchanged by this PR) was very slow — workers spent extended
time in a memory-pressure pause/resume loop before producing
output. That is independent of the `merge_all_boxes` change but
something to investigate as a separate follow-up.

### Bug fixes in the segmentation path

- `overlap = int(eval_kwargs['diameter'] * 2)` — latent: float
  `diameter` produced float zarr slice indices, which recent zarr
  versions reject with `TypeError: slice indices must be integers...`.
- `block_face_adjacency_graph`: `scipy.ndimage.generate_binary_structure(face.ndim, 1)`
  instead of the hardcoded `(3, 1)`. Robustness fix for 2D
  segmentations.

### Docs

`docs/distributed.rst`: adds a SLURM Raven example block; updates
the supported-clusters intro to remove the "SLURM is an easy addition,
please file an issue" line that referenced #1111.

## Cluster-portability notes

The patch was developed against MPCDF Raven, but Raven-specific
values appear only in docstring examples — not as hardcoded defaults
users can't override:

| Reference | Where | Override |
| --- | --- | --- |
| `/ptmp/<user>` scratch | `slurmCluster.__init__`, `local_directory` | falls back to `/tmp/<user>/` automatically when `/ptmp` doesn't exist; pass `local_directory=` to override explicitly |
| `--gres=gpu:a100:N`, `--constraint=gpu` | example only | callers pass their own `job_extra_directives` |
| `dask_cuda_worker_entry` shim | only used when `gpus_per_job > 1` | importable name; users with multi-GPU mode point it at `dask_cuda.cli.worker` (3-line shim) |
| 18 CPUs / 125000 MB per A100 share | docstring example | callers pass their own `ncpus` and `memory` |

## Out of scope

- LSF code path: unchanged (existing logic is preserved verbatim).
- `dask-cuda` installation: optional (only needed for `gpus_per_job > 1`).
- 3.x backport: filed as a companion PR.
