### PR TITLE
Fix PyQt5 checkStateChanged AttributeError on QCheckBox

### DIFF
--- a/cellpose/gui/gui.py
+++ b/cellpose/gui/gui.py
@@ -274,7 +274,10 @@ class MainW(QMainWindow):
         self.reset()
 
         # This needs to go after .reset() is called to get state fully set up:
-        self.autobtn.checkStateChanged.connect(self.compute_saturation_if_checked)
+        try:
+            self.autobtn.checkStateChanged.connect(self.compute_saturation_if_checked)
+        except AttributeError:
+            self.autobtn.stateChanged.connect(self.compute_saturation_if_checked)
 
         self.load_3D = False
 


### PR DESCRIPTION
### Description
Recent updates to `QCheckBox` signals in `gui.py` migrated `stateChanged` to `checkStateChanged`. While this correctly aligns with PyQt6, it breaks compatibility with `PyQt5` and `PySide2` where `checkStateChanged` does not exist on `QCheckBox`, causing an `AttributeError` upon starting the GUI.

### Solution
This PR adds a simple `try-except AttributeError` fallback that attempts to connect `checkStateChanged` (for PyQt6 / PySide6) and gracefully falls back to `stateChanged` (for PyQt5 / PySide2), ensuring Cellpose's GUI remains compatible across older Conda environments.
