### PR TITLE
Fix Python 3.8 syntax error by removing 3.10 specific union type hint

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1051,7 +1051,7 @@ class MainW(QMainWindow):
         return inv_name_map[self.RGBDropDown.currentText().lower()].lower()
 
     @color.setter
-    def color(self, value: str|int):
+    def color(self, value):
         """Set the color display mode by name or dropdown index.
 
         Updates the RGBDropDown widget, which triggers any connected signals

--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -1087,7 +1087,7 @@ class MainW(QMainWindow):
         return self.ViewDropDown.currentText()
 
     @view.setter
-    def view(self, value: int|str):
+    def view(self, value):
         """Set the active view in the ViewDropDown.
 
         Parameters


### PR DESCRIPTION
### Description
The recent updates to `gui.py` introduced a Python 3.10+ specific type hinting syntax (`str | int`) on the `color` property setter:
```python
    @color.setter
    def color(self, value: str|int):
```
This breaks compatibility for users running Python 3.8 or 3.9, resulting in a `TypeError: unsupported operand type(s) for |: 'type' and 'type'` upon starting the GUI.

### Solution
This PR simply removes the type hint (or could use `typing.Union[str, int]`) to restore compatibility with older supported Python versions.
