### PR TITLE
Fix neighbouring cell gradient contamination in _extend_centers_gpu

### DIFF
--- a/cellpose/dynamics.py
+++ b/cellpose/dynamics.py
@@ -56,16 +56,20 @@ def _extend_centers_gpu(neighbors, meds, isneighbor, shape, n_iter=200, device=t
         T_flat[flat_meds] += 1
         Tneigh = T_flat[flat_neighbors]
         T_flat[flat_center] = (Tneigh * isneighbor).sum(dim=0) / nneigh
-    del flat_meds, neighbors, meds, isneighbor, Tneigh
+    del flat_meds, neighbors, meds, Tneigh
 
     if ndim == 2:
         grads = T_flat[flat_neighbors[[2, 1, 4, 3]]]
+        grads *= isneighbor[[2, 1, 4, 3]]
+        del isneighbor
         dy = grads[0] - grads[1]
         dx = grads[2] - grads[3]
         del grads
         mu = np.stack((dy.cpu().numpy(), dx.cpu().numpy()), axis=0)
     else:
         grads = T_flat[flat_neighbors[1:]]          
+        grads *= isneighbor[1:]
+        del isneighbor
         dz = grads[0] - grads[1]
         dy = grads[2] - grads[3]
         dx = grads[4] - grads[5]


### PR DESCRIPTION
Fixes #1486 
By using the already defined isneighbor array, the 'grad' values concerning pixels outside of the cell can be filtered out. It effectively makes the gradient generation independant of whether the pixels outside of the cell are background or belonging to another cell. Please find attached a single 3D slice of the input masks, the flows before and after the fix and the masks before and after the fix using the following script :
```python 
from cellpose.dynamics import masks_to_flows_gpu_3d, follow_flows, get_masks_torch
import tifffile
import numpy as np
masks = tifffile.imread("masks.tif")
inds = np.nonzero(masks>0)
flows = masks_to_flows_gpu_3d(masks)
p = follow_flows(flows, inds)
regenerated_masks = get_masks_torch(p.int(), inds, masks.shape)
tifffile.imwrite("masks_regenerated.tif", regenerated_masks)
tifffile.imwrite("flows.tif", flows)
```

<img width="185" height="215" alt="input masks" src="https://github.com/user-attachments/assets/4576393b-70bc-45d0-9c75-3264b0a9d028" />
input image

<img width="555" height="215" alt="current flows" src="https://github.com/user-attachments/assets/6d05b7d4-5bc1-404d-8150-0d13c4ebf566" />
<img width="185" height="215" alt="current masks" src="https://github.com/user-attachments/assets/ededb32a-2cb3-4499-9727-758790b9265b" />

current ZYX flows | current masks reconstruction

<img width="555" height="215" alt="fixed flows" src="https://github.com/user-attachments/assets/2a15140e-66d6-4834-b1a6-0f29a8cd6b6d" />
<img width="185" height="215" alt="fixed masks" src="https://github.com/user-attachments/assets/16c131a9-2be4-42a2-9814-b18cc37e45b4" />

fixed ZYX flows | fixed masks reconstruction
