### PR TITLE
Fix --gpu_device mps falling back to CPU (fixes #1455)

### DIFF
--- a/cellpose/core.py
+++ b/cellpose/core.py
@@ -52,7 +52,14 @@ def _use_gpu_torch(gpu_number=0):
     except:
         pass
     try:
-        device = torch.device('mps:' + str(gpu_number))
+        # ``gpu_number`` may be the string ``"mps"`` (passed straight through
+        # from ``--gpu_device mps``) rather than a device index, in which case
+        # ``"mps:mps"`` is not a valid device string. Fall back to the plain
+        # ``"mps"`` device for any non-integer gpu_number.
+        if str(gpu_number).isdigit():
+            device = torch.device('mps:' + str(gpu_number))
+        else:
+            device = torch.device('mps')
         _ = torch.zeros((1,1)).to(device)
         core_logger.info('** TORCH MPS version installed and working. **')
         return True

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -21,6 +21,23 @@ def test_gpu_check():
     core.use_gpu()
 
 
+def test_assign_device_mps_string():
+    # Regression test for #1455: passing ``--gpu_device mps`` (i.e.
+    # ``device="mps"``) must select the MPS backend, not silently fall back to
+    # CPU. Previously the literal string "mps" was used as a device index,
+    # building the invalid ``torch.device("mps:mps")`` which raised and forced
+    # CPU. Only meaningful where MPS is actually available.
+    import torch
+    from cellpose import core
+
+    if not torch.backends.mps.is_available():
+        pytest.skip("MPS backend not available")
+
+    device, gpu = core.assign_device(use_torch=True, gpu=True, device="mps")
+    assert gpu
+    assert device.type == "mps"
+
+
 def itest_model_dir():
     import os, pathlib
     import numpy as np


### PR DESCRIPTION
## Summary

Fixes #1455. Running cellpose with `--gpu_device mps` on Apple silicon silently uses the **CPU**, while omitting the flag correctly uses MPS:

```
python -m cellpose --dir . --use_gpu --gpu_device mps ...
>>>> using CPU          # <- wrong, MPS is available

python -m cellpose --dir . --use_gpu ...
** TORCH MPS version installed and working. **
>>>> using GPU (MPS)    # <- works
```

### Root cause

`__main__` passes `device=args.gpu_device` (the string `"mps"`) into `assign_device`, which keeps it as the string `"mps"` and calls `use_gpu(gpu_number="mps")`. `_use_gpu_torch` then treats `gpu_number` as a device **index** and builds:

```python
torch.device("cuda:" + str(gpu_number))   # "cuda:mps" -> raises
torch.device("mps:"  + str(gpu_number))   # "mps:mps"  -> raises (invalid index)
```

Both raise, so `_use_gpu_torch` returns `False` and `assign_device` falls back to CPU. The default path works only because `gpu_device` defaults to `"0"`, which becomes `torch.device("mps:0")`.

### Fix

In `_use_gpu_torch`, treat a non-integer `gpu_number` (i.e. the `"mps"` sentinel) as a request for the default MPS device `torch.device("mps")`, instead of building `"mps:<gpu_number>"`. Integer indices keep their existing `"mps:<n>"` behaviour.

## Verification

Reproduced on Apple silicon (MPS available):

```python
from cellpose import core
core.assign_device(use_torch=True, gpu=True, device="mps")
# before: (device(type=cpu), False)
# after:  (device(type=mps), True)
```

Added a regression test `test_assign_device_mps_string` in `tests/test_import.py` (skipped when MPS is unavailable). It fails on the current code (`assert gpu` -> `False`) and passes with this change. The integer/default device paths are unchanged.