### PR TITLE
...

### DIFF
--- a/cellpose/contrib/distributed_segmentation.py
+++ b/cellpose/contrib/distributed_segmentation.py
@@ -774,7 +774,7 @@ def distributed_eval(
     
         segmentation_da = dask.array.from_zarr(temp_zarr)
         relabeled = dask.array.map_blocks(
-            lambda block: np.load(new_labeling_path)[block],
+            lambda block: np.load(new_labeling_path, mmap_mode='r')[block],
             segmentation_da,
             dtype=np.uint32,
             chunks=segmentation_da.chunks,


### PR DESCRIPTION
## Summary

Avoid loading the full `new_labeling.npy` array into memory on every Dask tile during the distributed relabeling step.

## Problem

After stitching, `distributed_eval` saves a large `new_labeling` vector to disk and relabels the unstitched segmentation with:

```python
dask.array.map_blocks(
    lambda block: np.load(new_labeling_path)[block],
    ...
)
```

`np.load` without `mmap_mode` copies the entire `.npy` file into each worker process for every block. On whole-slide runs this array can be multi-GB, so relabeling multiplies RAM use by the number of concurrent workers and can cause OOM or severe swapping.

Using `mmap_mode='r'` memory-maps the file so each block only reads the pages it needs.
