### PR TITLE
pad 1 or 2 channel images saved in gui window .stack

### DIFF
--- a/cellpose/gui/io.py
+++ b/cellpose/gui/io.py
@@ -185,9 +185,9 @@ def _initialize_images(parent, image, load_3D=False):
         parent.stack /= (img_max - img_min)
     parent.stack *= 255
 
-    if parent.stack.shape[-1] == 2:
-        parent.stack = np.concatenate((parent.stack, np.zeros((*parent.stack.shape[:-1], 1), dtype="float32")), axis=-1)
-    print(parent.stack.shape)
+    stack_chans = parent.stack.shape[-1]
+    if stack_chans < 3:
+        parent.stack = np.concatenate((parent.stack, np.zeros((*parent.stack.shape[:-1], 3-stack_chans), dtype="float32")), axis=-1)
 
     if load_3D:
         parent.logger.info(": converted to float and normalized values to 0.0->255.0")


### PR DESCRIPTION
2D images loaded into the 2D CP GUI would load correctly but were incorrectly padded to 1 channel instead of 3 channels. Previously, 2 channel images were correctly padded but not 1. The input to the network requires 3 channels. 

The GUI currently shows red instead of gray because this line doesn't fire: https://github.com/MouseLand/cellpose/blob/9947b9abbba07eeb46565f7ccf549a77748ad5cd/cellpose/gui/io.py#L124

The root cause of this is the different behavior of `transforms.convert_image()` which guaranteed a 3 channel image. 