### PR TITLE
Fix IndexError when loading image with auto-adjust saturation unchecked

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -177,7 +177,7 @@ class MainW(QMainWindow):
     def __init__(self, image=None, logger=None):
         super(MainW, self).__init__()
 
-        self.logger = logger
+        self.logger = logger if logger is not None else logging.getLogger(__name__)
         pg.setConfigOptions(imageAxisOrder="row-major")
         self.setGeometry(50, 50, 1200, 1000)
         self.setWindowTitle(f"cellpose v{version}")

--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -212,7 +212,18 @@ def _initialize_images(parent, image, load_3D=False):
         if parent.restore is None or parent.restore != "filter":
             parent.logger.info(": normalization checked: computing saturation levels (and optionally filtered image)")
             parent.compute_saturation()
-    
+    else:
+        # auto-adjust off: re-size saturation list to match NZ while
+        # preserving the user's per-channel values (first-Z value is
+        # broadcast across the new Z range).
+        prev = parent.saturation if hasattr(parent, 'saturation') else []
+        parent.saturation = []
+        for r in range(3):
+            if r < len(prev) and len(prev[r]) > 0:
+                sval = prev[r][0]
+            else:
+                sval = [0, 255]
+            parent.saturation.append([list(sval) for n in range(parent.NZ)])
     parent.compute_scale()
     parent.track_changes = []
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 
 
-@pytest.mark.slow
 @pytest.fixture(scope="module")
 def qapp():
     from qtpy.QtWidgets import QApplication
@@ -10,7 +9,6 @@ def qapp():
     yield app
 
 
-@pytest.mark.slow
 @pytest.fixture(scope="module")
 def win(qapp):
     from cellpose.gui.gui3d import MainW_3d

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    from qtpy.QtWidgets import QApplication
+    app = QApplication.instance() or QApplication([])
+    yield app
+
+
+@pytest.fixture(scope="module")
+def win(qapp):
+    from cellpose.gui.gui3d import MainW_3d
+    return MainW_3d()
+
+
+def test_saturation_invariants_with_autobtn_unchecked(win):
+    """Regression: when 'auto-adjust saturation' is unchecked, loading a 3D
+    image must (1) leave self.saturation sized 3 x NZ so that update_plot's
+    self.saturation[c][currentZ] index is valid, and (2) preserve the user's
+    per-channel values across reloads that change NZ."""
+    from cellpose.gui import io as gui_io
+
+    win.autobtn.setChecked(False)
+
+    # First load: NZ=10, saturation must be 3 x 10 with valid [lo, hi] entries.
+    win.load_3D = True
+    win.filename = "test.tif"
+    gui_io._initialize_images(
+        win, np.zeros((10, 64, 64, 3), dtype=np.float32), load_3D=True
+    )
+
+    assert win.NZ == 10
+    assert len(win.saturation) == 3
+    for c in range(3):
+        assert len(win.saturation[c]) == win.NZ
+        for z in range(win.NZ):
+            assert len(win.saturation[c][z]) == 2  # [lo, hi]
+
+    # Trigger the original failure path explicitly: move_in_Z -> update_plot
+    # -> setLevels(self.saturation[self.color - 1][self.currentZ]).
+    win.loaded = True
+    win.color = 1  # red channel (color > 0 and < 4 branch)
+    win.nchan = 3
+    win.scroll.setValue(win.NZ - 1)
+    win.move_in_Z()  # would have raised IndexError pre-fix
+
+    # User picks custom per-channel values.
+    for c in range(3):
+        for z in range(win.NZ):
+            win.saturation[c][z] = [10 + c, 200 + c]
+
+    # Reload with a different NZ; user values should be broadcast across new Z.
+    gui_io._initialize_images(
+        win, np.zeros((8, 64, 64, 3), dtype=np.float32), load_3D=True
+    )
+
+    assert win.NZ == 8
+    for c in range(3):
+        assert len(win.saturation[c]) == win.NZ
+        for z in range(win.NZ):
+            assert win.saturation[c][z] == [10 + c, 200 + c]

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 
 
+@pytest.mark.slow
 @pytest.fixture(scope="module")
 def qapp():
     from qtpy.QtWidgets import QApplication
@@ -9,12 +10,14 @@ def qapp():
     yield app
 
 
+@pytest.mark.slow
 @pytest.fixture(scope="module")
 def win(qapp):
     from cellpose.gui.gui3d import MainW_3d
     return MainW_3d()
 
 
+@pytest.mark.slow
 def test_saturation_invariants_with_autobtn_unchecked(win):
     """Regression: when 'auto-adjust saturation' is unchecked, loading a 3D
     image must (1) leave self.saturation sized 3 x NZ so that update_plot's


### PR DESCRIPTION
Dear Cellpose team,

Thank you for the great tool! Please find below a bug report and a proposed fix for saturation updates in the GUI:

In Zstack mode (`python -m cellpose --Zstack`), if an image is loaded when auto-adjust saturation is unchecked, an `IndexError: list index out of range is raised`:

```
File ".../cellpose/gui/gui3d.py", line 348, in move_in_Z
    self.update_plot()
File ".../cellpose/gui/gui3d.py", line 568, in update_plot
    super().update_plot()
File ".../cellpose/gui/gui.py", line 1372, in update_plot
    self.img.setLevels(self.saturation[self.color - 1][self.currentZ])
IndexError: list index out of range
```

This appears to be introduced in a982535 when saturation update when `parent.NZ` changes was disabled. This causes self.saturation not updating its shape at loading and remaining `[]` or per the last image loaded when auto-adjust saturation was checked. The first time `update_plot()` indexes `self.saturation[c][self.currentZ]` (e.g. via `move_in_Z` after the user scrolls, or immediately during the initial render at `currentZ = NZ // 2`), the list is shorter than the new `NZ` and indexing fails.

To fix this issue, in `cellpose/gui/io.py` `_initialize_images`, after `parent.NZ` is updated to the new image's Z depth, add an else branch to the existing if `parent.autobtn.isChecked():` block that re-sizes self.saturation to 3 × `NZ`. The user's previous per-channel values are preserved by broadcasting each channel's first-Z value across the new Z range; channels with no previous value default to [0, 255].

The structure is the same 3 × NZ × 2 (channel × Z × [lo, hi]) that `compute_saturation` produces, so `update_plot`, `level_change`, and the ortho views can index it without further changes.

A new test asserting `self.saturation` is 3 × NZ after loading with auto-adjust off is also added.

Please let me know if you need more information. Thank you.

Best,
Yen