### PR TITLE
Fix shrink_labels for 1D face strips in 2D distributed segmentation

### DIFF
--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -882,8 +882,12 @@ def block_face_adjacency_graph(faces, nlabels):
 
 def shrink_labels(plane, threshold):
     """Shrink labels in plane by some distance from their boundary"""
-    gradmag = np.linalg.norm(np.gradient(plane.squeeze()), axis=0)
-    shrunk_labels = np.copy(plane.squeeze())
+    squeezed = plane.squeeze()
+    grads = np.gradient(squeezed)
+    if not isinstance(grads, tuple):
+        grads = (grads,)
+    gradmag = np.linalg.norm(grads, axis=0)
+    shrunk_labels = np.copy(squeezed)
     shrunk_labels[gradmag > 0] = 0
     distances = scipy.ndimage.distance_transform_edt(shrunk_labels)
     shrunk_labels[distances <= threshold] = 0


### PR DESCRIPTION
## Summary

Fixes silent broken tile stitching for **2D** `distributed_eval` runs (whole-slide / flat images).

Complements [PR #1123](https://github.com/MouseLand/cellpose/pull/1123) (merged in 4.2.1), which fixed the `generate_binary_structure(3, 1)` rank crash. This PR fixes the remaining bug in `shrink_labels` that zeroes all face pixels on 1D face strips.

## Problem

During stitching, `block_face_adjacency_graph` calls `shrink_labels` on thin **face** arrays at tile boundaries.

| Image type | Typical face shape | `np.gradient` returns | `np.linalg.norm(..., axis=0)` |
|------------|-------------------|----------------------|-------------------------------|
| 3D volume  | `(1, H, W)` → `(H,W)` | **tuple** of 2 arrays | per-pixel `(H,W)` ✓ |
| **2D WSI** | `(1, W)` → `(W,)` | **single** 1D array | **scalar** ✗ |

When `gradmag` is a scalar and non-zero, this line zeros **every** pixel:

```python
shrunk_labels[gradmag > 0] = 0
```

Result: all faces are empty → no cross-tile label adjacency → masks are **hard-cut at every tile boundary** with **no error raised**.
